### PR TITLE
LockableKnob init fix

### DIFF
--- a/software/contrib/knob_playground.py
+++ b/software/contrib/knob_playground.py
@@ -1,0 +1,70 @@
+from machine import ADC
+from time import sleep
+
+from europi import k1, k2, b1, b2, oled, MAX_UINT16
+from europi_script import EuroPiScript
+from experimental.knobs import KnobBank
+
+"""
+An example program showing the use of a KnobBank or LockableKnobs. This script is not meant to be merged into main, 
+it only exists so that PR reviewers can try out a LockableKnob in physical hardware easily.
+"""
+
+
+class KnobPlayground(EuroPiScript):
+    def __init__(self):
+        super().__init__()
+        self.next_k1 = False
+        self.next_k2 = False
+
+        self.kb1 = (
+            KnobBank.builder(k1)
+            .with_locked_knob("p1", initial_uint16_value=0, threshold_percentage=0.02)
+            .with_locked_knob("p2", initial_uint16_value=MAX_UINT16 / 5)
+            .with_locked_knob("p3", initial_uint16_value=MAX_UINT16 / 3)
+            .build()
+        )
+        self.kb2 = (
+            KnobBank.builder(k2)
+            .with_disabled_knob()
+            .with_locked_knob("p4", initial_percentage_value=0.5, threshold_from_choice_count=7)
+            .with_locked_knob("p5", initial_percentage_value=1, threshold_from_choice_count=3)
+            .build()
+        )
+
+        @b1.handler
+        def next_knob1():
+            self.next_k1 = True
+
+        @b2.handler
+        def next_knob2():
+            self.next_k2 = True
+
+    def main(self):
+        choice_p4 = ["a", "b", "c", "d", "e", "f", "g"]
+        choice_p5 = ["one", "two", "three"]
+
+        while True:
+            if self.next_k1:
+                self.kb1.next()
+                self.next_k1 = False
+            if self.next_k2:
+                self.kb2.next()
+                self.next_k2 = False
+
+            p1 = "X" if self.kb1.index == 0 else " "
+            p2 = "*" if self.kb1.index == 1 else " "
+            p3 = "*" if self.kb1.index == 2 else " "
+            pd = "*" if self.kb2.index == 0 else " "
+            p4 = "*" if self.kb2.index == 1 else " "
+            p5 = "*" if self.kb2.index == 2 else " "
+            text = (
+                f"{p1} {self.kb1.p1.range(1000):4}  {pd} {k2.range()}      \n"
+                + f"{p2} {int(round(self.kb1.p2.percent(), 2)*100):3}%  {p4} {self.kb2.p4.choice(choice_p4):5}\n"
+                + f"{p3} {self.kb1.p3.read_position():4}  {p5} {self.kb2.p5.choice(choice_p5):5}"
+            )
+            oled.centre_text(text)
+
+
+if __name__ == "__main__":
+    KnobPlayground().main()

--- a/software/contrib/menu.py
+++ b/software/contrib/menu.py
@@ -11,6 +11,7 @@ bootsplash()
 
 from bootloader import BootloaderMenu
 
+from contrib.knob_playground import KnobPlayground
 from contrib.bernoulli_gates import BernoulliGates
 from contrib.coin_toss import CoinToss
 from contrib.consequencer import Consequencer
@@ -37,6 +38,7 @@ from calibrate import Calibrate
 
 # Scripts that are included in the menu
 EUROPI_SCRIPT_CLASSES = [
+    KnobPlayground,
     BernoulliGates,
     CoinToss,
     Consequencer,

--- a/software/contrib/menu.py
+++ b/software/contrib/menu.py
@@ -5,13 +5,14 @@ from europi import bootsplash, usb_connected
 #  This is a fix for a USB connection issue documented in GitHub issue #179, and its removal condition is set out in GitHub issue #184
 if usb_connected.value() == 0:
     from time import sleep
+
     sleep(0.5)
 
 bootsplash()
 
 from bootloader import BootloaderMenu
 
-from contrib.knob_playground import KnobPlayground
+# from contrib.knob_playground import KnobPlayground
 from contrib.bernoulli_gates import BernoulliGates
 from contrib.coin_toss import CoinToss
 from contrib.consequencer import Consequencer
@@ -38,7 +39,7 @@ from calibrate import Calibrate
 
 # Scripts that are included in the menu
 EUROPI_SCRIPT_CLASSES = [
-    KnobPlayground,
+    # KnobPlayground,
     BernoulliGates,
     CoinToss,
     Consequencer,

--- a/software/firmware/experimental/knobs.py
+++ b/software/firmware/experimental/knobs.py
@@ -12,10 +12,22 @@ class LockableKnob(Knob):
 
     This class is useful for cases where you want to have a single physical knob control several
     parameters (see also the :class:`KnobBank` class). Or where the value of a parameter needs to be
-    disassociated from the postition of the knob, as in after loading saved state.
+    disassociated from the position of the knob, as in after loading saved state.
+
+    This class accepts two different parameters to specify it's initial value,
+    `initial_uint16_value` and `initial_percentage_value`. Only one initial value may be specified.
+    If both are specified, `initial_percentage_value` is ignored. The percentage value is more
+    useful if you would like to hardcode a starting value for a knob in the code in a readable way.
+    The uint16 value uses the knob's internal representation and is more appropriate for use when
+    loading a saved knob position. If your script would like to read the internal representation of
+    current position of a `LockableKnob`, first lock the knob, then read it's value.::
+
+        lockable_knob.lock()
+        internal_rep = lockable_knob.value
 
     :param knob: The knob to wrap.
-    :param initial_value: The value to lock the knob at. If a value is provided the new knob is locked, otherwise it is unlocked.
+    :param initial_uint16_value: The UINT16 (0-`europi.MAXINT16`) value to lock the knob at. If a value is provided the new knob is locked, otherwise it is unlocked.
+    :param initial_percentage_value: The percentage (as a decimal 0-1) value to lock the knob at. If a value is provided the new knob is locked, otherwise it is unlocked.
     :param threshold: a decimal between 0 and 1 representing how close the knob must be to the locked value in order to unlock. The percentage is in terms of the knobs full range. Defaults to 5% (0.05)
     """
 
@@ -23,14 +35,26 @@ class LockableKnob(Knob):
     STATE_UNLOCK_REQUESTED = 1
     STATE_LOCKED = 2
 
-    def __init__(self, knob: Knob, initial_value=None, threshold_percentage=DEFAULT_THRESHOLD):
+    def __init__(
+        self,
+        knob: Knob,
+        initial_percentage_value=None,
+        initial_uint16_value=None,
+        threshold_percentage=DEFAULT_THRESHOLD,
+    ):
         super().__init__(knob.pin_id)
         self.pin = knob.pin  # Share the ADC
-        self.value = initial_value if initial_value != None else 0
-        if initial_value == None:
-            self.state = LockableKnob.STATE_UNLOCKED
-        else:
+
+        if initial_uint16_value != None:
+            self.value = initial_uint16_value
             self.state = LockableKnob.STATE_LOCKED
+        elif initial_percentage_value != None:
+            self.value = (1 - initial_percentage_value) * MAX_UINT16
+            self.state = LockableKnob.STATE_LOCKED
+        else:
+            self.value = MAX_UINT16  # Min value
+            self.state = LockableKnob.STATE_UNLOCKED
+
         self.threshold = int(threshold_percentage * MAX_UINT16)
 
     def __repr__(self) -> str:
@@ -74,7 +98,7 @@ class DisabledKnob(LockableKnob):
     :param knob: The knob to wrap."""
 
     def __init__(self, knob: Knob):
-        super().__init__(knob, initial_value=MAX_UINT16)
+        super().__init__(knob, initial_uint16_value=MAX_UINT16)
 
     def request_unlock(self):
         """LockedKnob can never be unlocked"""
@@ -92,7 +116,7 @@ class KnobBank:
            KnobBank.builder(k1)
            .with_disabled_knob()
            .with_unlocked_knob("x", threshold=0.02)
-           .with_locked_knob("y", initial_value=1)
+           .with_locked_knob("y", initial_percentage_value=1)
            .build()
        )
 
@@ -117,9 +141,9 @@ class KnobBank:
 
                   self.kb1 = (
                       KnobBank.builder(k1)
-                      .with_locked_knob("p1", initial_value=1, threshold_percentage=0.02)
-                      .with_locked_knob("p2", initial_value=1)
-                      .with_locked_knob("p3", initial_value=1)
+                      .with_locked_knob("p1", initial_percentage_value=1, threshold_percentage=0.02)
+                      .with_locked_knob("p2", initial_percentage_value=1)
+                      .with_locked_knob("p3", initial_percentage_value=1)
                       .build()
                   )
 
@@ -182,7 +206,8 @@ class KnobBank:
         def with_locked_knob(
             self,
             name: str,
-            initial_value,
+            initial_percentage_value=None,
+            initial_uint16_value=None,
             threshold_percentage=None,
             threshold_from_choice_count=None,
         ) -> "Builder":
@@ -191,17 +216,23 @@ class KnobBank:
             `threshold_from_choice_count` is a convenience parameter to be used in the case where
             this knob will be used to select from a relatively few number of choices, via the
             :meth:`~europi.Knob.choice()` method. Pass the number of choices to this parameter and
-            an appropriate threshhold value will be calculated.
+            an appropriate threshold value will be calculated.
 
             :param name: the name of this virtual knob
             :param threshold_percentage: the threshold percentage for this knob as described by :class:`LockableKnob`
             :param threshold_from_choice_count: Provides the number of choices this knob will be used with in order to generate an appropriate threshold.
             """
-            if initial_value is None:
-                raise ValueError("initial_value cannot be None")
+            if initial_uint16_value is None and initial_percentage_value is None:
+                raise ValueError(
+                    "initial_percentage_value and initial_uint16_value cannot both be None"
+                )
 
             return self._with_knob(
-                name, initial_value, threshold_percentage, threshold_from_choice_count
+                name,
+                initial_percentage_value=initial_percentage_value,
+                initial_uint16_value=initial_uint16_value,
+                threshold_percentage=threshold_percentage,
+                threshold_from_choice_count=threshold_from_choice_count,
             )
 
         def with_unlocked_knob(
@@ -216,7 +247,7 @@ class KnobBank:
             `threshold_from_choice_count` is a convenience parameter to be used in the case where
             this knob will be used to select from a relatively few number of choices, via the
             :meth:`~europi.Knob.choice()` method. Pass the number of choices to this parameter and
-            an appropriate threshhold value will be calculated.
+            an appropriate threshold value will be calculated.
 
             :param name: the name of this virtual knob
             :param threshold_percentage: the threshold percentage for this knob as described by :class:`LockableKnob`
@@ -226,7 +257,7 @@ class KnobBank:
             if self.initial_index != None:
                 raise ValueError(f"Second unlocked knob specified: {name}")
 
-            self._with_knob(name, None, threshold_percentage, threshold_from_choice_count)
+            self._with_knob(name, None, None, threshold_percentage, threshold_from_choice_count)
 
             self.initial_index = len(self.knobs_by_name) - 1
 
@@ -235,7 +266,8 @@ class KnobBank:
         def _with_knob(
             self,
             name: str,
-            initial_value,
+            initial_percentage_value,
+            initial_uint16_value,
             threshold_percentage,
             threshold_from_choice_count=None,
         ):
@@ -254,7 +286,10 @@ class KnobBank:
                 threshold_percentage = DEFAULT_THRESHOLD
 
             self.knobs_by_name[name] = LockableKnob(
-                self.knob, initial_value=initial_value, threshold_percentage=threshold_percentage
+                self.knob,
+                initial_percentage_value=initial_percentage_value,
+                initial_uint16_value=initial_uint16_value,
+                threshold_percentage=threshold_percentage,
             )
 
             return self

--- a/software/tests/experimental/test_knobs.py
+++ b/software/tests/experimental/test_knobs.py
@@ -9,7 +9,7 @@ from mock_hardware import MockHardware
 
 
 @pytest.fixture
-def locked_knob(mockHardware: MockHardware):
+def lockable_knob(mockHardware: MockHardware):
     k = LockableKnob(k1)
 
     # start the knob in the middle
@@ -18,134 +18,134 @@ def locked_knob(mockHardware: MockHardware):
     return k
 
 
-def test_starting_state(locked_knob: LockableKnob):
-    assert locked_knob.state == LockableKnob.STATE_UNLOCKED
+def test_starting_state(lockable_knob: LockableKnob):
+    assert lockable_knob.state == LockableKnob.STATE_UNLOCKED
     assert LockableKnob(k1).state == LockableKnob.STATE_UNLOCKED
     assert LockableKnob(k1, initial_value=1).state == LockableKnob.STATE_LOCKED
 
 
-def test_unlocked_knob_changes_value(mockHardware: MockHardware, locked_knob: LockableKnob):
-    assert locked_knob.state == LockableKnob.STATE_UNLOCKED
-    assert round(locked_knob.percent(deadzone=0.01), 2) == 0.50
-    assert round(locked_knob.percent(deadzone=0.0), 2) == 0.50
+def test_unlocked_knob_changes_value(mockHardware: MockHardware, lockable_knob: LockableKnob):
+    assert lockable_knob.state == LockableKnob.STATE_UNLOCKED
+    assert round(lockable_knob.percent(deadzone=0.01), 2) == 0.50
+    assert round(lockable_knob.percent(deadzone=0.0), 2) == 0.50
 
-    mockHardware.set_ADC_u16_value(locked_knob, MAX_UINT16 / 3)
-    assert round(locked_knob.percent(deadzone=0.01), 2) == 0.67
-    assert round(locked_knob.percent(deadzone=0.0), 2) == 0.67
-
-
-def test_locked_knob_stays_constant(mockHardware: MockHardware, locked_knob: LockableKnob):
-    assert round(locked_knob.percent(deadzone=0.01), 2) == 0.50
-    assert round(locked_knob.percent(deadzone=0.0), 2) == 0.50
-
-    locked_knob.lock()
-    assert locked_knob.state == LockableKnob.STATE_LOCKED
-
-    mockHardware.set_ADC_u16_value(locked_knob, MAX_UINT16 / 3)
-    assert round(locked_knob.percent(deadzone=0.01), 2) == 0.50
-    assert round(locked_knob.percent(deadzone=0.0), 2) == 0.50
+    mockHardware.set_ADC_u16_value(lockable_knob, MAX_UINT16 / 3)
+    assert round(lockable_knob.percent(deadzone=0.01), 2) == 0.67
+    assert round(lockable_knob.percent(deadzone=0.0), 2) == 0.67
 
 
-def test_request_unlock_outside_threshold(mockHardware: MockHardware, locked_knob: LockableKnob):
-    assert round(locked_knob.percent(deadzone=0.01), 2) == 0.50
-    assert round(locked_knob.percent(deadzone=0.0), 2) == 0.50
+def test_locked_knob_stays_constant(mockHardware: MockHardware, lockable_knob: LockableKnob):
+    assert round(lockable_knob.percent(deadzone=0.01), 2) == 0.50
+    assert round(lockable_knob.percent(deadzone=0.0), 2) == 0.50
 
-    locked_knob.lock()
-    mockHardware.set_ADC_u16_value(locked_knob, 0)
-    locked_knob.request_unlock()
+    lockable_knob.lock()
+    assert lockable_knob.state == LockableKnob.STATE_LOCKED
 
-    assert round(locked_knob.percent(deadzone=0.01), 2) == 0.50
-    assert round(locked_knob.percent(deadzone=0.0), 2) == 0.50
-
-
-def test_request_unlock_within_threshold(mockHardware: MockHardware, locked_knob: LockableKnob):
-    assert round(locked_knob.percent(deadzone=0.01), 2) == 0.50
-    assert round(locked_knob.percent(deadzone=0.0), 2) == 0.50
-
-    locked_knob.lock()
-    mockHardware.set_ADC_u16_value(locked_knob, 0)
-    locked_knob.request_unlock()
-
-    assert round(locked_knob.percent(deadzone=0.01), 2) == 0.50
-    assert round(locked_knob.percent(deadzone=0.0), 2) == 0.50
-    assert locked_knob.state == LockableKnob.STATE_UNLOCK_REQUESTED
-
-    mockHardware.set_ADC_u16_value(locked_knob, (MAX_UINT16 / 2) + 10)
-    assert round(locked_knob.percent(deadzone=0.01), 2) == 0.50
-    assert round(locked_knob.percent(deadzone=0.0), 2) == 0.50
-    assert locked_knob.state == LockableKnob.STATE_UNLOCKED
+    mockHardware.set_ADC_u16_value(lockable_knob, MAX_UINT16 / 3)
+    assert round(lockable_knob.percent(deadzone=0.01), 2) == 0.50
+    assert round(lockable_knob.percent(deadzone=0.0), 2) == 0.50
 
 
-def test_state_changes(locked_knob: LockableKnob):
+def test_request_unlock_outside_threshold(mockHardware: MockHardware, lockable_knob: LockableKnob):
+    assert round(lockable_knob.percent(deadzone=0.01), 2) == 0.50
+    assert round(lockable_knob.percent(deadzone=0.0), 2) == 0.50
+
+    lockable_knob.lock()
+    mockHardware.set_ADC_u16_value(lockable_knob, 0)
+    lockable_knob.request_unlock()
+
+    assert round(lockable_knob.percent(deadzone=0.01), 2) == 0.50
+    assert round(lockable_knob.percent(deadzone=0.0), 2) == 0.50
+
+
+def test_request_unlock_within_threshold(mockHardware: MockHardware, lockable_knob: LockableKnob):
+    assert round(lockable_knob.percent(deadzone=0.01), 2) == 0.50
+    assert round(lockable_knob.percent(deadzone=0.0), 2) == 0.50
+
+    lockable_knob.lock()
+    mockHardware.set_ADC_u16_value(lockable_knob, 0)
+    lockable_knob.request_unlock()
+
+    assert round(lockable_knob.percent(deadzone=0.01), 2) == 0.50
+    assert round(lockable_knob.percent(deadzone=0.0), 2) == 0.50
+    assert lockable_knob.state == LockableKnob.STATE_UNLOCK_REQUESTED
+
+    mockHardware.set_ADC_u16_value(lockable_knob, (MAX_UINT16 / 2) + 10)
+    assert round(lockable_knob.percent(deadzone=0.01), 2) == 0.50
+    assert round(lockable_knob.percent(deadzone=0.0), 2) == 0.50
+    assert lockable_knob.state == LockableKnob.STATE_UNLOCKED
+
+
+def test_state_changes(lockable_knob: LockableKnob):
     # Unlocked
-    assert locked_knob.state == LockableKnob.STATE_UNLOCKED
+    assert lockable_knob.state == LockableKnob.STATE_UNLOCKED
 
-    locked_knob.request_unlock()
-    assert locked_knob.state == LockableKnob.STATE_UNLOCKED
+    lockable_knob.request_unlock()
+    assert lockable_knob.state == LockableKnob.STATE_UNLOCKED
 
-    locked_knob.lock()
-    assert locked_knob.state == LockableKnob.STATE_LOCKED
+    lockable_knob.lock()
+    assert lockable_knob.state == LockableKnob.STATE_LOCKED
 
     # locked
-    locked_knob.lock()
-    assert locked_knob.state == LockableKnob.STATE_LOCKED
+    lockable_knob.lock()
+    assert lockable_knob.state == LockableKnob.STATE_LOCKED
 
-    locked_knob.request_unlock()
-    assert locked_knob.state == LockableKnob.STATE_UNLOCK_REQUESTED
+    lockable_knob.request_unlock()
+    assert lockable_knob.state == LockableKnob.STATE_UNLOCK_REQUESTED
 
     # Unlock requested
 
-    locked_knob.request_unlock()
-    assert locked_knob.state == LockableKnob.STATE_UNLOCK_REQUESTED
+    lockable_knob.request_unlock()
+    assert lockable_knob.state == LockableKnob.STATE_UNLOCK_REQUESTED
 
-    locked_knob.lock()
-    assert locked_knob.state == LockableKnob.STATE_LOCKED
-
-
-def test_access_percent(mockHardware: MockHardware, locked_knob: LockableKnob):
-    assert round(locked_knob.percent(deadzone=0.01), 2) == 0.50
-    assert round(locked_knob.percent(deadzone=0.0), 2) == 0.50
-
-    mockHardware.set_ADC_u16_value(locked_knob, MAX_UINT16)
-    assert round(locked_knob.percent(deadzone=0.01), 2) == 0
-    assert round(locked_knob.percent(deadzone=0.0), 2) == 0
-
-    mockHardware.set_ADC_u16_value(locked_knob, 0)
-    assert round(locked_knob.percent(deadzone=0.01), 2) == 1
-    assert round(locked_knob.percent(deadzone=0.0), 2) == 1
+    lockable_knob.lock()
+    assert lockable_knob.state == LockableKnob.STATE_LOCKED
 
 
-def test_access_choice(mockHardware: MockHardware, locked_knob: LockableKnob):
-    assert locked_knob.choice([1, 2, 3]) == 2
+def test_access_percent(mockHardware: MockHardware, lockable_knob: LockableKnob):
+    assert round(lockable_knob.percent(deadzone=0.01), 2) == 0.50
+    assert round(lockable_knob.percent(deadzone=0.0), 2) == 0.50
 
-    mockHardware.set_ADC_u16_value(locked_knob, MAX_UINT16)
-    assert locked_knob.choice([1, 2, 3]) == 1
+    mockHardware.set_ADC_u16_value(lockable_knob, MAX_UINT16)
+    assert round(lockable_knob.percent(deadzone=0.01), 2) == 0
+    assert round(lockable_knob.percent(deadzone=0.0), 2) == 0
 
-    mockHardware.set_ADC_u16_value(locked_knob, 0)
-    assert locked_knob.choice([1, 2, 3]) == 3
-
-
-def test_access_range(mockHardware: MockHardware, locked_knob: LockableKnob):
-    assert locked_knob.range() == 49
-
-    mockHardware.set_ADC_u16_value(locked_knob, MAX_UINT16)
-    assert locked_knob.range() == 0
-
-    mockHardware.set_ADC_u16_value(locked_knob, 0)
-    assert locked_knob.range() == 99
+    mockHardware.set_ADC_u16_value(lockable_knob, 0)
+    assert round(lockable_knob.percent(deadzone=0.01), 2) == 1
+    assert round(lockable_knob.percent(deadzone=0.0), 2) == 1
 
 
-def test_access_read_position(mockHardware: MockHardware, locked_knob: LockableKnob):
-    assert locked_knob.read_position(deadzone=0.01) == 49
-    assert locked_knob.read_position(deadzone=0.0) == 49
+def test_access_choice(mockHardware: MockHardware, lockable_knob: LockableKnob):
+    assert lockable_knob.choice([1, 2, 3]) == 2
 
-    mockHardware.set_ADC_u16_value(locked_knob, MAX_UINT16)
-    assert locked_knob.read_position(deadzone=0.01) == 0
-    assert locked_knob.read_position(deadzone=0.0) == 0
+    mockHardware.set_ADC_u16_value(lockable_knob, MAX_UINT16)
+    assert lockable_knob.choice([1, 2, 3]) == 1
 
-    mockHardware.set_ADC_u16_value(locked_knob, 0)
-    assert locked_knob.read_position(deadzone=0.01) == 99
-    assert locked_knob.read_position(deadzone=0.0) == 99
+    mockHardware.set_ADC_u16_value(lockable_knob, 0)
+    assert lockable_knob.choice([1, 2, 3]) == 3
+
+
+def test_access_range(mockHardware: MockHardware, lockable_knob: LockableKnob):
+    assert lockable_knob.range() == 49
+
+    mockHardware.set_ADC_u16_value(lockable_knob, MAX_UINT16)
+    assert lockable_knob.range() == 0
+
+    mockHardware.set_ADC_u16_value(lockable_knob, 0)
+    assert lockable_knob.range() == 99
+
+
+def test_access_read_position(mockHardware: MockHardware, lockable_knob: LockableKnob):
+    assert lockable_knob.read_position(deadzone=0.01) == 49
+    assert lockable_knob.read_position(deadzone=0.0) == 49
+
+    mockHardware.set_ADC_u16_value(lockable_knob, MAX_UINT16)
+    assert lockable_knob.read_position(deadzone=0.01) == 0
+    assert lockable_knob.read_position(deadzone=0.0) == 0
+
+    mockHardware.set_ADC_u16_value(lockable_knob, 0)
+    assert lockable_knob.read_position(deadzone=0.01) == 99
+    assert lockable_knob.read_position(deadzone=0.0) == 99
 
 
 # Disabled Knob Tests


### PR DESCRIPTION
The range for setting the initial value of a LockableKnob was unclear and hard to use. This PR attempts to alleviate both of these issues. In addition it updates the Turing machine and knob playground to support these changes.

Details:

The internal representation of a LockableKnob's value uses the full AnalogueReader range of 0-MAX_UINT16. This was unclear in the LockableKnob's documentation and api. To fix this we've updated the API to make it clear how the value is being used by giving two possible ways. First is the original full int range, second is a percentage. The int range will be useful when saving and loading a knob value. The percentage will be more useful when hard coding a knobs initial state.

I've again included the 'KnobPlayground' script to aid in PR review and testing. It should be removed before merge.