### PR TITLE
⚡️  adding support for ain bipolar mod

### DIFF
--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -31,8 +31,8 @@ else:
 try:
     from calibration_values import INPUT_CALIBRATION_VALUES, OUTPUT_CALIBRATION_VALUES
 except ImportError:
-    # Note: run calibrate.py to get a more precise calibration.
-    INPUT_CALIBRATION_VALUES = [384, 44634]
+    # Note: run calibrate.py to get a more precise calibration.    
+    INPUT_CALIBRATION_VALUES = [0, 64354]
     OUTPUT_CALIBRATION_VALUES = [
         0,
         6300,
@@ -181,10 +181,12 @@ class AnalogueInput(AnalogueReader):
         percent = reading / max_value
         # low precision vs. high precision
         if len(self._gradients) == 2:
-            cv = 10 * (reading / INPUT_CALIBRATION_VALUES[-1])
+            cv = int(self.MAX_VOLTAGE - self.MIN_VOLTAGE) * (reading / INPUT_CALIBRATION_VALUES[-1])
         else:
             index = int(percent * (len(INPUT_CALIBRATION_VALUES) - 1))
-            cv = index + (self._gradients[index] * (reading - INPUT_CALIBRATION_VALUES[index]))
+            cv = index + (self._gradients[index] * (reading - INPUT_CALIBRATION_VALUES[index]))        
+        
+        cv = cv + self.MIN_VOLTAGE        
         return clamp(cv, self.MIN_VOLTAGE, self.MAX_VOLTAGE)
 
 

--- a/software/tests/mock_hardware.py
+++ b/software/tests/mock_hardware.py
@@ -1,6 +1,6 @@
 from machine import ADC, Pin
 
-from europi import AnalogueReader, DigitalReader
+from europi import AnalogueReader, DigitalReader, AnalogueInput
 
 
 class MockHardware:
@@ -26,3 +26,8 @@ class MockHardware:
     def set_digital_value(self, reader: DigitalReader, value: bool):
         """Sets the value that will be returned by a call to `value` on the given DigitalReader."""
         self._digital_pin_values[reader.pin] = not value
+    
+    def set_min_max_voltage(self, reader: AnalogueInput, min_voltage: float, max_voltage: float):
+        """Sets the minimum and maximum voltage that will be returned by a call to `read_voltage` on the given AnalogueInput."""
+        reader.MIN_VOLTAGE = min_voltage
+        reader.MAX_VOLTAGE = max_voltage

--- a/software/tests/mock_hardware.py
+++ b/software/tests/mock_hardware.py
@@ -26,7 +26,7 @@ class MockHardware:
     def set_digital_value(self, reader: DigitalReader, value: bool):
         """Sets the value that will be returned by a call to `value` on the given DigitalReader."""
         self._digital_pin_values[reader.pin] = not value
-    
+
     def set_min_max_voltage(self, reader: AnalogueInput, min_voltage: float, max_voltage: float):
         """Sets the minimum and maximum voltage that will be returned by a call to `read_voltage` on the given AnalogueInput."""
         reader.MIN_VOLTAGE = min_voltage

--- a/software/tests/test_AnalogueInput.py
+++ b/software/tests/test_AnalogueInput.py
@@ -1,0 +1,48 @@
+import pytest
+
+from europi import AnalogueInput, MAX_UINT16
+
+from mock_hardware import MockHardware
+
+
+@pytest.fixture
+def analogueInput():
+    return AnalogueInput(pin=1)  # actual pin value doesn't matter
+
+AIN_MX_IN = 64354
+@pytest.mark.parametrize(
+    "value, min_voltage, max_voltage, expected",
+    [        
+        (int(AIN_MX_IN/10*0), 0 , 12,0.0),
+        (int(AIN_MX_IN/10*1), 0 , 12,1.2),
+        (int(AIN_MX_IN/10*2), 0 , 12,2.4),
+        (int(AIN_MX_IN/10*3), 0 , 12,3.6),
+        (int(AIN_MX_IN/10*4), 0 , 12,4.8),
+        (int(AIN_MX_IN/10*5), 0 , 12,6.0),
+        (int(AIN_MX_IN/10*6), 0 , 12,7.2),
+        (int(AIN_MX_IN/10*7), 0 , 12,8.4),
+        (int(AIN_MX_IN/10*8), 0 , 12,9.6),
+        (int(AIN_MX_IN/10*9), 0 , 12,10.8),
+        (int(AIN_MX_IN/10*10), 0 , 12,12),
+
+        (int(AIN_MX_IN/10*0),  -6 , 6, -6.0),
+        (int(AIN_MX_IN/10*1),  -6 , 6, -4.8),
+        (int(AIN_MX_IN/10*2),  -6 , 6, -3.6),
+        (int(AIN_MX_IN/10*3),  -6 , 6, -2.4),
+        (int(AIN_MX_IN/10*4),  -6 , 6, -1.2),
+        (int(AIN_MX_IN/10*5),  -6 , 6, 0.0),
+        (int(AIN_MX_IN/10*6),  -6 , 6, 1.2),
+        (int(AIN_MX_IN/10*7),  -6 , 6, 2.4),
+        (int(AIN_MX_IN/10*8),  -6 , 6, 3.6),
+        (int(AIN_MX_IN/10*9),  -6 , 6, 4.8),
+        (int(AIN_MX_IN/10*10), -6 , 6, 6.0),
+
+    ],
+)
+def test_read_voltage(mockHardware: MockHardware, analogueInput, value, min_voltage, max_voltage, expected):    
+    mockHardware.set_min_max_voltage(analogueInput, min_voltage, max_voltage)
+    mockHardware.set_ADC_u16_value(analogueInput, value)   
+
+    assert round(analogueInput.read_voltage(),1) == expected
+
+

--- a/software/tests/test_AnalogueInput.py
+++ b/software/tests/test_AnalogueInput.py
@@ -9,40 +9,41 @@ from mock_hardware import MockHardware
 def analogueInput():
     return AnalogueInput(pin=1)  # actual pin value doesn't matter
 
+
 AIN_MX_IN = 64354
+
+
 @pytest.mark.parametrize(
     "value, min_voltage, max_voltage, expected",
-    [        
-        (int(AIN_MX_IN/10*0), 0 , 12,0.0),
-        (int(AIN_MX_IN/10*1), 0 , 12,1.2),
-        (int(AIN_MX_IN/10*2), 0 , 12,2.4),
-        (int(AIN_MX_IN/10*3), 0 , 12,3.6),
-        (int(AIN_MX_IN/10*4), 0 , 12,4.8),
-        (int(AIN_MX_IN/10*5), 0 , 12,6.0),
-        (int(AIN_MX_IN/10*6), 0 , 12,7.2),
-        (int(AIN_MX_IN/10*7), 0 , 12,8.4),
-        (int(AIN_MX_IN/10*8), 0 , 12,9.6),
-        (int(AIN_MX_IN/10*9), 0 , 12,10.8),
-        (int(AIN_MX_IN/10*10), 0 , 12,12),
-
-        (int(AIN_MX_IN/10*0),  -6 , 6, -6.0),
-        (int(AIN_MX_IN/10*1),  -6 , 6, -4.8),
-        (int(AIN_MX_IN/10*2),  -6 , 6, -3.6),
-        (int(AIN_MX_IN/10*3),  -6 , 6, -2.4),
-        (int(AIN_MX_IN/10*4),  -6 , 6, -1.2),
-        (int(AIN_MX_IN/10*5),  -6 , 6, 0.0),
-        (int(AIN_MX_IN/10*6),  -6 , 6, 1.2),
-        (int(AIN_MX_IN/10*7),  -6 , 6, 2.4),
-        (int(AIN_MX_IN/10*8),  -6 , 6, 3.6),
-        (int(AIN_MX_IN/10*9),  -6 , 6, 4.8),
-        (int(AIN_MX_IN/10*10), -6 , 6, 6.0),
-
+    [
+        (int(AIN_MX_IN / 10 * 0), 0, 12, 0.0),
+        (int(AIN_MX_IN / 10 * 1), 0, 12, 1.2),
+        (int(AIN_MX_IN / 10 * 2), 0, 12, 2.4),
+        (int(AIN_MX_IN / 10 * 3), 0, 12, 3.6),
+        (int(AIN_MX_IN / 10 * 4), 0, 12, 4.8),
+        (int(AIN_MX_IN / 10 * 5), 0, 12, 6.0),
+        (int(AIN_MX_IN / 10 * 6), 0, 12, 7.2),
+        (int(AIN_MX_IN / 10 * 7), 0, 12, 8.4),
+        (int(AIN_MX_IN / 10 * 8), 0, 12, 9.6),
+        (int(AIN_MX_IN / 10 * 9), 0, 12, 10.8),
+        (int(AIN_MX_IN / 10 * 10), 0, 12, 12),
+        (int(AIN_MX_IN / 10 * 0), -6, 6, -6.0),
+        (int(AIN_MX_IN / 10 * 1), -6, 6, -4.8),
+        (int(AIN_MX_IN / 10 * 2), -6, 6, -3.6),
+        (int(AIN_MX_IN / 10 * 3), -6, 6, -2.4),
+        (int(AIN_MX_IN / 10 * 4), -6, 6, -1.2),
+        (int(AIN_MX_IN / 10 * 5), -6, 6, 0.0),
+        (int(AIN_MX_IN / 10 * 6), -6, 6, 1.2),
+        (int(AIN_MX_IN / 10 * 7), -6, 6, 2.4),
+        (int(AIN_MX_IN / 10 * 8), -6, 6, 3.6),
+        (int(AIN_MX_IN / 10 * 9), -6, 6, 4.8),
+        (int(AIN_MX_IN / 10 * 10), -6, 6, 6.0),
     ],
 )
-def test_read_voltage(mockHardware: MockHardware, analogueInput, value, min_voltage, max_voltage, expected):    
+def test_read_voltage(
+    mockHardware: MockHardware, analogueInput, value, min_voltage, max_voltage, expected
+):
     mockHardware.set_min_max_voltage(analogueInput, min_voltage, max_voltage)
-    mockHardware.set_ADC_u16_value(analogueInput, value)   
+    mockHardware.set_ADC_u16_value(analogueInput, value)
 
-    assert round(analogueInput.read_voltage(),1) == expected
-
-
+    assert round(analogueInput.read_voltage(), 1) == expected


### PR DESCRIPTION
This change allows the use of bipolar signals in the Analogue input (`ain`)

The main change is in the `read_voltage` method of the `AnalogueInput` class in `europi.py`. It considers the Min and Max Voltage provided in the constructor. 

In order to test this, the `test_AnalogueInput.py` was created and the `mock_hardware.py` modified to mock analog inputs. 
Now, the EuroPi ain circuit has a non-inverting input with 1.22 gain. This means that the wide range of the `ain` is 0 to 12.22V. To make the `pytest` doable with mock hardware, the default value of `INPUT_CALIBRATION_VALUES` in the `europi.py` needs to change to  `[0, 64354]` (roughly the range of 0 to 12V). Likewise, the test needs to specify an input of min/max of 0 to 12 and -6 to 6 V.

I did not test this on an original EuroPi, instead I used a remix that allows bipolar input. The Calibration script should work as long as the minimum voltage is used instead of Ground (or disconnected).

Not sure if the implementation of the test is ok, please make remarks if needed

