### PR TITLE
MicroPython 1.19.1 doc

### DIFF
--- a/software/programming_instructions.md
+++ b/software/programming_instructions.md
@@ -5,7 +5,7 @@ This document will take you through the steps to get your module ready to progra
 ## NOTE:
 If you already have any version of the firmware or any other code loaded onto your EuroPi and want to ensure a clean installation, or you just want to make sure you have all the most recent scripts available, first follow these instructions:
 
-1. Download [flash_nuke.uf2](https://learn.adafruit.com/getting-started-with-raspberry-pi-pico-circuitpython/circuitpython) from Adafruit.
+1. Download [flash_nuke.uf2](https://learn.adafruit.com/getting-started-with-raspberry-pi-pico-circuitpython/circuitpython#flash-resetting-uf2-3083182) from Adafruit.
   
 2. Holding down the white button labeled 'BOOTSEL' on the Raspberry Pi Pico, connect the module to your computer via the USB cable.  
 
@@ -27,7 +27,7 @@ To start with, you'll need to download the [Thonny IDE](https://thonny.org/). Th
 ![Thonny](https://i.imgur.com/UX4uQDO.jpg)
 
 ### Installing the firmware
-1. Download the [most recent firmware](https://micropython.org/download/rp2-pico/) from the MicroPython website.
+1. Download the [most recent firmware](https://micropython.org/download/rp2-pico/) from the MicroPython website. The latest supported version is `19.1.1`.
 2. Holding down the white button labeled 'BOOTSEL' on the Raspberry Pi Pico, connect the module to your computer via the USB cable.
 
     ![_DSC2400](https://user-images.githubusercontent.com/79809962/148647201-52b0d279-fc1e-4615-9e65-e51543605e15.jpg)


### PR DESCRIPTION
This PR is meant to close up some documentation on MicroPython 1.19 and close issue #156.

It adds two doc changes to programming_instructions.md. The first links more closely to the flash_nuke download file, making it easier to find for new users. The second change explicitly documents the current supported version of micropython at 1.19.1.