### PR TITLE
Minor improvements to the DigitalReader class

### DIFF
--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -298,16 +298,17 @@ class DigitalReader:
                 return
             self.last_rising_ms = time.ticks_ms()
             return self._rising_handler()
-        elif self.value() == LOW:
+        else:
             if time.ticks_diff(time.ticks_ms(), self.last_falling_ms) < self.debounce_delay:
                 return
             self.last_falling_ms = time.ticks_ms()
 
-            # Check if 'other' pin is set and if 'other' pins is high and if this pin has been high for long enough.
+            # Check if 'other' pin was set not long ago and still is set and this pin has been high for long enough.
             if (
                 self._other
                 and self._other.value()
-                and time.ticks_diff(self.last_falling_ms, self.last_rising_ms) > 500
+                and time.ticks_diff(self.last_falling_ms, self.last_rising_ms) > 200
+                and time.ticks_diff(self.last_falling_ms, self._other.last_rising_ms) < 1000
             ):
                 return self._both_handler()
             return self._falling_handler()

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -303,7 +303,7 @@ class DigitalReader:
                 return
             self.last_falling_ms = time.ticks_ms()
 
-            # Check if 'other' pin was set not long ago and still is set and this pin has been high for long enough.
+            # When this button is released after a short press, check if 'other' button is set and currently pressed not long ago.
             if (
                 self._other
                 and self._other.value()


### PR DESCRIPTION
I made some improvements to the DigitalReader class.
Before it was reading the hardware pin twice in a row on a falling edge signal and could in theory (very unlikely, but still) miss falling edge signals (if the pin would change between these reads).
Also I found it some times unintuitive or failed to trigger the 'both buttons' action.
I propose to reduce the time needed to hold both buttons and in turn add a check how long the 'other' button has been down to avoid accidental triggering (I am open to adjusting the timing values).
I am still not happy with the DigitalReader class or more precisely the _bounce_wrapper.
De-bouncing is not optimal yet, as it will prevent double triggers of the same event (a bounce after a rising wont trigger an other rising) but not of the counter event (a bounce after a rising can trigger a early falling event).
But for now I have no elegant way to to fix that without the risk of dropping legit events.
So this PR only fixes the other things for now.