### PR TITLE
more docs

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - mjj/more_docs
 
 jobs:
   deploy:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ You can find more about this (including a project diary) and other projects of m
 * The power supply is now diode protected to prevent back-powering your rack when the module is connected via USB
 * All jacks are protected from overvoltage input (previously the Pico GPIO pin was directly exposed to any input, potentially leading to damage)
 
-Please see the README.md files in the hardware and software folders for more specific information about each, including hardware specifications and how to use the [europi.py](software/firmware/europi.py) library.
+Please see the README.md files in the hardware and software folders for more specific information about each, including hardware specifications and how to use the [europi.py](software/firmware/europi.py) library. Additional API documentation
+can be found [here](https://allen-synthesis.github.io/EuroPi/).
 
 
 ### Issues

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can find more about this (including a project diary) and other projects of m
 * The power supply is now diode protected to prevent back-powering your rack when the module is connected via USB
 * All jacks are protected from overvoltage input (previously the Pico GPIO pin was directly exposed to any input, potentially leading to damage)
 
-Please see the README.md files in the hardware and software folders for more specific information about each, including hardware specifications and how to use the [europi.py](https://github.com/Allen-Synthesis/EuroPi/blob/main/software/firmware/europi.py) library.
+Please see the README.md files in the hardware and software folders for more specific information about each, including hardware specifications and how to use the [europi.py](software/firmware/europi.py) library.
 
 
 ### Issues
@@ -41,11 +41,11 @@ There are Issue templates available, so please choose whichever is most relevant
 ### License
 
 This module, and any documentation included in this repository, is entirely "free" software and hardware, under different licenses depending on the software, hardware, and documentation itself.
-  
-Software: [Apache 2.0](https://github.com/Allen-Synthesis/EuroPi/blob/main/software/LICENSE)  
-Hardware: [CERN OHL-S v2](https://github.com/Allen-Synthesis/EuroPi/blob/main/hardware/LICENSE)  
-Documentation: [CC0 1.0](https://github.com/Allen-Synthesis/EuroPi/blob/main/LICENSE)
-  
+
+* Software: [Apache 2.0](software/LICENSE)
+* Hardware: [CERN OHL-S v2](hardware/LICENSE)
+* Documentation: [CC0 1.0](LICENSE)
+
 Anyone is welcome to design their own versions of the idea, or modify my designs.
 The only thing I would ask is that you refrain from using the brand name 'Allen Synthesis' on your DIY builds if they have modified my files in any way, just to prevent any confusion if they end up being re-sold or distributed. This is in line with section 8.2 of the CERN license. You may use the brand name if you have simply copied the files from this repository to replicate without modification.
   

--- a/contrib/diagnostic.py
+++ b/contrib/diagnostic.py
@@ -5,7 +5,7 @@ from europi import OLED_HEIGHT, OLED_WIDTH, ain, b1, b2, cv1, cv2, cv3, cv4, cv5
 """
 A diagnostic utility intended to help prove out a new europi build and calibration.
 - Input values, including knobs and buttons, are shown on the screen.
-- Outputs are held at specific, predictible, and hopefully useful values.
+- Outputs are held at specific, predictable, and hopefully useful values.
 - The boundary of the screen is outlined.
 - Inputs can be tested by self-patching the various CV outputs.
 """

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,11 @@
 ## Building the Docs
 
-The EuroPi documentation is built by [Sphinx](https://www.sphinx-doc.org) and deployed to
-[GitHub Pages](https://pages.github.com) upon pushes to the ``main`` branch using
+The [EuroPi documentation](https://allen-synthesis.github.io/EuroPi/) is built by [Sphinx](https://www.sphinx-doc.org)
+and deployed to [GitHub Pages](https://pages.github.com) upon pushes to the ``main`` branch using
 [GitHub Actions](https://github.com/features/actions).
+
+If you've made changes to the documentation you'll want to build the docs locally in order ot verify that the build runs
+without errors and that your changes are rendered as you expect.
 
 In order to build the documentation locally you'll need to install Sphinx and the related dependencies in a virtual
 environment. Our deployment uses Python 3.8. Install the requirements with:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,7 +40,7 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'README.md']
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,5 +1,8 @@
 # Contributing
 
+The information on this page concerns contributing to the EuroPi project itself. This isn't required reading if you want
+to build, use, or even program a EuroPi. However, if you'd like to help out with the project itself, read on.
 
+% include the docs directory readme, which ios instructions on how to build the docs
 ```{include} README.md
 ```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,8 +1,0 @@
-# Contributing
-
-The information on this page concerns contributing to the EuroPi project itself. This isn't required reading if you want
-to build, use, or even program a EuroPi. However, if you'd like to help out with the project itself, read on.
-
-% include the docs directory readme, which ios instructions on how to build the docs
-```{include} README.md
-```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,8 @@
 ```{include} ../README.md
 ```
 
+Source code and additional documentation can be found in the [GitHub repo](https://github.com/Allen-Synthesis/EuroPi).
+
 ```{toctree}
 :maxdepth: 2
 :caption: "Contents:"

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,5 @@
 ```{include} ../README.md
+:end-before: "## Capabilities"
 ```
 
 Source code and additional documentation can be found in the [GitHub repo](https://github.com/Allen-Synthesis/EuroPi).
@@ -9,6 +10,5 @@ Source code and additional documentation can be found in the [GitHub repo](https
 :titlesonly:
 
 api
-contributing
 genindex
 ```

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -1,8 +1,5 @@
 # Hardware Specifications
 
-### Note:
-The PCB files have been temporarily removed to prevent people from creating their own before the files have been tested. I do not want to risk anyone creating something based on unfinished designs. Rest assured once they have been tested, the files will be available in this folder.
-
 ## Outputs
 - 1k Output Impedance
 - RC filter smoothed PWM

--- a/hardware/build_guide.md
+++ b/hardware/build_guide.md
@@ -143,11 +143,11 @@ The 'front' of the Pico PCB is the side with the actual Raspberry Pi Pico on it,
 #### Solder the I²C header to the front
 ![_DSC2352](https://user-images.githubusercontent.com/79809962/148646508-d44a06fb-7a40-4acd-96ce-360de89eb10a.jpg)
 
-  
-  
-[Skiff Friendly Option](https://github.com/Allen-Synthesis/EuroPi/blob/main/hardware/skiff_friendly_instructions.md#step-1)
 
-#### Push the female Pico headers onto the Pico itself  
+
+[Skiff Friendly Option](skiff_friendly_instructions.md#step-1)
+
+#### Push the female Pico headers onto the Pico itself
 ![_DSC2355](https://user-images.githubusercontent.com/79809962/148646518-ea8e78d0-0eac-4c52-a066-faef7229b62f.jpg)
 
 
@@ -175,7 +175,7 @@ The 'front' of the Pico PCB is the side with the actual Raspberry Pi Pico on it,
 
 ### 7805
 
-[Skiff Friendly Option](https://github.com/Allen-Synthesis/EuroPi/blob/main/hardware/skiff_friendly_instructions.md#step-2)
+[Skiff Friendly Option](skiff_friendly_instructions.md#step-2)
 
 #### Solder the 7805 power regulator to the front, with the metal side in line with the white stripe on the PCB
   

--- a/software/firmware/README.md
+++ b/software/firmware/README.md
@@ -1,6 +1,6 @@
 # Firmware
 
 Please download the most recent MicroPython firmware from [the MicroPython website](https://micropython.org/download/rp2-pico/).
-  
-The 'flashnuke.uf2' file is a last resort, and will wipe all data stored on your Pico, including calibration data and custom programs.  
-It is only to be used when all other troubleshooting options have been covered, as found in [troubleshooting.md](https://github.com/Allen-Synthesis/EuroPi/blob/main/troubleshooting.md)
+
+The 'flashnuke.uf2' file is a last resort, and will wipe all data stored on your Pico, including calibration data and custom programs.
+It is only to be used when all other troubleshooting options have been covered, as found in [troubleshooting.md](../../troubleshooting.md)

--- a/software/programming_instructions.md
+++ b/software/programming_instructions.md
@@ -60,9 +60,9 @@ To start with, you'll need to download the [Thonny IDE](https://thonny.org/). Th
 
 Now that you have installed the europi.py and ssd1306 libraries, you are ready to take the next step with the module.  
 
-[Option 1](https://github.com/roryjamesallen/EuroPi/blob/main/software/programming_instructions.md#write-your-own-program-from-scratch): Start writing your own program from scratch  
-[Option 2](https://github.com/roryjamesallen/EuroPi/blob/main/software/programming_instructions.md#copy-someone-elses-program-to-run-on-your-module): Use someone else's program from the [contrib folder](/contrib/)  
-[Option 3](https://github.com/roryjamesallen/EuroPi/blob/main/software/programming_instructions.md#calibrate-the-module): Calibrate the module for higher accuracy  
+* [Option 1](#write-your-own-program-from-scratch): Start writing your own program from scratch
+* [Option 2](#copy-someone-elses-program-to-run-on-your-module): Use someone else's program from the [contrib folder](/contrib/)
+* [Option 3](#calibrate-the-module): Calibrate the module for higher accuracy
 
 
 ### Write your own program from scratch
@@ -102,7 +102,7 @@ Now you have access to the inputs and outputs using easy methods, which you can 
 To use the module for accurately reading and outputting voltages, you need to complete a calibration process. This will allow your specific module to account for any differences in components, such as resistor tolerances.  
 If you do not wish to calibrate the module and don't mind your voltages being slightly inaccurate, simply skip to the programming step and your module will use default values.
 
-1. To begin, you need to copy the [calibrate.py](/software/firmware/calibrate.py) file from the firmware folder to your Pico using the [process outlined above](https://github.com/roryjamesallen/EuroPi/blob/main/software/programming_instructions.md#copy-someone-elses-program-to-run-on-your-module).
+1. To begin, you need to copy the [calibrate.py](/software/firmware/calibrate.py) file from the firmware folder to your Pico using the [process outlined above](#copy-someone-elses-program-to-run-on-your-module).
 2. Name it 'main.py', just as if it were a program you were running as normal. Make sure there are no other programs also called 'main.py' at the same time, or Python won't know which one to run.
 3. Make sure your module is connected to rack power for the calibration process. It doesn't matter if it connected to USB as well, however if it is it will give an extra warning to turn on rack power which you need to skip using button 1.
 4. Turn on the rack power supply, and the screen will display 'Calibration Mode'. If it doesn't, try [troubleshooting](../troubleshooting.md).  

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -39,7 +39,7 @@ This means that the Pico cannot detect the OLED display.
 1. Make sure that the solder joints between the OLED board and the PCB are secure and free of dirt
 2. If you have a multimeter, test the continuity of each pin with the appropriate pin on the Pico according to [the pinout](hardware/europi_pinout.pdf)
 3. Make sure your PCB standoffs are screwed on tightly; if the two board slip apart by any more than a millimetre or two then the connection will not be made
-4. Make sure your OLED matches one of the two compatible pin configurations as outlined in the [build guide](https://github.com/roryjamesallen/EuroPi/blob/main/hardware/build_guide.md#oled-configuration)
+4. Make sure your OLED matches one of the two compatible pin configurations as outlined in the [build guide](hardware/build_guide.md#oled-configuration)
 
 
 ## Backend terminated or disconnected


### PR DESCRIPTION
Here are a few minor changes related to our docs discussion today:

- clarify when you would want to build the docs
- remove note about missing PCB files
- fix some spelling
- make links relative so that they point to the right fork
- exclude the docs readme from the generated site
- Add links between the github and api docs
- remove the contributing section and most of the readme from the api docs


The trigger to build on this branch should be removed before merge