### PR TITLE
fixed right possibility to 0-100 range instead of 0-99

### DIFF
--- a/software/contrib/bernoulli_gates.py
+++ b/software/contrib/bernoulli_gates.py
@@ -50,10 +50,10 @@ class SingleBernoulliGate():
 
     def get_prob(self):
         if self.control_port:
-            self.right_possibility = self.control_knob.percent() + self.control_port.read_voltage()/12
+            self.right_possibility = (self.control_knob.read_position(100)/100) + self.control_port.read_voltage()/12
             self.left_possibility = 1 - self.right_possibility
         else:
-            self.right_possibility = self.control_knob.percent()
+            self.right_possibility = (self.control_knob.read_position(100)/100)
             self.left_possibility = 1 - self.right_possibility
 
     def probability_text_visualization(self):


### PR DESCRIPTION
percent() only returns values from 0-0.99 so never actually gets to 100.
In this script, it meant that the right possibility could never get to 100%.
This fix ensures that reading a knob value always returns a 0-100 value.