### PR TITLE
Performance enhancements for Coin Toss script

### DIFF
--- a/contrib/coin_toss.md
+++ b/contrib/coin_toss.md
@@ -8,8 +8,8 @@ Two pairs of clocked probability gates.
 
 Knob 1 adjusts the master clock speed of gate change probability. Knob 2 moves
 the probability thresholed between A and B with a 50% chance at noon. Output 
-column 1 (cv1 and cv4) run at 1x speed and output column2 (cv2 and cv5) run at
-4x speed for interesting rhythmic patterns. Push button 1 to toggle between
+row 1 (cv1 and cv2) run at 1x speed and output row 2 (cv4 and cv5) run at
+1/4x speed for interesting rhythmic patterns. Push button 1 to toggle between
 internal and external clock source. Push button 2 to toggle between gate and
 trigger mode. Analogue input is summed with the threshold knob value to allow
 external threshold control.
@@ -20,8 +20,8 @@ external threshold control.
     knob 2: probability threshold
     button 1: toggle internal / external clock source
     button 2: toggle gate/trigger mode
-    cv1/cv4: Coin 1 gate output pair when voltage above/below threshold
-    cv2/cv5: Coin 2 gate output pair when voltage above/below threshold
+    cv1/cv2: Coin 1 gate output pair when voltage above/below threshold
+    cv4/cv5: Coin 2 gate output pair at 1/4x speed
     cv3: Coin 1 clock
     cv6: Coin 2 clock
 

--- a/contrib/coin_toss.py
+++ b/contrib/coin_toss.py
@@ -31,31 +31,19 @@ from utime import sleep_ms, ticks_ms
 import machine
 
 
+# Internal clock tempo range.
 MAX_BPM = 280
 MIN_BPM = 20
 
-# Constant values for display
+# Constant values for display.
 FRAME_WIDTH = int(OLED_WIDTH / 8)
 
-# Number of sequential reads for smoothing analog read values
-SAMPLES = 256
+# Number of sequential reads for smoothing analog read values.
+SAMPLES = 32
 
-# Overclock the Pico
-#machine.freq(250000000)
-machine.freq(125000000)
-
-
-## Override oled with a noop
-class Noop(object):
-    def noop(*args, **kw): pass
-    def __getattr__(self, _): return self.noop
-#oled = Noop()
-
-
-def trigger(output, delay=10):
-    output.on()
-    sleep_ms(delay)
-    output.off()
+# Overclock the Pico for improved performance.
+machine.freq(250000000)
+#machine.freq(125000000)  # Default clock speed.
 
 
 class CoinToss:
@@ -111,12 +99,13 @@ class CoinToss:
         """
         coin = random()
         # Sum the knob2 and analogue input values to determine threshold.
-        self.threshold = clamp(k2.read_position(SAMPLES)/100 + ain.read_voltage(SAMPLES)/12, 0, 1)
+        read_sum = k2.unit_interval(SAMPLES) + ain.read_voltage(SAMPLES)/12
+        self.threshold = clamp(read_sum, 0, 1)
         if self.gate_mode:
             a.value(coin < self.threshold)
             b.value(coin > self.threshold)
         else:
-            trigger(a if coin < self.threshold else b)
+            (a if coin < self.threshold else b).on()
         
         if not draw:
             return
@@ -140,10 +129,18 @@ class CoinToss:
             oled.fill_rect(0, 0, FRAME_WIDTH, OLED_HEIGHT, 0)
 
             self.toss(cv1, cv4)
-            trigger(cv3)
+            cv3.on()  # First column clock trigger
             if counter % 4 == 0:
                 self.toss(cv2, cv5, False)
-                trigger(cv6)
+                cv6.on()  # Second column clock trigger (1/4x speed)
+            
+            sleep_ms(10)
+            if self.gate_mode:
+                # Only turn off clock triggers.
+                [o.off() for o in (cv3, cv6)]
+            else:
+                # Turn of all cvs in trigger mode.
+                [o.off() for o in cvs]
 
             # Draw threshold line
             oled.hline(0, int(self.threshold * OLED_HEIGHT), FRAME_WIDTH, 1)

--- a/contrib/coin_toss.py
+++ b/contrib/coin_toss.py
@@ -78,7 +78,7 @@ class CoinToss:
         """Pause script execution waiting for next quarter note in the clock cycle."""
         if self.internal_clock:
             while True:
-                if ticks_ms() > self._deadline:
+                if ticks_ms() >= self._deadline:
                     self._deadline = self.get_next_deadline()
                     return
         else:  # External clock


### PR DESCRIPTION
Most notably, I should have called `get_next_deadline` immediately after reaching the previous deadline, and CV triggers should happen in parallel, not sequentially. Other improvements include overclocking the pico from 125MHz to 225MHz. Additionally, after playing around with a few different values for SAMPLES (the number of sequential reads for smoothing analog read values), I found that 32 samples resulted in the most smooth and consistent performance for this script.

I also assumed that drawing to the OLED display could cause performance issues with my script, but I was pleasantly surprised that enabling OLED did not negatively impact performance!