### PR TITLE
Harmonic LFOs Update (again, sorry...)

### DIFF
--- a/software/contrib/harmonic_lfos.md
+++ b/software/contrib/harmonic_lfos.md
@@ -4,7 +4,7 @@ author: rory allen
 
 date: 12/01/22
 
-labels: LFO, Random
+labels: LFO
 
 Six harmonically related sine/saw/square wave LFOs
 
@@ -12,7 +12,7 @@ Six harmonically related sine/saw/square wave LFOs
     analogue in: Added to master rate
     knob 1: Master rate
     knob 2: Adjusts the master clock division of the currently selected LFO
-    button 1: Change mode between sine/saw/square
+    button 1: Change mode of current LFO between sine/saw/square
     button 2: Select the next LFO
     cv1/cv2/cv3/cv4/cv5/cv6: LFO outputs
 
@@ -24,6 +24,6 @@ The last example would only come back into sync after 2,472,424,774,707 cycles, 
 The default example uses all prime numbers (except 1 if you want to be technical), and will only sync up around 15,015 cycles.
 You can change any of these values during operation of the program by using knob 2, and button 2 to change which LFO you have selected. The maximum division is controlled by the MAX_HARMONIC variable at the top of the script.
 
-Both the values stored in the divisions list and the mode (LFO wave shape) are saved to a file, so will be retained after shut down. For this reason there isn't much point in changing the values of the LFO divisions in code, as they will be overwritten and saved as soon as you use knob 2 to alter them.
+Both the division and mode (wave shape) of each LFO are saved to a file, so will be retained after shut down. For this reason there isn't much point in changing the values of the LFO divisions in code, as they will be overwritten and saved as soon as you use knob 2 to alter them.
 
 There is also a variable named ```MAX_VOLTAGE```, which is likely only going to be 10 or 5 depending on which you prefer in your system, and what modules you are controlling. This is inherited by the MAX_OUTPUT_VOLTAGE set in europi.py, but you can override it if you use this script for something specific.


### PR DESCRIPTION
Just an extra bit of functionality I realised would be very useful as I was playing with the new ability to change the divisions on the fly: mode per LFO.
This is incredibly useful in practice because it means you can use LFO 1 as a master clock for example, sending square waves, and then use the others as any other waveform with any other division.

The wave form of the current LFO is now shown as a little symbol underneath its division when it is selected, so it's very easy to see which LFO is using which waveform.  The individual LFO waveforms are now saved to the file in a list the same way as the dviisions list, rather than a global mode variable.

This also will make it easier in future to add different or more complex waveforms, or even things like swing per LFO.

p.s. sorry for not thinking of this before I requested the review of the previous PR!