### PR TITLE
Make links between documentation files relative

### DIFF
--- a/software/README.md
+++ b/software/README.md
@@ -1,7 +1,7 @@
 # EuroPi Library
 
-Before using any of this library, follow the instructions in [programming_instructions.md](https://github.com/Allen-Synthesis/EuroPi/blob/main/software/programming_instructions.md) to set up your module.  
-  
+Before using any of this library, follow the instructions in [programming_instructions.md](/software/programming_instructions.md) to set up your module.  
+
 The EuroPi library is a single file named *europi.py*.  
 It should be imported into any custom program by using 'from europi import \*' to give you full access to the functions within, which are outlined below.  
 Inputs and outputs are used as objects, which each have methods to allow them to be used.  
@@ -45,4 +45,4 @@ The functions all take an optional parameter of samples, which will oversample t
 The OLED Display works by collecting all the applied commands and only updates the physical display when oled.show() is called.  
 This allows you to perform more complicated graphics without slowing your program, or to perform the calculations for other functions, but only update the display every few steps to prevent lag.
 
-More explanations and tips about the the display can be found in the [oled_tips](https://github.com/Allen-Synthesis/EuroPi/blob/main/software/oled_tips.md) file
+More explanations and tips about the the display can be found in the [oled_tips](/software/oled_tips.md) file

--- a/software/oled_tips.md
+++ b/software/oled_tips.md
@@ -36,7 +36,7 @@ These can be accessed the same way as the predefined methods listed above, and y
 
 | Method | Parameters | Function |
 | ------ | ---------- | -------- |
-|centre_text|string|Takes a string of up to 3 lines separated by '\n', and displays them centered vertically and horizontally|
+|centre_text|string|Takes a string of up to 3 lines separated by '\n', and displays them centred vertically and horizontally|
 
 ### centre_text example
 Python Program             |  OLED Result

--- a/software/oled_tips.md
+++ b/software/oled_tips.md
@@ -36,7 +36,7 @@ These can be accessed the same way as the predefined methods listed above, and y
 
 | Method | Parameters | Function |
 | ------ | ---------- | -------- |
-|centre_text|string|Takes a string of up to 3 lines separated by '\n', and displays them centred vertically and horizontally|
+|centre_text|string|Takes a string of up to 3 lines separated by '\n', and displays them centered vertically and horizontally|
 
 ### centre_text example
 Python Program             |  OLED Result

--- a/software/programming_instructions.md
+++ b/software/programming_instructions.md
@@ -10,7 +10,7 @@ To start with, you'll need to download the [Thonny IDE](https://thonny.org/). Th
 ![Thonny](https://i.imgur.com/UX4uQDO.jpg)
 
 ### Installing the firmware
-1. Download the [firmware.uf2](https://github.com/Allen-Synthesis/EuroPi/raw/main/software/firmware/firmware.uf2) file from this repository.
+1. Download the [firmware.uf2](/software/firmware/firmware.uf2) file from this repository.
 2. Holding down the white button on the Raspberry Pi Pico, connect the module to your computer via the USB cable.
 3. Open your file manager and drag and drop the downloaded firmware.uf2 onto the new drive named 'RPI-RP2'.
 4. The Pico will automatically eject once the process is completed.
@@ -36,7 +36,7 @@ To start with, you'll need to download the [Thonny IDE](https://thonny.org/). Th
 
 ### Installing the europi library
 
-1. Open the [europi.py](https://github.com/Allen-Synthesis/EuroPi/blob/main/software/firmware/europi.py) file from this repository.
+1. Open the [europi.py](/software/firmware/europi.py) file from this repository.
 2. Copy its entire contents by selecting all and pressing Ctrl-C.
 3. Open Thonny back up and press Ctrl-N to create a new file.
 4. Paste the europi.py contents into the new file, and press Ctrl-Shift-S to save as.
@@ -86,4 +86,4 @@ Now import the entire europi library by simply adding the line 'from europi impo
 
 ![From europi import](https://i.imgur.com/UK3nJcV.jpg)
 
-Now you have access to the inputs and outputs using easy methods, which you can read about more in the [README.md](https://github.com/Allen-Synthesis/EuroPi/blob/main/software/README.md) of the software folder.
+Now you have access to the inputs and outputs using easy methods, which you can read about more in the [README.md](/software/README.md) of the software folder.

--- a/software/programs/README.md
+++ b/software/programs/README.md
@@ -2,6 +2,6 @@
 
 This folder contains programs written by me (Rory) for the EuroPi, using the europi.py library.  
 You will need to have this library installed on your EuroPi to use any of these programs, along with the SSD1306 module.  
-Instructions on how to install both of these can be found [on my website](https://allensynthesis.co.uk/europi/europi-programming.html).  
-  
+Instructions on how to install both of these can be found in [programming_instructions.md](/software/programming_instructions.md).  
+
 The europi.py library is often updated, and there is a chance that some of these updates may cause issues with older programs. I'll always try to rectify these at the same time as pushing the europi.py update, but if there are any I have missed, please add the bug as an [Issue](https://github.com/Allen-Synthesis/EuroPi/issues) on GitHub

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -17,7 +17,7 @@ This means that your device is either not connected, or not being detected.
 #### Steps to fix
 1. Make sure the USB cable is connected firmly to both the Pico and your computer
 2. Make sure your USB cable is capable of data transfer rather than just power
-3. Re-flash the firmware using 'firmware.uf2' by following the process set out in the [programming instructions](https://allensynthesis.co.uk/europi/europi-programming.html)
+3. Re-flash the firmware using 'firmware.uf2' by following the process set out in the [programming instructions](/software/programming_instructions.md)
 4. Re-flash the firmware using the 'flash_nuke.uf2', and then re-flash it again using 'firmware.uf2'
 
 
@@ -31,7 +31,7 @@ This means that your device is either not connected, or not being detected.
 This means that the Pico cannot detect the OLED display.
 #### Steps to fix
 1. Make sure that the solder joints between the OLED board and the PCB are secure and free of dirt
-2. If you have a multimeter, test the continuity of each pin with the appropriate pin on the Pico according to [the pinout](https://github.com/Allen-Synthesis/EuroPi/raw/main/hardware/europi_pinout.pdf)
+2. If you have a multimeter, test the continuity of each pin with the appropriate pin on the Pico according to [the pinout](hardware/europi_pinout.pdf)
 3. Make sure your PCB standoffs are screwed on tightly; if the two board slip apart by any more than a millimetre or two then the connection will not be made
 
 


### PR DESCRIPTION
- Relative links mean that the user will not be directed to the
  project's main branch when clicking on links in branches and forks.
- also fix broken links
- typos

Fixes issue #9 