### PR TITLE
Create deploy batch files

### DIFF
--- a/scripts/windows/deploy_contrib.bat
+++ b/scripts/windows/deploy_contrib.bat
@@ -1,0 +1,11 @@
+::CONTRIB::
+rshell mkdir /pyboard/lib/contrib
+set "deployfilepath=%~dp0"
+set "filepathcontrib=%deployfilepath%..\..\software\contrib\*.py"
+set "filepathrshell=%filepathcontrib:\=/%"
+set "filepathrshell=%filepathrshell:C:/=/%"
+dir "%filepathcontrib%"
+cd/
+rshell cp %filepathrshell% /pyboard/lib/contrib
+
+cd %~dp0

--- a/scripts/windows/deploy_experimental.bat
+++ b/scripts/windows/deploy_experimental.bat
@@ -1,0 +1,11 @@
+::EXPERIMENTAL::
+rshell mkdir /pyboard/lib/experimental
+set "deployfilepath=%~dp0"
+set "filepathexperimental=%deployfilepath%..\..\software\firmware\experimental\*.py"
+set "filepathrshell=%filepathexperimental:\=/%"
+set "filepathrshell=%filepathrshell:C:/=/%"
+dir "%filepathexperimental%"
+cd/
+rshell cp %filepathrshell% /pyboard/lib/experimental
+
+cd %~dp0

--- a/scripts/windows/deploy_firmware.bat
+++ b/scripts/windows/deploy_firmware.bat
@@ -1,0 +1,11 @@
+::FIRMWARE::
+set "deployfilepath=%~dp0"
+set "filepathfirmware=%deployfilepath%..\..\software\firmware\*.py"
+set "filepathrshell=%filepathfirmware:\=/%"
+set "filepathrshell=%filepathrshell:C:/=/%"
+dir "%filepathfirmware%"
+cd/
+rshell mkdir /pyboard/lib
+rshell cp %filepathrshell% /pyboard/lib/
+
+cd %~dp0

--- a/scripts/windows/menu_setup.bat
+++ b/scripts/windows/menu_setup.bat
@@ -1,0 +1,11 @@
+call deploy_firmware.bat
+call deploy_experimental.bat
+call deploy_contrib.bat
+
+rshell cp /pyboard/lib/contrib/menu.py menu.py
+ren menu.py main.py
+rshell cp main.py /pyboard
+del main.py
+
+::Navigate back to original directory::
+cd %~dp0


### PR DESCRIPTION
These are .bat files (for windows) which will copy the various firmware and contrib files onto a connected Pico.
There is one batch file per folder of scripts; one for basic firmware, one for experimental firmware, and one for all contrib scripts.
There is also a master batch file named ```menu_setup.bat``` which when run will execute the previously mentioned three files in order, and then copy and rename ```menu.py``` from contrib to ```main.py``` in root.
  
With these files, the only extra step is to install the ssd1306 library, after which the module can be connected to power and used immediately. Thanks to the batch files being separated, if you were only editing the contrib files, you could only copy those over by running ```deploy_contrib.bat``` and not the rest.