### PR TITLE
Harmonic LFOs Update

### DIFF
--- a/software/contrib/harmonic_lfos.md
+++ b/software/contrib/harmonic_lfos.md
@@ -18,12 +18,12 @@ Six harmonically related sine/saw/square wave LFOs
 
 
 #### Editing/understanding the program
-There is a list named ```HARMONICS``` which controls the relationship of each LFO to the master clock, in terms of its division.
+There is a list named ```divisions``` which controls the relationship of each LFO to the master clock, in terms of its division.
 You could change them to all be evenly divisible, for example ```[1, 2, 4, 8, 16, 32]```, or to be very 'unrelated', for example ```[1.24, 5.27, 9.46, 13.45, 17.23, 23.54]```.
 The last example would only come back into sync after 2,472,424,774,707 cycles, which is approximately 78400 years at one second per cycle.
 The default example uses all prime numbers (except 1 if you want to be technical), and will only sync up around 15,015 cycles.
 You can change any of these values during operation of the program by using knob 2, and button 2 to change which LFO you have selected. The maximum division is controlled by the MAX_HARMONIC variable at the top of the script.
 
-Both the values stored in the HARMONICS list and the MODE (LFO wave shape) are saved to a file, so will be retained after shut down. For this reason there isn't much point in changing the values of the LFO divisions in code, as they will be overwritten and saved as soon as you use knob 2 to alter them.
+Both the values stored in the divisions list and the mode (LFO wave shape) are saved to a file, so will be retained after shut down. For this reason there isn't much point in changing the values of the LFO divisions in code, as they will be overwritten and saved as soon as you use knob 2 to alter them.
 
-There is also a variable named ```MAX_VOLTAGE```, which is likely only going to be 10 or 5 depending on which you prefer in your system, and what modules you are controlling.
+There is also a variable named ```MAX_VOLTAGE```, which is likely only going to be 10 or 5 depending on which you prefer in your system, and what modules you are controlling. This is inherited by the MAX_OUTPUT_VOLTAGE set in europi.py, but you can override it if you use this script for something specific.

--- a/software/contrib/harmonic_lfos.md
+++ b/software/contrib/harmonic_lfos.md
@@ -11,7 +11,7 @@ Six harmonically related sine/saw/square wave LFOs
     digital in: Reset all LFOs
     analogue in: Added to master rate
     knob 1: Master rate
-    knob 2: Currently selected LFO's division of the master clock
+    knob 2: Adjusts the master clock division of the currently selected LFO
     button 1: Change mode between sine/saw/square
     button 2: Select the next LFO
     cv1/cv2/cv3/cv4/cv5/cv6: LFO outputs

--- a/software/contrib/harmonic_lfos.md
+++ b/software/contrib/harmonic_lfos.md
@@ -18,10 +18,12 @@ Six harmonically related sine/saw/square wave LFOs
 
 
 #### Editing/understanding the program
-There is a list named ```HARMONICS```, by editing which you can change the relationships of the LFOs.
+There is a list named ```HARMONICS``` which controls the relationship of each LFO to the master clock, in terms of its division.
 You could change them to all be evenly divisible, for example ```[1, 2, 4, 8, 16, 32]```, or to be very 'unrelated', for example ```[1.24, 5.27, 9.46, 13.45, 17.23, 23.54]```.
 The last example would only come back into sync after 2,472,424,774,707 cycles, which is approximately 78400 years at one second per cycle.
 The default example uses all prime numbers (except 1 if you want to be technical), and will only sync up around 15,015 cycles.
-This list only affects the starting values of the LFOs, of course you can change any of them during the operation of the program.
+You can change any of these values during operation of the program by using knob 2, and button 2 to change which LFO you have selected. The maximum division is controlled by the MAX_HARMONIC variable at the top of the script.
+
+Both the values stored in the HARMONICS list and the MODE (LFO wave shape) are saved to a file, so will be retained after shut down. For this reason there isn't much point in changing the values of the LFO divisions in code, as they will be overwritten and saved as soon as you use knob 2 to alter them.
 
 There is also a variable named ```MAX_VOLTAGE```, which is likely only going to be 10 or 5 depending on which you prefer in your system, and what modules you are controlling.

--- a/software/contrib/harmonic_lfos.md
+++ b/software/contrib/harmonic_lfos.md
@@ -6,15 +6,15 @@ date: 12/01/22
 
 labels: LFO, Random
 
-Six harmonically related sine wave LFOs
+Six harmonically related sine/saw/square wave LFOs
 
     digital in: Reset all LFOs
     analogue in: Added to master rate
     knob 1: Master rate
-    knob 2: Random chance of changing an LFO's division
-    button 1: Reset all LFOs
-    button 2: Change mode between sine/saw/square
-    cv1/cv2/cv3/cv4/cv5/cv6: Harmonically related LFOs
+    knob 2: Currently selected LFO's division of the master clock
+    button 1: Change mode between sine/saw/square
+    button 2: Select the next LFO
+    cv1/cv2/cv3/cv4/cv5/cv6: LFO outputs
 
 
 #### Editing/understanding the program
@@ -22,7 +22,6 @@ There is a list named ```HARMONICS```, by editing which you can change the relat
 You could change them to all be evenly divisible, for example ```[1, 2, 4, 8, 16, 32]```, or to be very 'unrelated', for example ```[1.24, 5.27, 9.46, 13.45, 17.23, 23.54]```.
 The last example would only come back into sync after 2,472,424,774,707 cycles, which is approximately 78400 years at one second per cycle.
 The default example uses all prime numbers (except 1 if you want to be technical), and will only sync up around 15,015 cycles.
-
-The default values for harmonics give some nice relationships which do come back into sync after not too long, but you're welcome to change them to your own needs.
+This list only affects the starting values of the LFOs, of course you can change any of them during the operation of the program.
 
 There is also a variable named ```MAX_VOLTAGE```, which is likely only going to be 10 or 5 depending on which you prefer in your system, and what modules you are controlling.

--- a/software/contrib/harmonic_lfos.py
+++ b/software/contrib/harmonic_lfos.py
@@ -1,11 +1,17 @@
 from europi import *
 from math import cos, radians
 from random import randint
-from time import sleep
+from time import sleep_ms
 from europi_script import EuroPiScript
 
 MAX_VOLTAGE = 10
 HARMONICS = [1, 3, 5, 7, 11, 13]
+MAX_HARMONIC = 32
+
+machine.freq(250_000_000)
+
+def read_k2():
+    return k2.read_position(MAX_HARMONIC, 1) + 1
 
 def reset():
     global degree
@@ -18,55 +24,75 @@ def change_mode():
     if MODE == 3:
         MODE = 0
 
-def get_delay_increment_value_random_chance():
-    random_chance = k2.read_position(100,1)
-    delay = (0.1 - (k1.read_position(100)/1000)) + (ain.read_voltage(1)/100)
-    return delay, round((((1/delay)-10)/1)+1), random_chance
+def get_delay_increment_value():
+    delay = (0.1 - (k1.read_position(100, 1)/1000)) + (ain.read_voltage(1)/100)
+    return delay, round((((1/delay)-10)/1)+1)
 
-def change_harmonic():
-    global HARMONICS
-    HARMONICS[randint(0,5)] = randint(1,13)
+def increment_selection():
+    global selected_lfo, selected_lfo_start_value
+    selected_lfo += 1
+    if selected_lfo == 6:
+        selected_lfo = 0
+    selected_lfo_start_value = read_k2()
 
 MODE = 0
 degree = 0
-delay, increment_value, random_chance = get_delay_increment_value_random_chance()
+delay, increment_value = get_delay_increment_value()
 pixel_x = OLED_WIDTH-1
 pixel_y = OLED_HEIGHT-1
+selected_lfo = 0
+selected_lfo_start_value = read_k2()
 
 class HarmonicLFOs(EuroPiScript):
 
     def main(self):
-        global degree, delay, increment_value, random_chance
+        global degree, delay, increment_value, selected_lfo, selected_lfo_start_value
 
         din.handler(reset)
-        b1.handler(reset)
-        b2.handler(change_mode)
+        b1.handler(change_mode)
+        b2.handler(increment_selection)
 
         while True:
             rad = radians(degree)
             
-            if randint(0,100) < random_chance:
-                change_harmonic()
+            #Hysteresis to prevent each LFO's value from being changed as soon as it is selected
+            k2_reading = read_k2()
+            if k2_reading != selected_lfo_start_value:
+                selected_lfo_start_value = k2_reading
+                HARMONICS[selected_lfo] = k2_reading
             
             oled.vline(pixel_x,0,OLED_HEIGHT,0)
             for cv, multiplier in zip(cvs, HARMONICS):
+                three_sixty = 360*multiplier
+                degree_three_sixty = degree % three_sixty
+                
                 if MODE == 0: #Sin
-                    volts = ((0-(cos(rad*(1/multiplier)))+1))*(MAX_VOLTAGE/2)
+                    volts = ((0-(cos(rad*(1/multiplier)))+1)) * (MAX_VOLTAGE/2)
                 elif MODE == 1: #Saw
-                    volts = ((degree%(360*multiplier))/(360*multiplier))*MAX_VOLTAGE
+                    volts = (degree_three_sixty / (three_sixty)) * MAX_VOLTAGE
                 elif MODE == 2: #Square
-                    volts = MAX_VOLTAGE * (int(((degree%(360*multiplier))/(360*multiplier))*MAX_VOLTAGE) < (MAX_VOLTAGE/2))
+                    volts = MAX_VOLTAGE * (int((degree_three_sixty / (three_sixty)) * MAX_VOLTAGE) < (MAX_VOLTAGE/2))
                     
                 cv.voltage(volts)
-                if cv != cv1:
-                    oled.pixel(pixel_x,pixel_y-int(volts*(pixel_y/10)),1)
+                oled.pixel(pixel_x,pixel_y-int(volts*(pixel_y/10)),1)
             
+            #Draw the current LFO's information to the display
+            oled.fill_rect(0,0,18,32,0)
+            oled.fill_rect(0,0,18,9,1)
+            oled.text(str(selected_lfo+1),0,1,0)
+            
+            oled.text('1',0,15,1)
+            oled.hline(0,23,(8 * (((HARMONICS[selected_lfo]) // 10) + 1)),1)
+            oled.text(str(HARMONICS[selected_lfo]),0,25,1)
+            
+            #Delay based on the speed, controlled by knob 1
             degree += increment_value
-            sleep(delay)
+            sleep_ms(int(delay))
             oled.scroll(-1,0)
             
+            #Update the display every 10 cycles
             if round(degree, -1) % 10 == 0:
-                delay, increment_value, random_chance = get_delay_increment_value_random_chance()
+                delay, increment_value = get_delay_increment_value()
                 oled.show()
 
 

--- a/software/contrib/harmonic_lfos.py
+++ b/software/contrib/harmonic_lfos.py
@@ -5,21 +5,22 @@ from time import sleep_ms
 from machine import freq
 from europi_script import EuroPiScript
 
-#Define maximum voltage and maximum harmonic (the harmonic value may become hard to choose using the knob if you use too high of a maximum)
-MAX_VOLTAGE = MAX_OUTPUT_VOLTAGE
-MAX_HARMONIC = 32
-
-#Overclock the Pico for improved performance
-freq(250_000_000)
+MAX_VOLTAGE = MAX_OUTPUT_VOLTAGE #Default is inherited but this can be overriden by replacing "MAX_OUTPUT_VOLTAGE" with an integer
+MAX_HARMONIC = 32 #Too high a value may be hard to select using the knob, but the actual hardware limit is only reached at 4096
 
 class HarmonicLFOs(EuroPiScript):
     def __init__(self):
         super().__init__()
+        
+        #Retreive saved state information from file
         state = self.load_state_json()
         
+        #Overclock the Pico for improved performance
+        freq(250_000_000)
+        
         #Use the saved values for the LFO divisions and mode if found in the save state file, using defaults if not
-        self.HARMONICS = state.get("HARMONICS", [1, 3, 5, 7, 11, 13])
-        self.MODE = state.get("MODE", 0)
+        self.divisions = state.get("divisions", [1, 3, 5, 7, 11, 13])
+        self.mode = state.get("mode", 0)
         
         #Initialise all the other variables
         self.degree = 0
@@ -27,99 +28,115 @@ class HarmonicLFOs(EuroPiScript):
         self.pixel_x = OLED_WIDTH-1
         self.pixel_y = OLED_HEIGHT-1
         self.selected_lfo = 0
-        self.selected_lfo_start_value = self.read_k2()
+        self.selected_lfo_start_value = self.get_clock_division()
         
         #Set the digital input and button handlers
         din.handler(self.reset)
         b1.handler(self.change_mode)
         b2.handler(self.increment_selection)
 
-    #Read knob 2 as a new division between 1 and MAX_HARMONIC
-    def read_k2(self):
+    def get_clock_division(self):
+        """Determine the new clock division based on the position of knob 2"""
         return k2.read_position(MAX_HARMONIC) + 1
 
-    #Reset all LFOs to zero, maintaining their divisions
     def reset(self):
+        """Reset all LFOs to zero volts, maintaining their divisions"""
         self.degree = 0
 
-    #Change between sine, saw, and square wave LFOs
     def change_mode(self):
-        self.MODE += 1
+        """Change the mode that controls wave shape"""
+        self.mode += 1
         
-        if self.MODE == 3:
-            self.MODE = 0
+        if self.mode == 3:
+            self.mode = 0
             
         self.save_state()
 
-    #Determine the time to wait between steps (this controls the master rate of the LFOs)
     def get_delay_increment_value(self):
+        """Calculate the wait time between degrees"""
         delay = (0.1 - (k1.read_position(100, 1)/1000)) + (ain.read_voltage(1)/100)
         return delay, round((((1/delay)-10)/1)+1)
 
-    #Move on to select the next LFO to change the division
     def increment_selection(self):
+        """Move the selection to the next LFO"""
         self.selected_lfo += 1
         if self.selected_lfo == 6:
             self.selected_lfo = 0
-        self.selected_lfo_start_value = self.read_k2()
+        self.selected_lfo_start_value = self.get_clock_division()
 
-    #Save the current values of HARMONICS and MODE to the save state file
     def save_state(self):
-        # Don't save if it has been less than 5 seconds since last save.
+        """Save the current set of divisions to file"""
         if self.last_saved() < 5000:
             return
         
         state = {
-            "HARMONICS": self.HARMONICS,
-            "MODE": self.MODE
+            "divisions": self.divisions,
+            "mode": self.mode
         }
         self.save_state_json(state)
+        
+    def update_display(self):
+        """Update the OLED display every 10 cycles (degrees)"""
+        oled.scroll(-1,0)
+        if round(self.degree, -1) % 10 == 0:
+            oled.show()
+            
+    def increment(self):
+        """Increment the current degree and determine new values of delay and increment_value"""
+        self.degree += self.increment_value
+        self.delay, self.increment_value = self.get_delay_increment_value()
+        sleep_ms(int(self.delay))
+        
+    def display_selected_lfo(self):
+        """Draw the current LFO's number and division to the OLED display"""
+        oled.fill_rect(0,0,20,32,0)
+        oled.fill_rect(0,0,20,9,1)
+        oled.text(str(self.selected_lfo+1),6,1,0)
+        
+        number = self.divisions[self.selected_lfo]
+        x = 2 if number >= 10 else 6
+        oled.text(str(number),x,20,1)
+        
+    def calculate_voltage(self, multiplier):
+        """Determine the voltage based on current degree, wave shape, and MAX_VOLTAGE"""
+        three_sixty = 360*multiplier
+        degree_three_sixty = self.degree % three_sixty
+        if self.mode == 0: #Sin
+            voltage = ((0-(cos(self.rad*(1/multiplier)))+1)) * (MAX_VOLTAGE/2)
+        elif self.mode == 1: #Saw
+            voltage = (degree_three_sixty / (three_sixty)) * MAX_VOLTAGE
+        elif self.mode == 2: #Square
+            voltage = MAX_VOLTAGE * (int((degree_three_sixty / (three_sixty)) * MAX_VOLTAGE) < (MAX_VOLTAGE/2))
+        return voltage
+        
+    def display_graphic_lines(self):
+        """Draw the lines displaying each LFO's voltage to the OLED display"""
+        self.rad = radians(self.degree)
+        oled.vline(self.pixel_x,0,OLED_HEIGHT,0)
+        for cv, multiplier in zip(cvs, self.divisions):
+            volts = self.calculate_voltage(multiplier)
+            cv.voltage(volts)
+            oled.pixel(self.pixel_x,self.pixel_y-int(volts*(self.pixel_y/10)),1)
+
+    def check_change_clock_division(self):
+        """Change current LFO's division with knob movement detection"""
+        self.clock_division = self.get_clock_division()
+        if self.clock_division != self.selected_lfo_start_value:
+            self.selected_lfo_start_value, self.divisions[self.selected_lfo] = self.clock_division, self.clock_division
+            self.save_state()
+        
 
     def main(self):
         while True:
-            rad = radians(self.degree)
+            self.check_change_clock_division()
             
-            #Hysteresis to prevent each LFO's value from being changed as soon as it is selected
-            self.k2_reading = self.read_k2()
-            if self.k2_reading != self.selected_lfo_start_value:
-                self.selected_lfo_start_value = self.k2_reading
-                self.HARMONICS[self.selected_lfo] = self.k2_reading
-                self.save_state()
+            self.display_graphic_lines()
             
-            #Draw the lines for the LFOs on the display
-            oled.vline(self.pixel_x,0,OLED_HEIGHT,0)
-            for cv, multiplier in zip(cvs, self.HARMONICS):
-                three_sixty = 360*multiplier
-                degree_three_sixty = self.degree % three_sixty
-                
-                if self.MODE == 0: #Sin
-                    volts = ((0-(cos(rad*(1/multiplier)))+1)) * (MAX_VOLTAGE/2)
-                elif self.MODE == 1: #Saw
-                    volts = (degree_three_sixty / (three_sixty)) * MAX_VOLTAGE
-                elif self.MODE == 2: #Square
-                    volts = MAX_VOLTAGE * (int((degree_three_sixty / (three_sixty)) * MAX_VOLTAGE) < (MAX_VOLTAGE/2))
-                    
-                cv.voltage(volts)
-                oled.pixel(self.pixel_x,self.pixel_y-int(volts*(self.pixel_y/10)),1)
+            self.display_selected_lfo()
             
-            #Draw the current LFO's information to the display
-            oled.fill_rect(0,0,20,32,0)
-            oled.fill_rect(0,0,20,9,1)
-            oled.text(str(self.selected_lfo+1),6,1,0)
+            self.update_display()
             
-            number = self.HARMONICS[self.selected_lfo]
-            x = int(number >= 10) * 4
-            oled.text(str(number),(6 - x),20,1)
-            
-            #Delay based on the speed, controlled by knob 1
-            self.degree += self.increment_value
-            sleep_ms(int(self.delay))
-            oled.scroll(-1,0)
-            
-            #Update the display every 10 cycles
-            if round(self.degree, -1) % 10 == 0:
-                self.delay, self.increment_value = self.get_delay_increment_value()
-                oled.show()
+            self.increment()
 
 
 if __name__ == "__main__":

--- a/software/contrib/harmonic_lfos.py
+++ b/software/contrib/harmonic_lfos.py
@@ -17,8 +17,8 @@ class HarmonicLFOs(EuroPiScript):
         state = self.load_state_json()
         
         self.HARMONICS = state.get("HARMONICS", [1, 3, 5, 7, 11, 13])
+        self.MODE = state.get("MODE", 0)
         
-        self.MODE = 0
         self.degree = 0
         self.delay, self.increment_value = self.get_delay_increment_value()
         self.pixel_x = OLED_WIDTH-1
@@ -41,6 +41,8 @@ class HarmonicLFOs(EuroPiScript):
         
         if self.MODE == 3:
             self.MODE = 0
+            
+        self.save_state()
 
     def get_delay_increment_value(self):
         delay = (0.1 - (k1.read_position(100, 1)/1000)) + (ain.read_voltage(1)/100)
@@ -60,6 +62,7 @@ class HarmonicLFOs(EuroPiScript):
         
         state = {
             "HARMONICS": self.HARMONICS,
+            "MODE": self.MODE
         }
         self.save_state_json(state)
 

--- a/software/contrib/harmonic_lfos.py
+++ b/software/contrib/harmonic_lfos.py
@@ -2,97 +2,112 @@ from europi import *
 from math import cos, radians
 from random import randint
 from time import sleep_ms
+from machine import freq
 from europi_script import EuroPiScript
 
 MAX_VOLTAGE = 10
-HARMONICS = [1, 3, 5, 7, 11, 13]
 MAX_HARMONIC = 32
 
-machine.freq(250_000_000)
-
-def read_k2():
-    return k2.read_position(MAX_HARMONIC, 1) + 1
-
-def reset():
-    global degree
-    degree = 0
-
-def change_mode():
-    global MODE
-    MODE += 1
-    
-    if MODE == 3:
-        MODE = 0
-
-def get_delay_increment_value():
-    delay = (0.1 - (k1.read_position(100, 1)/1000)) + (ain.read_voltage(1)/100)
-    return delay, round((((1/delay)-10)/1)+1)
-
-def increment_selection():
-    global selected_lfo, selected_lfo_start_value
-    selected_lfo += 1
-    if selected_lfo == 6:
-        selected_lfo = 0
-    selected_lfo_start_value = read_k2()
-
-MODE = 0
-degree = 0
-delay, increment_value = get_delay_increment_value()
-pixel_x = OLED_WIDTH-1
-pixel_y = OLED_HEIGHT-1
-selected_lfo = 0
-selected_lfo_start_value = read_k2()
+freq(250_000_000)
 
 class HarmonicLFOs(EuroPiScript):
+
+    def __init__(self):
+        super().__init__()
+        state = self.load_state_json()
+        
+        self.HARMONICS = state.get("HARMONICS", [1, 3, 5, 7, 11, 13])
+        
+        self.MODE = 0
+        self.degree = 0
+        self.delay, self.increment_value = self.get_delay_increment_value()
+        self.pixel_x = OLED_WIDTH-1
+        self.pixel_y = OLED_HEIGHT-1
+        self.selected_lfo = 0
+        self.selected_lfo_start_value = self.read_k2()
+        
+        din.handler(self.reset)
+        b1.handler(self.change_mode)
+        b2.handler(self.increment_selection)
+
+    def read_k2(self):
+        return k2.read_position(MAX_HARMONIC) + 1
+
+    def reset(self):
+        self.degree = 0
+
+    def change_mode(self):
+        self.MODE += 1
+        
+        if self.MODE == 3:
+            self.MODE = 0
+
+    def get_delay_increment_value(self):
+        delay = (0.1 - (k1.read_position(100, 1)/1000)) + (ain.read_voltage(1)/100)
+        return delay, round((((1/delay)-10)/1)+1)
+
+    def increment_selection(self):
+        self.selected_lfo += 1
+        if self.selected_lfo == 6:
+            self.selected_lfo = 0
+        self.selected_lfo_start_value = self.read_k2()
+
+    def save_state(self):
+        """Save the current state variables as JSON."""
+        # Don't save if it has been less than 5 seconds since last save.
+        if self.last_saved() < 5000:
+            return
+        
+        state = {
+            "HARMONICS": self.HARMONICS,
+        }
+        self.save_state_json(state)
 
     def main(self):
         global degree, delay, increment_value, selected_lfo, selected_lfo_start_value
 
-        din.handler(reset)
-        b1.handler(change_mode)
-        b2.handler(increment_selection)
-
         while True:
-            rad = radians(degree)
+            rad = radians(self.degree)
             
             #Hysteresis to prevent each LFO's value from being changed as soon as it is selected
-            k2_reading = read_k2()
-            if k2_reading != selected_lfo_start_value:
-                selected_lfo_start_value = k2_reading
-                HARMONICS[selected_lfo] = k2_reading
+            self.k2_reading = self.read_k2()
+            if self.k2_reading != self.selected_lfo_start_value:
+                self.selected_lfo_start_value = self.k2_reading
+                self.HARMONICS[self.selected_lfo] = self.k2_reading
+                self.save_state()
             
-            oled.vline(pixel_x,0,OLED_HEIGHT,0)
-            for cv, multiplier in zip(cvs, HARMONICS):
+            oled.vline(self.pixel_x,0,OLED_HEIGHT,0)
+            for cv, multiplier in zip(cvs, self.HARMONICS):
                 three_sixty = 360*multiplier
-                degree_three_sixty = degree % three_sixty
+                degree_three_sixty = self.degree % three_sixty
                 
-                if MODE == 0: #Sin
+                if self.MODE == 0: #Sin
                     volts = ((0-(cos(rad*(1/multiplier)))+1)) * (MAX_VOLTAGE/2)
-                elif MODE == 1: #Saw
+                elif self.MODE == 1: #Saw
                     volts = (degree_three_sixty / (three_sixty)) * MAX_VOLTAGE
-                elif MODE == 2: #Square
+                elif self.MODE == 2: #Square
                     volts = MAX_VOLTAGE * (int((degree_three_sixty / (three_sixty)) * MAX_VOLTAGE) < (MAX_VOLTAGE/2))
                     
                 cv.voltage(volts)
-                oled.pixel(pixel_x,pixel_y-int(volts*(pixel_y/10)),1)
+                oled.pixel(self.pixel_x,self.pixel_y-int(volts*(self.pixel_y/10)),1)
             
             #Draw the current LFO's information to the display
-            oled.fill_rect(0,0,18,32,0)
-            oled.fill_rect(0,0,18,9,1)
-            oled.text(str(selected_lfo+1),0,1,0)
+            oled.fill_rect(0,0,20,32,0)
+            oled.fill_rect(0,0,20,9,1)
+            oled.text(str(self.selected_lfo+1),6,1,0)
             
-            oled.text('1',0,15,1)
-            oled.hline(0,23,(8 * (((HARMONICS[selected_lfo]) // 10) + 1)),1)
-            oled.text(str(HARMONICS[selected_lfo]),0,25,1)
+            number = self.HARMONICS[self.selected_lfo]
+            x = int(number >= 10) * 4
+            oled.text(str(number),(6 - x),20,1)
             
             #Delay based on the speed, controlled by knob 1
-            degree += increment_value
-            sleep_ms(int(delay))
+            self.degree += self.increment_value
+            sleep_ms(int(self.delay))
             oled.scroll(-1,0)
             
             #Update the display every 10 cycles
-            if round(degree, -1) % 10 == 0:
-                delay, increment_value = get_delay_increment_value()
+            if round(self.degree, -1) % 10 == 0:
+                self.delay, self.increment_value = self.get_delay_increment_value()
                 oled.show()
 
 

--- a/software/contrib/harmonic_lfos.py
+++ b/software/contrib/harmonic_lfos.py
@@ -6,7 +6,7 @@ from machine import freq
 from europi_script import EuroPiScript
 
 #Define maximum voltage and maximum harmonic (the harmonic value may become hard to choose using the knob if you use too high of a maximum)
-MAX_VOLTAGE = 10
+MAX_VOLTAGE = MAX_OUTPUT_VOLTAGE
 MAX_HARMONIC = 32
 
 #Overclock the Pico for improved performance

--- a/software/contrib/harmonic_lfos.py
+++ b/software/contrib/harmonic_lfos.py
@@ -5,20 +5,23 @@ from time import sleep_ms
 from machine import freq
 from europi_script import EuroPiScript
 
+#Define maximum voltage and maximum harmonic (the harmonic value may become hard to choose using the knob if you use too high of a maximum)
 MAX_VOLTAGE = 10
 MAX_HARMONIC = 32
 
+#Overclock the Pico for improved performance
 freq(250_000_000)
 
 class HarmonicLFOs(EuroPiScript):
-
     def __init__(self):
         super().__init__()
         state = self.load_state_json()
         
+        #Use the saved values for the LFO divisions and mode if found in the save state file, using defaults if not
         self.HARMONICS = state.get("HARMONICS", [1, 3, 5, 7, 11, 13])
         self.MODE = state.get("MODE", 0)
         
+        #Initialise all the other variables
         self.degree = 0
         self.delay, self.increment_value = self.get_delay_increment_value()
         self.pixel_x = OLED_WIDTH-1
@@ -26,16 +29,20 @@ class HarmonicLFOs(EuroPiScript):
         self.selected_lfo = 0
         self.selected_lfo_start_value = self.read_k2()
         
+        #Set the digital input and button handlers
         din.handler(self.reset)
         b1.handler(self.change_mode)
         b2.handler(self.increment_selection)
 
+    #Read knob 2 as a new division between 1 and MAX_HARMONIC
     def read_k2(self):
         return k2.read_position(MAX_HARMONIC) + 1
 
+    #Reset all LFOs to zero, maintaining their divisions
     def reset(self):
         self.degree = 0
 
+    #Change between sine, saw, and square wave LFOs
     def change_mode(self):
         self.MODE += 1
         
@@ -44,18 +51,20 @@ class HarmonicLFOs(EuroPiScript):
             
         self.save_state()
 
+    #Determine the time to wait between steps (this controls the master rate of the LFOs)
     def get_delay_increment_value(self):
         delay = (0.1 - (k1.read_position(100, 1)/1000)) + (ain.read_voltage(1)/100)
         return delay, round((((1/delay)-10)/1)+1)
 
+    #Move on to select the next LFO to change the division
     def increment_selection(self):
         self.selected_lfo += 1
         if self.selected_lfo == 6:
             self.selected_lfo = 0
         self.selected_lfo_start_value = self.read_k2()
 
+    #Save the current values of HARMONICS and MODE to the save state file
     def save_state(self):
-        """Save the current state variables as JSON."""
         # Don't save if it has been less than 5 seconds since last save.
         if self.last_saved() < 5000:
             return
@@ -67,8 +76,6 @@ class HarmonicLFOs(EuroPiScript):
         self.save_state_json(state)
 
     def main(self):
-        global degree, delay, increment_value, selected_lfo, selected_lfo_start_value
-
         while True:
             rad = radians(self.degree)
             
@@ -79,6 +86,7 @@ class HarmonicLFOs(EuroPiScript):
                 self.HARMONICS[self.selected_lfo] = self.k2_reading
                 self.save_state()
             
+            #Draw the lines for the LFOs on the display
             oled.vline(self.pixel_x,0,OLED_HEIGHT,0)
             for cv, multiplier in zip(cvs, self.HARMONICS):
                 three_sixty = 360*multiplier


### PR DESCRIPTION
The reset feature with button and knob 2 has been replaced by the ability to adjust the divisions of each LFO during normal operation.

The currently selected LFO can be cycled through using button 2, and then division of the selected LFO adjusted using knob 2.

Both the mode (LFO wave shape), and current division values for each LFO, are now saved using the save state functionality of the EuroPiScript class, allowing users to set up a wave shape and division pattern and then reuse it without needing to re-set all the values upon reboot.

The reset feature can still be accessed by using the digital input, so it isn't fully gone, and I feel a digital input is far more likely to be used than a random chance of reset (which also usually tended to result in some immediate random changes as the knob will have been turned above zero to select harmonic LFOs from the bootloader menu)

The whole program has also been cleaned up a lot so that all the functions are within the EuroPiScript class, and all variables that should be are attributes of the class, removing the need for global variables all over the place