### PR TITLE
add ability to manually publish docs

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -2,6 +2,7 @@ name: publish docs to github pages
 # taken from https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-static-site-generators-with-python
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
A manual trigger means that we don't have to push empty commits to trigger doc builds in any weird situations that come up.

related to issue #29 