### PR TITLE
Add new Display methods and use constants for HIGH and LOW digital states

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ Temporary Items
 __pycache__
 venv
 .venv
+.idea

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -412,6 +412,11 @@ class Display(SSD1306_I2C):
     `oled_tips.md <https://github.com/Allen-Synthesis/EuroPi/blob/main/software/oled_tips.md>`_
     """
 
+    DIRECTION_LEFT = 0
+    DIRECTION_RIGHT = 1
+    DIRECTION_TOP = 2
+    DIRECTION_BOTTOM = 3
+
     def __init__(
         self,
         sda,
@@ -451,15 +456,26 @@ class Display(SSD1306_I2C):
         self.show()
 
     def centered_text_line(self, text, y, color=1):
-        """Displays the given text horizontally centered on its line"""
+        """Displays the given text horizontally centered on its line."""
         x_offset = int((self.width - ((len(text) + 1) * 7)) / 2) - 1
         self.text(text, x_offset, y, color)
 
-    def arrow(self, y, x=2, direction="left", size=4, color=1):
-        """Displays an arrow of the desired size and color pointing left or right"""
+    def arrow(self, x, y, direction=None, size=4, color=1):
+        """Displays an arrow of the desired size and color pointing left, right, top or bottom.
+        Use the class constants DIRECTION_LEFT, DIRECTION_RIGHT, DIRECTION_TOP and DIRECTION_BOTTOM
+        to set the direction."""
+        direction = self.DIRECTION_LEFT if direction is None else direction
+
+        if direction in [self.DIRECTION_LEFT, self.DIRECTION_RIGHT]:
+            for i in range(size):
+                xi = x + i if direction == self.DIRECTION_LEFT else self.width - x - i - 1
+                self.line(xi, y - i, xi, y + i, color)
+
+            return
+
         for i in range(size):
-            xi = x + i if direction == "left" else self.width - x - i
-            self.line(xi, y - i, xi, y + i, color)
+            yi = y + i if direction == self.DIRECTION_TOP else self.height - y - i - 1
+            self.line(x + i, yi, x - i, yi, color)
 
 
 class Output:

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -448,7 +448,7 @@ class Display(SSD1306_I2C):
         for index, content in enumerate(lines):
             y_offset = int((index * 9) + padding_top) - 1
             self.centered_text_line(content, y_offset)
-        oled.show()
+        self.show()
 
     def centered_text_line(self, text, y, color=1):
         """Displays the given text horizontally centered on its line"""

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -413,11 +413,6 @@ class Display(SSD1306_I2C):
     `oled_tips.md <https://github.com/Allen-Synthesis/EuroPi/blob/main/software/oled_tips.md>`_
     """
 
-    DIRECTION_LEFT = 0
-    DIRECTION_RIGHT = 1
-    DIRECTION_TOP = 2
-    DIRECTION_BOTTOM = 3
-
     def __init__(
         self,
         sda,

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -452,31 +452,10 @@ class Display(SSD1306_I2C):
 
         padding_top = (self.height - (len(lines) * 9)) / 2
         for index, content in enumerate(lines):
+            x_offset = int((self.width - ((len(content) + 1) * 7)) / 2) - 1
             y_offset = int((index * 9) + padding_top) - 1
-            self.centred_text_line(content, y_offset)
+            self.text(content, x_offset, y_offset)
         self.show()
-
-    def centred_text_line(self, text, y, colour=1):
-        """Displays the given text horizontally centered on its line."""
-        x_offset = int((self.width - ((len(text) + 1) * 7)) / 2) - 1
-        self.text(text, x_offset, y, colour)
-
-    def arrow(self, x, y, direction=None, size=4, colour=1):
-        """Displays an arrow of the desired size and colour pointing left, right, top or bottom.
-        Use the class constants DIRECTION_LEFT, DIRECTION_RIGHT, DIRECTION_TOP and DIRECTION_BOTTOM
-        to set the direction."""
-        direction = self.DIRECTION_LEFT if direction is None else direction
-
-        if direction in [self.DIRECTION_LEFT, self.DIRECTION_RIGHT]:
-            for i in range(size):
-                xi = x + i if direction == self.DIRECTION_LEFT else self.width - x - i - 1
-                self.line(xi, y - i, xi, y + i, colour)
-
-            return
-
-        for i in range(size):
-            yi = y + i if direction == self.DIRECTION_TOP else self.height - y - i - 1
-            self.line(x + i, yi, x - i, yi, colour)
 
 
 class Output:

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -452,7 +452,7 @@ class Display(SSD1306_I2C):
         padding_top = (self.height - (len(lines) * 9)) / 2
         for index, content in enumerate(lines):
             y_offset = int((index * 9) + padding_top) - 1
-            self.centered_text_line(content, y_offset)
+            self.centred_text_line(content, y_offset)
         self.show()
 
     def centred_text_line(self, text, y, colour=1):

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -272,19 +272,20 @@ class DigitalReader:
             self.last_rising_ms = time.ticks_ms()
             return self._rising_handler()
 
-        if time.ticks_diff(time.ticks_ms(), self.last_falling_ms) < self.debounce_delay:
-            return
-        self.last_falling_ms = time.ticks_ms()
+        elif self.value() == LOW:
+            if time.ticks_diff(time.ticks_ms(), self.last_falling_ms) < self.debounce_delay:
+                return
+            self.last_falling_ms = time.ticks_ms()
 
-        # Check if 'other' pin is set and if 'other' pins is high and if this pin has been high for long enough.
-        if (
-            self._other
-            and self._other.value()
-            and time.ticks_diff(self.last_falling_ms, self.last_rising_ms) > 500
-        ):
-            return self._both_handler()
+            # Check if 'other' pin is set and if 'other' pins is high and if this pin has been high for long enough.
+            if (
+                self._other
+                and self._other.value()
+                and time.ticks_diff(self.last_falling_ms, self.last_rising_ms) > 500
+            ):
+                return self._both_handler()
 
-        return self._falling_handler()
+            return self._falling_handler()
 
     def value(self):
         """The current binary value, HIGH (1) or LOW (0)."""

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -450,13 +450,13 @@ class Display(SSD1306_I2C):
             self.centered_text_line(content, y_offset)
         oled.show()
 
-    def centered_text_line(self, s, y, color=1):
-        """Displays the given text centered on its line"""
-        x_offset = int((self.width - ((len(s) + 1) * 7)) / 2) - 1
-        self.text(s, x_offset, y, color)
+    def centered_text_line(self, text, y, color=1):
+        """Displays the given text horizontally centered on its line"""
+        x_offset = int((self.width - ((len(text) + 1) * 7)) / 2) - 1
+        self.text(text, x_offset, y, color)
 
     def arrow(self, y, x=2, direction="left", size=4, color=1):
-        """Display an arrow of the desired size and color pointing left or right"""
+        """Displays an arrow of the desired size and color pointing left or right"""
         for i in range(size):
             xi = x + i if direction == "left" else self.width - x - i
             self.line(xi, y - i, xi, y + i, color)

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -455,13 +455,13 @@ class Display(SSD1306_I2C):
             self.centered_text_line(content, y_offset)
         self.show()
 
-    def centered_text_line(self, text, y, color=1):
+    def centred_text_line(self, text, y, colour=1):
         """Displays the given text horizontally centered on its line."""
         x_offset = int((self.width - ((len(text) + 1) * 7)) / 2) - 1
-        self.text(text, x_offset, y, color)
+        self.text(text, x_offset, y, colour)
 
-    def arrow(self, x, y, direction=None, size=4, color=1):
-        """Displays an arrow of the desired size and color pointing left, right, top or bottom.
+    def arrow(self, x, y, direction=None, size=4, colour=1):
+        """Displays an arrow of the desired size and colour pointing left, right, top or bottom.
         Use the class constants DIRECTION_LEFT, DIRECTION_RIGHT, DIRECTION_TOP and DIRECTION_BOTTOM
         to set the direction."""
         direction = self.DIRECTION_LEFT if direction is None else direction
@@ -469,13 +469,13 @@ class Display(SSD1306_I2C):
         if direction in [self.DIRECTION_LEFT, self.DIRECTION_RIGHT]:
             for i in range(size):
                 xi = x + i if direction == self.DIRECTION_LEFT else self.width - x - i - 1
-                self.line(xi, y - i, xi, y + i, color)
+                self.line(xi, y - i, xi, y + i, colour)
 
             return
 
         for i in range(size):
             yi = y + i if direction == self.DIRECTION_TOP else self.height - y - i - 1
-            self.line(x + i, yi, x - i, yi, color)
+            self.line(x + i, yi, x - i, yi, colour)
 
 
 class Output:

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -446,10 +446,20 @@ class Display(SSD1306_I2C):
 
         padding_top = (self.height - (len(lines) * 9)) / 2
         for index, content in enumerate(lines):
-            x_offset = int((self.width - ((len(content) + 1) * 7)) / 2) - 1
             y_offset = int((index * 9) + padding_top) - 1
-            self.text(content, x_offset, y_offset)
+            self.centered_text_line(content, y_offset)
         oled.show()
+
+    def centered_text_line(self, s, y, color=1):
+        """Displays the given text centered on its line"""
+        x_offset = int((self.width - ((len(s) + 1) * 7)) / 2) - 1
+        self.text(s, x_offset, y, color)
+
+    def arrow(self, y, x=2, direction="left", size=4, color=1):
+        """Display an arrow of the desired size and color pointing left or right"""
+        for i in range(size):
+            xi = x + i if direction == "left" else self.width - x - i
+            self.line(xi, y - i, xi, y + i, color)
 
 
 class Output:

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -70,6 +70,10 @@ MAX_OUTPUT_VOLTAGE = 10
 CHAR_WIDTH = 8
 CHAR_HEIGHT = 8
 
+# Digital input and output binary values.
+HIGH = 1
+LOW = 0
+
 
 # Helper functions.
 
@@ -262,33 +266,32 @@ class DigitalReader:
 
     def _bounce_wrapper(self, pin):
         """IRQ handler wrapper for falling and rising edge callback functions."""
-        if self.value() == 1:
+        if self.value() == HIGH:
             if time.ticks_diff(time.ticks_ms(), self.last_rising_ms) < self.debounce_delay:
                 return
             self.last_rising_ms = time.ticks_ms()
             return self._rising_handler()
 
-        elif self.value() == 0:
-            if time.ticks_diff(time.ticks_ms(), self.last_falling_ms) < self.debounce_delay:
-                return
-            self.last_falling_ms = time.ticks_ms()
+        if time.ticks_diff(time.ticks_ms(), self.last_falling_ms) < self.debounce_delay:
+            return
+        self.last_falling_ms = time.ticks_ms()
 
-            # Check if 'other' pin is set and if 'other' pins is high and if this pin has been high for long enough.
-            if (
-                self._other
-                and self._other.value()
-                and time.ticks_diff(self.last_falling_ms, self.last_rising_ms) > 500
-            ):
-                return self._both_handler()
+        # Check if 'other' pin is set and if 'other' pins is high and if this pin has been high for long enough.
+        if (
+            self._other
+            and self._other.value()
+            and time.ticks_diff(self.last_falling_ms, self.last_rising_ms) > 500
+        ):
+            return self._both_handler()
 
-            return self._falling_handler()
+        return self._falling_handler()
 
     def value(self):
         """The current binary value, HIGH (1) or LOW (0)."""
         # Both the digital input and buttons are normally high, and 'pulled'
-        # low when on, so this is flipped to be more intuitive (1 when on, 0
-        # when off)
-        return 1 - self.pin.value()
+        # low when on, so this is flipped to be more intuitive
+        # (high when on, low when off)
+        return LOW if self.pin.value() else HIGH
 
     def handler(self, func):
         """Define the callback function to call when rising edge detected."""
@@ -504,7 +507,7 @@ class Output:
 
     def value(self, value):
         """Sets the output to 0V or 5V based on a binary input, 0 or 1."""
-        if value == 1:
+        if value == HIGH:
             self.on()
         else:
             self.off()

--- a/software/oled_tips.md
+++ b/software/oled_tips.md
@@ -19,11 +19,11 @@ The pixels are indexed with (0, 0) at the top left, and (127, 31) at the bottom 
 |vline|x, y, length, colour|Draws a vertical wide line starting at (x, y) with specified length and colour|
 |rect|x, y, width, height, colour|Draws a rectangle starting at (x, y) with specified width, height, and outline colour|
 |fill_rect|x, y, width, height, colour|Draws a rectangle starting at (x, y) with specified width, height, and fill colour|
-|blit|buffer, x, y|Draws a bitmap based on a buffer, starting at (x, y)|
-|scroll|x, y|Scrolls the contents of the display by (x, y)|
-|invert|colour|Inverts the display|
-|contrast|contrast|Changes the contrast based on a value|
-|show||Updates the physical display with the contents of the buffer|
+|blit|buffer, x, y|Draws a bitmap based on a buffer, starting at (x, y)
+|scroll|x, y|Scrolls the contents of the display by (x, y)
+|invert|colour|Inverts the display
+|contrast|contrast|Changes the contrast based on a value
+|show||Updates the physical display with the contents of the buffer
 
 ### Using .show()
 One thing to make sure of is that you use oled.show() whenever you need to update the display.  
@@ -34,12 +34,10 @@ The reason this isn't automatic is because the actual .show() method is quite CP
 There are also some methods provided in the EuroPi library, which are designed to make certain common uses of the OLED easier.  
 These can be accessed the same way as the predefined methods listed above, and you can even add your own to your own europi.py file if you wish.
 
-| Method            | Parameters                    | Function                                                                                                      |
-|-------------------|-------------------------------|---------------------------------------------------------------------------------------------------------------|
-| centre_text       | string                        | Takes a string of up to 3 lines separated by '\n', and displays them centred vertically and horizontally      |
-| centred_text_line | string, y, colour             | Centers a single line of text horizontally                                                                    |
-| arrow             | x, y, direction, size, colour | Draws an arrow of the desired size and colour pointing left, right, top or bottom                             |
-| clear             |                               | Clear the display upon calling this method. If you just need to clear the display buffer, use `oled.fill(0)`. |
+| Method | Parameters | Function |
+| ------ | ---------- | -------- |
+|centre_text|string|Takes a string of up to 3 lines separated by '\n', and displays them centred vertically and horizontally|
+|clear||Clear the display upon calling this method. If you just need to clear the display buffer, use `oled.fill(0)`.
 
 ### `centre_text` example
 
@@ -54,26 +52,3 @@ oled.centre_text("this text\nhas been\ncentred")
 *OLED Result*
 
 ![imgur](https://i.imgur.com/Elljlt1.jpg)
-
-### `arrow` example
-
-*Python Program*
-
-```python
-from europi import *
-
-oled.fill(0)
-
-oled.arrow(0, 15)
-oled.arrow(0, 15, oled.DIRECTION_RIGHT, 16)
-oled.arrow(63, 0, oled.DIRECTION_TOP, 6)
-oled.arrow(63, 0, oled.DIRECTION_BOTTOM, 13)
-
-# Inverting display to see exactly where the arrows start and end, you don't have to do that
-oled.invert(1)
-oled.show()
-```
-
-*OLED Result*
-
-![imgur](https://i.imgur.com/pQIu4it.jpg)

--- a/software/oled_tips.md
+++ b/software/oled_tips.md
@@ -34,12 +34,12 @@ The reason this isn't automatic is because the actual .show() method is quite CP
 There are also some methods provided in the EuroPi library, which are designed to make certain common uses of the OLED easier.  
 These can be accessed the same way as the predefined methods listed above, and you can even add your own to your own europi.py file if you wish.
 
-| Method             | Parameters                   | Function                                                                                                      |
-|--------------------|------------------------------|---------------------------------------------------------------------------------------------------------------|
-| centre_text        | string                       | Takes a string of up to 3 lines separated by '\n', and displays them centred vertically and horizontally      |
-| centered_text_line | string, y, color             | Centers a single line of text horizontally                                                                    |
-| arrow              | x, y, direction, size, color | Draws an arrow of the desired size and color pointing left, right, top or bottom                              |
-| clear              |                              | Clear the display upon calling this method. If you just need to clear the display buffer, use `oled.fill(0)`. |
+| Method            | Parameters                    | Function                                                                                                      |
+|-------------------|-------------------------------|---------------------------------------------------------------------------------------------------------------|
+| centre_text       | string                        | Takes a string of up to 3 lines separated by '\n', and displays them centred vertically and horizontally      |
+| centred_text_line | string, y, colour             | Centers a single line of text horizontally                                                                    |
+| arrow             | x, y, direction, size, colour | Draws an arrow of the desired size and colour pointing left, right, top or bottom                             |
+| clear             |                               | Clear the display upon calling this method. If you just need to clear the display buffer, use `oled.fill(0)`. |
 
 ### `centre_text` example
 

--- a/software/oled_tips.md
+++ b/software/oled_tips.md
@@ -63,15 +63,17 @@ oled.centre_text("this text\nhas been\ncentred")
 from europi import *
 
 oled.fill(0)
+
 oled.arrow(0, 15)
-oled.arrow(0, 15, direction=oled.DIRECTION_RIGHT)
-oled.arrow(63, 0, direction=oled.DIRECTION_TOP)
-oled.arrow(63, 0, direction=oled.DIRECTION_BOTTOM)
-# Invert display to see exactly where the arrows start and end, you don't have to do that
+oled.arrow(0, 15, oled.DIRECTION_RIGHT, 16)
+oled.arrow(63, 0, oled.DIRECTION_TOP, 6)
+oled.arrow(63, 0, oled.DIRECTION_BOTTOM, 13)
+
+# Inverting display to see exactly where the arrows start and end, you don't have to do that
 oled.invert(1)
 oled.show()
 ```
 
 *OLED Result*
 
-![imgur](https://i.imgur.com/0qGkocG.jpeg)
+![imgur](https://i.imgur.com/pQIu4it.jpg)

--- a/software/oled_tips.md
+++ b/software/oled_tips.md
@@ -19,11 +19,11 @@ The pixels are indexed with (0, 0) at the top left, and (127, 31) at the bottom 
 |vline|x, y, length, colour|Draws a vertical wide line starting at (x, y) with specified length and colour|
 |rect|x, y, width, height, colour|Draws a rectangle starting at (x, y) with specified width, height, and outline colour|
 |fill_rect|x, y, width, height, colour|Draws a rectangle starting at (x, y) with specified width, height, and fill colour|
-|blit|buffer, x, y|Draws a bitmap based on a buffer, starting at (x, y)
-|scroll|x, y|Scrolls the contents of the display by (x, y)
-|invert|colour|Inverts the display
-|contrast|contrast|Changes the contrast based on a value
-|show||Updates the physical display with the contents of the buffer
+|blit|buffer, x, y|Draws a bitmap based on a buffer, starting at (x, y)|
+|scroll|x, y|Scrolls the contents of the display by (x, y)|
+|invert|colour|Inverts the display|
+|contrast|contrast|Changes the contrast based on a value|
+|show||Updates the physical display with the contents of the buffer|
 
 ### Using .show()
 One thing to make sure of is that you use oled.show() whenever you need to update the display.  
@@ -34,10 +34,12 @@ The reason this isn't automatic is because the actual .show() method is quite CP
 There are also some methods provided in the EuroPi library, which are designed to make certain common uses of the OLED easier.  
 These can be accessed the same way as the predefined methods listed above, and you can even add your own to your own europi.py file if you wish.
 
-| Method | Parameters | Function |
-| ------ | ---------- | -------- |
-|centre_text|string|Takes a string of up to 3 lines separated by '\n', and displays them centred vertically and horizontally|
-|clear||Clear the display upon calling this method. If you just need to clear the display buffer, use `oled.fill(0)`.
+| Method             | Parameters                   | Function                                                                                                      |
+|--------------------|------------------------------|---------------------------------------------------------------------------------------------------------------|
+| centre_text        | string                       | Takes a string of up to 3 lines separated by '\n', and displays them centred vertically and horizontally      |
+| centered_text_line | string, y, color             | Centers a single line of text horizontally                                                                    |
+| arrow              | y, x, direction, size, color | Draws an arrow of the desired size and color pointing left or right                                           |
+| clear              |                              | Clear the display upon calling this method. If you just need to clear the display buffer, use `oled.fill(0)`. |
 
 ### `centre_text` example
 

--- a/software/oled_tips.md
+++ b/software/oled_tips.md
@@ -38,7 +38,7 @@ These can be accessed the same way as the predefined methods listed above, and y
 |--------------------|------------------------------|---------------------------------------------------------------------------------------------------------------|
 | centre_text        | string                       | Takes a string of up to 3 lines separated by '\n', and displays them centred vertically and horizontally      |
 | centered_text_line | string, y, color             | Centers a single line of text horizontally                                                                    |
-| arrow              | y, x, direction, size, color | Draws an arrow of the desired size and color pointing left or right                                           |
+| arrow              | x, y, direction, size, color | Draws an arrow of the desired size and color pointing left, right, top or bottom                              |
 | clear              |                              | Clear the display upon calling this method. If you just need to clear the display buffer, use `oled.fill(0)`. |
 
 ### `centre_text` example
@@ -54,3 +54,24 @@ oled.centre_text("this text\nhas been\ncentred")
 *OLED Result*
 
 ![imgur](https://i.imgur.com/Elljlt1.jpg)
+
+### `arrow` example
+
+*Python Program*
+
+```python
+from europi import *
+
+oled.fill(0)
+oled.arrow(0, 15)
+oled.arrow(0, 15, direction=oled.DIRECTION_RIGHT)
+oled.arrow(63, 0, direction=oled.DIRECTION_TOP)
+oled.arrow(63, 0, direction=oled.DIRECTION_BOTTOM)
+# Invert display to see exactly where the arrows start and end, you don't have to do that
+oled.invert(1)
+oled.show()
+```
+
+*OLED Result*
+
+![imgur](https://i.imgur.com/0qGkocG.jpeg)


### PR DESCRIPTION
# Improvements

~~## Added 2 methods to the `Display` class~~

~~### `centred_text_line()`~~
~~Allows to center a single line of text.~~

~~I updated the existing `centre_text()` method to use this one for its horizontal centering part.~~

~~Ideally I would have called this method `centred_text()` but I think this would be too close to the already existing method and could create some confusion.~~

~~### `arrow()`~~
~~A simple method to draw arrows of different sizes and color pointing left, right, top or bottom.~~

~~I'm using it in my script class already but I think it's a nice little addition to the `Display` class.~~

~~Ideally I would have written all the conditions to display the different directions inside a single loop but to save as much computing time I decided to have two separated loops dependent of a condition executed only once.~~

## Add `LOW` and `HIGH` constants

Abstracting the `HIGH` and `LOW` digital values slightly improves readability and maintainability.

All scripts can use these constants to make things clearer.
When using such constants, it makes it very easy to distinguish integers from digitals states in a logic.

# Fix

## Global `oled` instance called in `Display` class

`Display::centre_text()` was calling `oled.show()` instead of calling its own `show()` method.
Since there is only one display instance, that's not much of an issue but it's still incorrect.