### PR TITLE
Update LED resistor values

### DIFF
--- a/hardware/bill_of_materials.md
+++ b/hardware/bill_of_materials.md
@@ -7,10 +7,11 @@ Please note that a few of these are multi-packs of components, and there may wel
 
 | Component | Quantity | Value | Description | Suggested Supplier
 |-|-|-|-|-|
-| R1 - R20 | 20 | 1k | 1 Kiloohm Resistor | [CPC](https://cpc.farnell.com/unbranded/mf25-1k/resistor-0-25w-1-1k/dp/RE03722?st=1k%20resistor)
+| R1 - R12, R18 - R20 | 14 | 1k | 1 Kiloohm Resistor | [CPC](https://cpc.farnell.com/unbranded/mf25-1k/resistor-0-25w-1-1k/dp/RE03722?st=1k%20resistor)
+|R13 - R17 | 6 | 5.1k | 5.1 Kiloohm Resistor | [CPC](https://cpc.farnell.com/unbranded/mf25-5k1/resistor-0-25w-1-5k1/dp/RE03761?st=5.1k%20resistor)
 | R21 - R23 | 3 | 22k | 22 Kiloohm Resistor | [CPC](https://cpc.farnell.com/unbranded/mf25-22k/resistor-0-25w-1-22k/dp/RE03743?st=22k%20resistor)
 | R24 - R26 | 3 | 10k | 10 Kiloohm Resistor | [CPC](https://cpc.farnell.com/unbranded/mf25-10k/resistor-0-25w-1-10k/dp/RE03723?st=0.25w%2010k%201%25)
-| R27 - R34 | 8 | 100k | 100 Kiloohm Resistor | [CPC](https://cpc.farnell.com/multicomp-pro/mcmf006ff1003a50/res-100k-1-600mw-axial-metal-film/dp/RE07823?st=100k%20resistor)
+| R27 - R34 | 8 | 100k | 100 Kiloohm Resistor | [CPC](https://cpc.farnell.com/unbranded/mf25-100k/resistor-0-25w-1-100k/dp/RE03724?st=100k%20resistor)
 | R35 - R40 | 6 | 220k | 220 Kiloohm Resistor | [CPC](https://cpc.farnell.com/unbranded/mf25-220k/resistor-0-25w-1-220k/dp/RE03744?st=220k%20resistor)
 | C1 - C2 | 2 | 1uF | 1 Microfarad Capacitor (Polarised)| [CPC](https://cpc.farnell.com/multicomp/mcmhr50v105m4x7/capacitor-1uf-50v-radial-105-deg/dp/CA08237?st=1uf%20capacitor)
 | C3 - C14 | 12 | 100nF | 100 Nanofarad Capacitor (Non-Polarised)| [CPC](https://cpc.farnell.com/multicomp/mcrr50104x7rk0050/capacitor-100nf-50v/dp/CA06296?st=100nf%20capacitor)

--- a/hardware/build_guide.md
+++ b/hardware/build_guide.md
@@ -196,7 +196,12 @@ The 'front' of the Jack PCB is the side with the OLED, jack, and button outlines
 
 ### Resistors
 
-#### Solder the 1k resistors to the back (R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19, R20)
+#### Solder the 1k resistors to the back (R7, R8, R9, R10, R11, R12, R19, R20)
+![_DSC2362 5](https://user-images.githubusercontent.com/79809962/150558359-0099aee5-0d3a-49af-a78c-c10f4b6cd9de.jpg)
+
+---
+
+#### Solder the 5.1k resistors to the back (R13, R14, R15, R16, R17, R18)
 ![_DSC2362](https://user-images.githubusercontent.com/79809962/148646613-c9404b94-883f-4991-a0bb-5fea3bde99bc.jpg)
 
 ---


### PR DESCRIPTION
Edit build guide and bill of materials to include 5.1k resistors rather than 1k for the LEDs. This fixes issue [#32](https://github.com/Allen-Synthesis/EuroPi/issues/32)