### PR TITLE
update output formatting in diagnostic utility

### DIFF
--- a/contrib/diagnostic.py
+++ b/contrib/diagnostic.py
@@ -22,8 +22,8 @@ while True:
     oled.clear()
 
     # display the input values
-    oled.text(f"ain: {ain.read_voltage():0.2f}v", 2, 3, 1)
-    oled.text(f"k1: {k1.read_position()}  k2: {k2.read_position()}", 2, 13, 1)
+    oled.text(f"ain: {ain.read_voltage():5.2f}v", 2, 3, 1)
+    oled.text(f"k1: {k1.read_position():2}  k2: {k2.read_position():2}", 2, 13, 1)
     oled.text(f"din:{din.value()} b1:{b1.value()} b2:{b2.value()}", 2, 23, 1)
 
     # show the screen boundaries


### PR DESCRIPTION
Format the output of the analog output and knob values so that the
values don't jump around when the number of digits changes.