### PR TITLE
Fixes #117 - ext. clock now triggers on rising value.

### DIFF
--- a/software/contrib/coin_toss.py
+++ b/software/contrib/coin_toss.py
@@ -59,9 +59,9 @@ class CoinToss(EuroPiScript):
                 if din.value() != self._prev_clock:
                     # We've detected a new clock value.
                     self._prev_clock = 1 if self._prev_clock == 0 else 0
-                    # If the previous value is 0 then we are seeing a high 
-                    # value for the first time, break wait and return.
-                    if self._prev_clock == 0:
+                    # If the previous value was just set to 1 then we are seeing 
+                    # a high value for the first time, break wait and return.
+                    if self._prev_clock == 1:
                         return
 
     def toss(self, a, b, draw=True):


### PR DESCRIPTION
Previously, the external clock would trigger on a falling value, which was made very apparent if the clock signal was a 50% duty square wave or similar.