### PR TITLE
Add link to contrib/README.md and youtube tutorials by nik

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You can find more about this (including a project diary) and other projects of m
 **Software**: Before using any of the software, follow the instructions in [programming_instructions.md](software/programming_instructions.md) to set up and calibrate your module.
 
 A list of user contributed scripts and their usage can be found in [contrib/README.md](software/contrib/README.md).
-There is also a [youtube playlist](https://www.youtube.com/playlist?list=PLbingtr9KGPUdIODLWgzgAdIyN497YyEs) showcasing europi and some of the different scripts available.
+There is also a [youtube playlist](https://www.youtube.com/playlist?list=PLbingtr9KGPUdIODLWgzgAdIyN497YyEs) showcasing EuroPi and some of the different scripts available.
 
 The EuroPi firmware API documentation can be found at https://allen-synthesis.github.io/EuroPi/. This documentation will explain all of the available features of the EuroPi firmware API. It also includes some examples of how to use various features of the firmware as well as [interesting_things.md](software/interesting_things.md).
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ You can find more about this (including a project diary) and other projects of m
 
 **Software**: Before using any of the software, follow the instructions in [programming_instructions.md](software/programming_instructions.md) to set up and calibrate your module.
 
+A list of user contributed scripts and their usage can be found in [contrib/README.md](software/contrib/README.md).
+There is also a [youtube playlist](https://www.youtube.com/playlist?list=PLbingtr9KGPUdIODLWgzgAdIyN497YyEs) showcasing europi and some of the different scripts available.
+
 The EuroPi firmware API documentation can be found at https://allen-synthesis.github.io/EuroPi/. This documentation will explain all of the available features of the EuroPi firmware API. It also includes some examples of how to use various features of the firmware as well as [interesting_things.md](software/interesting_things.md).
 
 If you would like to extend any of the features of the EuroPi software, you can view the firmware source code at [europi.py](software/firmware/europi.py).

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You can find more about this (including a project diary) and other projects of m
 **Software**: Before using any of the software, follow the instructions in [programming_instructions.md](software/programming_instructions.md) to set up and calibrate your module.
 
 A list of user contributed scripts and their usage can be found in [contrib/README.md](software/contrib/README.md).
-There is also a [youtube playlist](https://www.youtube.com/playlist?list=PLbingtr9KGPUdIODLWgzgAdIyN497YyEs) showcasing EuroPi and some of the different scripts available.
+There is also a [YouTube playlist](https://www.youtube.com/playlist?list=PLbingtr9KGPUdIODLWgzgAdIyN497YyEs) showcasing EuroPi and some of the different scripts available.
 
 The EuroPi firmware API documentation can be found at https://allen-synthesis.github.io/EuroPi/. This documentation will explain all of the available features of the EuroPi firmware API. It also includes some examples of how to use various features of the firmware as well as [interesting_things.md](software/interesting_things.md).
 


### PR DESCRIPTION
This PR was suggested by d’Composer and mjaskula on discord.
It adds a link to the excellent youtube tutorials by nik and also to the contrib/README.md file on the landing page.
I guess this would make it easier for people to get started and get an impression for the capabilities of europi.
Since the link is to the playlist, there is no need to update it if new videos are added there.
Happy to accept any feedback.