### PR TITLE
Re-word calibration instructions to make sense with the menu

### DIFF
--- a/software/programming_instructions.md
+++ b/software/programming_instructions.md
@@ -134,7 +134,8 @@ NOTE: If you have just installed the menu, simply run the calibration script and
 6. Once all the required voltages have been input, you now need to disconnect the analogue input from your voltage source, and instead connect it to CV output 1.
 7. Once you have connected the analogue input to CV output 1, press button 1
 8. Wait for each voltage up to 10V to complete. The module will tell you once it has completed.
-9. The calibration process is now complete! You now need to rename or delete the 'calibrate.py' program, however DO NOT delete the new file created called 'calibration_values.py'. This file is where the calibration values are stored, and if you delete it you will have to complete the calibration again.
+9. NOTE: Skip this final step if you are running the calibration script from the menu system.  
+The calibration process is now complete! You now need to rename or delete the 'calibrate.py' program, however DO NOT delete the new file created called 'calibration_values.py'. This file is where the calibration values are stored, and if you delete it you will have to complete the calibration again.
 
 
 # Programming Limitations

--- a/software/programming_instructions.md
+++ b/software/programming_instructions.md
@@ -111,13 +111,18 @@ Now you have access to the inputs and outputs using easy methods, which you can 
 
 1. Complete all of the steps for [Option 2](https://github.com/Allen-Synthesis/EuroPi/edit/release_prep/0.2.0/software/programming_instructions.md#copy-someone-elses-program-to-run-on-your-module), but you must use ``menu.py`` as the file to save to the root directory. Name it ``main.py`` as you would any other script.
 2. Now you can disconnect the module from your computer, connect it to rack power, and the menu will open automatically. After you choose a program that will become the default program that runs when the module is connected to power, but you can still go back to the menu at any time by pressing and holding both buttons for >0.5s and then releasing.
+  
+One of the scripts that is installed with the menu system is named '~ Calibrate', and it requires you to send precise voltages to the module to calibrate it for the future, allowing you to input and output precise values from your module.  
+This is entirely optional and it will work with a usable degree of accuracy without calibration, however if you do want to then move to the ['Calibrate the module'](#calibrate-the-module) step.
 
 
 ### Calibrate the module
 
 To use the module for accurately reading and outputting voltages, you need to complete a calibration process. This will allow your specific module to account for any differences in components, such as resistor tolerances.  
 If you do not wish to calibrate the module and don't mind your voltages being slightly inaccurate, simply skip to the programming step and your module will use default values.
-
+  
+NOTE: If you have just installed the menu, simply run the calibration script and skip to step 2.
+  
 1. To begin, you need to choose the `calibrate.py` file and save it as `main.py` in the root directory, as we did in [Option 2](#copy-someone-elses-program-to-run-on-your-module) above. You can obtain the `calibrate.py` file from either the `lib` directory on your Pico, or from [the firmware directory in the repository](/software/firmware/calibrate.py).
 2. Make sure your module is connected to rack power for the calibration process. It doesn't matter if it connected to USB as well, however if it is it will give an extra warning to turn on rack power which you need to skip using button 1.
 3. Turn on the rack power supply, and the screen will display 'Calibration Mode'. If it doesn't, try [troubleshooting](../troubleshooting.md).  


### PR DESCRIPTION
As pointed out by 'STABB' in the Discord, when following the instructions to calibrate the module the user is encouraged to delete ```calibrate.py``` when finished with it, however if using the menu system this will cause a bug.

I have reworded the programming instructions to make this more clear and to allow the user to calibrate the module from the menu without needing to rename.