### PR TITLE
Add output calibration process

### DIFF
--- a/software/firmware/calibrate.py
+++ b/software/firmware/calibrate.py
@@ -68,8 +68,8 @@ for voltage in range(1,11):
 print(f'\n{output_duties}')
 
 with open(f'lib/calibration.py', 'a+') as file:
-    values = ", ".join(map(str, readings))
-    file.write(f"OUTPUT_CALIBRATION_VALUES=[{output_duties}]")
+    values = ", ".join(map(str, output_duties))
+    file.write(f"\nOUTPUT_CALIBRATION_VALUES=[{values}]")
     
 print('\nCalibration Complete!')
 

--- a/software/firmware/calibrate.py
+++ b/software/firmware/calibrate.py
@@ -1,6 +1,7 @@
 from machine import Pin, ADC, PWM
 from time import sleep
 
+machine.freq(250000000)
 
 ain = ADC(Pin(26, Pin.IN, Pin.PULL_DOWN))
 cv1 = PWM(Pin(21))
@@ -12,8 +13,10 @@ def wait_for_voltage(voltage):
     else:
         input('\nPlease unplug all cables and then press Enter')
     print('\n Calibrating...')
-    sleep(2)
-    return round(ain.read_u16())
+    readings = []
+    for reading in range(256):
+        readings.append(ain.read_u16())
+    return round(sum(readings)/256)
 
 
 chosen_process = ''
@@ -42,3 +45,31 @@ else:
 with open(f'lib/calibration.py', 'w') as file:
     values = ", ".join(map(str, readings))
     file.write(f"CALIBRATION_VALUES=[{values}]")
+print(f'\n{readings}\n')
+    
+    
+
+from europi import AnalogueInput
+ain = AnalogueInput(26)
+cv1 = PWM(Pin(21))
+
+input('\nPlease plug CV output 1 into the analogue input and then press Enter')
+output_duties = []
+duty = 0
+reading = 0
+for voltage in range(1,11):
+    while abs(reading - voltage) > 0.005 and reading < voltage:
+        cv1.duty_u16(duty)
+        duty += 25
+        reading = round(ain.read_voltage(),2)
+    output_duties.append(duty)
+    print(f'\n{voltage}V')
+        
+print(f'\n{output_duties}')
+
+with open(f'lib/calibration.py', 'a+') as file:
+    values = ", ".join(map(str, readings))
+    file.write(f"OUTPUT_CALIBRATION_VALUES=[{output_duties}]")
+    
+print('\nCalibration Complete!')
+


### PR DESCRIPTION
The output calibration process generates a list of duty cycles that result in the corresponding voltages from CV1
e.g. 
cv1.duty_u16(OUTPUT_CALIBRATION_VALUES[0]) will output 1V

The usage of this in europi.py is still to be implemented