### PR TITLE
Fix usb connection issue

### DIFF
--- a/software/contrib/menu.py
+++ b/software/contrib/menu.py
@@ -56,4 +56,3 @@ EUROPI_SCRIPT_CLASSES = [
 
 if __name__ == "__main__":
     BootloaderMenu(EUROPI_SCRIPT_CLASSES).main()
-

--- a/software/contrib/menu.py
+++ b/software/contrib/menu.py
@@ -1,5 +1,10 @@
 """See menu.md for details."""
-from europi import bootsplash
+
+from europi import bootsplash, Pin
+
+if Pin(24).value() == 1:
+    from time import sleep
+    sleep(0.5)
 
 bootsplash()
 
@@ -51,3 +56,4 @@ EUROPI_SCRIPT_CLASSES = [
 
 if __name__ == "__main__":
     BootloaderMenu(EUROPI_SCRIPT_CLASSES).main()
+

--- a/software/contrib/menu.py
+++ b/software/contrib/menu.py
@@ -2,6 +2,7 @@
 
 from europi import bootsplash, Pin
 
+#  This is a fix for a USB connection issue documented in GitHub issue #179, and its removal condition is set out in GitHub issue #184
 if Pin(24).value() == 1:
     from time import sleep
 

--- a/software/contrib/menu.py
+++ b/software/contrib/menu.py
@@ -1,9 +1,9 @@
 """See menu.md for details."""
 
-from europi import bootsplash, Pin
+from europi import bootsplash, usb_connected
 
 #  This is a fix for a USB connection issue documented in GitHub issue #179, and its removal condition is set out in GitHub issue #184
-if Pin(24).value() == 1:
+if usb_connected.value() == 0:
     from time import sleep
 
     sleep(0.5)

--- a/software/contrib/menu.py
+++ b/software/contrib/menu.py
@@ -4,6 +4,7 @@ from europi import bootsplash, Pin
 
 if Pin(24).value() == 1:
     from time import sleep
+
     sleep(0.5)
 
 bootsplash()

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -542,5 +542,7 @@ cv5 = Output(18)
 cv6 = Output(19)
 cvs = [cv1, cv2, cv3, cv4, cv5, cv6]
 
+usb_connected = DigitalReader(24, 0)
+
 # Reset the module state upon import.
 reset_state()

--- a/software/programming_instructions.md
+++ b/software/programming_instructions.md
@@ -29,14 +29,18 @@ To start with, you'll need to download the [Thonny IDE](https://thonny.org/). Th
 
     ![Interpreter Select](https://i.imgur.com/XeRem1w.jpg)
 
-5. Click Tools -> Manage Packages to open the package manager.
-6. Type 'ssd1306' into the search box and click 'Search on PyPi'
-7. Click the result named 'micropython-ssd1306'.
+5. **Important**: Wait until the Shell window at the bottom shows the MicroPython version and the purple ```>>>``` symbol.
+
+    ![image](https://user-images.githubusercontent.com/79809962/196224993-70a7a662-90ca-45df-90f6-a2c1f1f70a9e.png)
+
+6. Click Tools -> Manage Packages to open the package manager.
+7. Type 'ssd1306' into the search box and click 'Search on PyPi'
+8. Click the result named 'micropython-ssd1306'.
 
     ![ssd1306 library](https://i.imgur.com/7t2mWHh.jpg)
 
-8. Click 'Install'.
-9. You will see that a folder has been created inside the Pico named 'lib', which contains the new file 'ssd1306.py'.
+9. Click 'Install'.
+10. You will see that a folder has been created inside the Pico named 'lib', which contains the new file 'ssd1306.py'.
 
     ![ssd1306 inside lib](https://i.imgur.com/jkmeaFM.jpg)
 


### PR DESCRIPTION
Fix issue #179 

By adding a conditional delay based on the value of GPIO24 to menu.py, only when the menu is main.py *and* the module is connected via USB to a computer will the module delay running the menu, thus giving the module time to establish the USB connection first with no chance of interference. 
  
At least from my experiments this change entirely fixes the issue documented in #179 .
  
It would be up to our judgement as to whether this condition and delay should occur within europi.py or menu.py, but I think menu.py is more appropriate as users may want to solve this a different way (or not at all) when writing their own scripts, and europi.py *should* only be a library and not a script in itself