### PR TITLE
fix missing version file

### DIFF
--- a/software/firmware/version.py
+++ b/software/firmware/version.py
@@ -1,2 +1,2 @@
 # EuroPi firmware and contrib package version
-__version__ = "0.7.0"
+__version__ = "0.7.1"

--- a/software/setup.py
+++ b/software/setup.py
@@ -13,5 +13,6 @@ setup(
     author_email="contact@allensynthesis.co.uk",
     license="Apache 2.0",
     packages=["contrib"],
+    py_modules=["firmware.version"],
     namespace_packages=["contrib"],
 )


### PR DESCRIPTION
This intends to fix #203 by copying the version.py file from the firmware directory into the distribution.

This PR also apps the version number to prep for this bug fix release.