### PR TITLE
mock hardware

### DIFF
--- a/software/tests/conftest.py
+++ b/software/tests/conftest.py
@@ -1,6 +1,15 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.append(str(Path(__file__).parent.parent / "firmware"))
 sys.path.append(str(Path(__file__).parent.parent))  # contrib
 sys.path.append(str(Path(__file__).parent.parent / "tests" / "mocks"))
+
+
+from mock_hardware import MockHardware
+
+@pytest.fixture
+def mockHardware(monkeypatch):
+    return MockHardware(monkeypatch)

--- a/software/tests/mock_hardware.py
+++ b/software/tests/mock_hardware.py
@@ -1,0 +1,19 @@
+from machine import ADC
+
+class MockHardware:
+    """A class used in tests to stand in for actual EuroPi hardware. Allows a test to set the values for various
+    hardware components, such as the position of a knob. Then a test can run a script and assert the script's behavior.
+    """
+
+    def __init__(self, monkeypatch):
+        self._monkeypatch = monkeypatch
+        self._adc_pin_values = {}
+
+        self._patch()
+
+    def _patch(self):
+        self._monkeypatch.setattr(ADC, "read_u16", lambda pin: self._adc_pin_values[pin])
+
+    def set_ADC_u16_value(self, component, value):
+        """Sets the value that will be returned by a call to `read_u16` on the given component."""
+        self._adc_pin_values[component.pin] =  value

--- a/software/tests/mock_hardware.py
+++ b/software/tests/mock_hardware.py
@@ -1,4 +1,6 @@
-from machine import ADC
+from machine import ADC, Pin
+
+from europi import AnalogueReader, DigitalReader
 
 class MockHardware:
     """A class used in tests to stand in for actual EuroPi hardware. Allows a test to set the values for various
@@ -8,12 +10,19 @@ class MockHardware:
     def __init__(self, monkeypatch):
         self._monkeypatch = monkeypatch
         self._adc_pin_values = {}
+        self._digital_pin_values = {}
 
         self._patch()
 
     def _patch(self):
         self._monkeypatch.setattr(ADC, "read_u16", lambda pin: self._adc_pin_values[pin])
+        self._monkeypatch.setattr(Pin, "value", lambda pin: self._digital_pin_values[pin])
 
-    def set_ADC_u16_value(self, component, value):
-        """Sets the value that will be returned by a call to `read_u16` on the given component."""
-        self._adc_pin_values[component.pin] =  value
+    def set_ADC_u16_value(self, reader: AnalogueReader, value: int):
+        """Sets the value that will be returned by a call to `read_u16` on the given AnalogueReader."""
+        self._adc_pin_values[reader.pin] =  value
+
+    def set_digital_value(self, reader: DigitalReader, value: bool):
+        """Sets the value that will be returned by a call to `value` on the given DigitalReader."""
+        self._digital_pin_values[reader.pin] =  not value
+

--- a/software/tests/mocks/machine.py
+++ b/software/tests/mocks/machine.py
@@ -23,6 +23,9 @@ class Pin:
     def irq(self, handler=None, trigger=None):
         pass
 
+    def value(self, *args):
+        pass
+
 class PWM:
     def __init__(self, *args):
         pass

--- a/software/tests/test_AnalogueReader.py
+++ b/software/tests/test_AnalogueReader.py
@@ -1,0 +1,62 @@
+import pytest
+
+from europi import AnalogueReader, MAX_UINT16
+
+from mock_hardware import MockHardware
+
+
+@pytest.fixture
+def analogueReader():
+    return AnalogueReader(pin=1)  #actual pin value doesn't matter
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (0, 0.0000),
+        (MAX_UINT16 / 4, 0.2500),
+        (MAX_UINT16 / 3, 0.3333),
+        (MAX_UINT16 / 2, 0.5000),
+        (MAX_UINT16, 1.0000),
+    ],
+)
+def test_percent(mockHardware: MockHardware, analogueReader, value, expected):
+    mockHardware.set_ADC_u16_value(analogueReader, value)
+
+    assert round(analogueReader.percent(), 4) == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (0, 0),
+        (MAX_UINT16 / 4, 25),
+        (MAX_UINT16 / 3, 33),
+        (MAX_UINT16 / 2, 50),
+        (MAX_UINT16, 99),
+    ],
+)
+def test_range(mockHardware: MockHardware, analogueReader, value, expected):
+    mockHardware.set_ADC_u16_value(analogueReader, value)
+
+    assert analogueReader.range() == expected
+
+
+@pytest.mark.parametrize(
+    "values, value, expected",
+    [
+        ([i for i in range(10)], 0, 0),
+        ([i for i in range(10)], MAX_UINT16 / 4, 2),
+        ([i for i in range(10)], MAX_UINT16 / 3, 3),
+        ([i for i in range(10)], MAX_UINT16 / 2, 5),
+        ([i for i in range(10)], MAX_UINT16, 9),
+
+        (["a", "b"], 0, "a"),
+        (["a", "b"], MAX_UINT16, "b"),
+    ],
+)
+def test_choice(mockHardware: MockHardware, analogueReader, values, value, expected):
+    mockHardware.set_ADC_u16_value(analogueReader, value)
+
+    assert analogueReader.choice(values) == expected
+
+

--- a/software/tests/test_DigitalReader.py
+++ b/software/tests/test_DigitalReader.py
@@ -1,0 +1,23 @@
+import pytest
+
+from europi import DigitalReader
+
+from mock_hardware import MockHardware
+
+
+@pytest.fixture
+def digitalReader():
+    return DigitalReader(pin=1)  # actual pin value doesn't matter
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (0, 0),
+        (1, 1),
+    ],
+)
+def test_value(mockHardware: MockHardware, digitalReader, value, expected):
+    mockHardware.set_digital_value(digitalReader, value)
+
+    assert digitalReader.value() == expected

--- a/software/tests/test_knob.py
+++ b/software/tests/test_knob.py
@@ -1,0 +1,45 @@
+import pytest
+
+from europi import k1, k2, MAX_UINT16
+
+from mock_hardware import MockHardware
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (0, 1.0000),
+        (MAX_UINT16 / 4, 0.7500),
+        (MAX_UINT16 / 3, 0.6667),
+        (MAX_UINT16 / 2, 0.5000),
+        (MAX_UINT16, 0.0000),
+    ],
+)
+def test_percent(mockHardware: MockHardware, value, expected):
+    mockHardware.set_ADC_u16_value(k1, value)
+
+    assert round(k1.percent(), 4) == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (0, 99),
+        (MAX_UINT16 / 4, 74),
+        (MAX_UINT16 / 3, 66),
+        (MAX_UINT16 / 2, 49),
+        (MAX_UINT16, 0),
+    ],
+)
+def test_read_position(mockHardware: MockHardware, value, expected):
+    mockHardware.set_ADC_u16_value(k1, value)
+
+    assert k1.read_position() == expected
+
+
+def test_knobs_are_independent(mockHardware: MockHardware):
+    mockHardware.set_ADC_u16_value(k1, 0)
+    mockHardware.set_ADC_u16_value(k2, MAX_UINT16)
+
+    assert k1.percent() == 1.0
+    assert k2.percent() == 0.0


### PR DESCRIPTION
This PR adds a new test fixture called MockHardware. This fixture allows tests to setup the digital and analog inputs in their tests so that tests can assert on behavior based on these values. I've added some tests for the base EuroPi classes to show how this will work.

This will allow us to add tests for the calibration code, as well as some tests that I'd like to write related to my TuringMachine code.