### PR TITLE
Add dead zone to knobs

### DIFF
--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -258,7 +258,7 @@ class Knob(AnalogueReader):
     """
 
     def __init__(self, pin):
-        super().__init__(pin, deadzone=0.0)
+        super().__init__(pin, deadzone=0.01)
 
     def percent(self, samples=None):
         """Return the knob's position as relative percentage."""

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -265,7 +265,7 @@ class Knob(AnalogueReader):
     """
 
     def __init__(self, pin, deadzone=0.01):
-        super().__init__(pin, deadzone)
+        super().__init__(pin, deadzone=deadzone)
 
     def percent(self, samples=None, deadzone=None):
         """Return the knob's position as relative percentage."""

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -128,10 +128,11 @@ class AnalogueReader:
     not need to be used by user scripts.
     """
 
-    def __init__(self, pin, samples=DEFAULT_SAMPLES):
+    def __init__(self, pin, samples=DEFAULT_SAMPLES, deadzone=0.0):
         self.pin_id = pin
         self.pin = ADC(Pin(pin))
         self.set_samples(samples)
+        self.deadzone=deadzone
 
     def _sample_adc(self, samples=None):
         # Over-samples the ADC and returns the average.
@@ -148,7 +149,9 @@ class AnalogueReader:
 
     def percent(self, samples=None):
         """Return the percentage of the component's current relative range."""
-        return self._sample_adc(samples) / MAX_UINT16
+        value = self._sample_adc(samples) / MAX_UINT16
+        value = value*(1.0+2.0*deadzone)-deadzone
+        return max(0.0,min(1.0,value))
 
     def range(self, steps=100, samples=None):
         """Return a value (upper bound excluded) chosen by the current voltage value."""

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -148,7 +148,7 @@ class AnalogueReader:
         self._samples = samples
 
     def set_deadzone(self, deadzone):
-        """Override the default number of sample reads with the given value."""
+        """Override the default deadzone with the given value."""
         if not isinstance(deadzone, float):
             raise ValueError(f"set_deadzone expects an float value, got: {deadzone}")
         self._deadzone = deadzone
@@ -247,6 +247,11 @@ class Knob(AnalogueReader):
     The default ``samples`` value can also be set using the ``set_samples()``
     method, which will then be used on all analogue read calls for that
     component.
+    
+    An optional ``deadzone`` parameter can be used to place deadzones at both
+    positions (all the way left and right) of the knob to make sure the full range
+    is available on all builds. The default value is 0.01 (resulting in 1% of the 
+    travel used as deadzone on each side). There is usually no need to change this.
 
     Additionally, the ``choice()`` method can be used to select a value from a
     list of values based on the knob's position::

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -128,11 +128,11 @@ class AnalogueReader:
     not need to be used by user scripts.
     """
 
-    def __init__(self, pin, samples=DEFAULT_SAMPLES,deadzone=0.0):
+    def __init__(self, pin, samples=DEFAULT_SAMPLES, deadzone=0.0):
         self.pin_id = pin
         self.pin = ADC(Pin(pin))
         self.set_samples(samples)
-        self.deadzone=deadzone
+        self.deadzone = deadzone
 
     def _sample_adc(self, samples=None):
         # Over-samples the ADC and returns the average.
@@ -150,8 +150,8 @@ class AnalogueReader:
     def percent(self, samples=None):
         """Return the percentage of the component's current relative range."""
         value = self._sample_adc(samples) / MAX_UINT16
-        value = value*(1.0+2.0*self.deadzone)-self.deadzone
-        return max(0.0,min(1.0,value))
+        value = value * (1.0 + 2.0 * self.deadzone) - self.deadzone
+        return max(0.0, min(1.0, value))
 
     def range(self, steps=100, samples=None):
         """Return a value (upper bound excluded) chosen by the current voltage value."""
@@ -190,7 +190,7 @@ class AnalogueInput(AnalogueReader):
     """
 
     def __init__(self, pin, min_voltage=MIN_INPUT_VOLTAGE, max_voltage=MAX_INPUT_VOLTAGE):
-        super().__init__(pin,deadzone=0.0)
+        super().__init__(pin)
         self.MIN_VOLTAGE = min_voltage
         self.MAX_VOLTAGE = max_voltage
         self._gradients = []
@@ -258,12 +258,12 @@ class Knob(AnalogueReader):
     """
 
     def __init__(self, pin):
-        super().__init__(pin)
+        super().__init__(pin, deadzone=0.0)
 
     def percent(self, samples=None):
         """Return the knob's position as relative percentage."""
         # Reverse range to provide increasing range.
-        return 1.0-super().percent(samples)
+        return 1.0 - super().percent(samples)
 
     def read_position(self, steps=100, samples=None):
         """Returns the position as a value between zero and provided integer."""

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -146,7 +146,7 @@ class AnalogueReader:
         if not isinstance(samples, int):
             raise ValueError(f"set_samples expects an int value, got: {samples}")
         self._samples = samples
-       
+
     def set_deadzone(self, deadzone):
         """Override the default number of sample reads with the given value."""
         if not isinstance(deadzone, float):
@@ -155,7 +155,7 @@ class AnalogueReader:
 
     def percent(self, samples=None, deadzone=None):
         """Return the percentage of the component's current relative range."""
-        dz = (deadzone or self._deadzone)
+        dz = deadzone or self._deadzone
         value = self._sample_adc(samples) / MAX_UINT16
         value = value * (1.0 + 2.0 * dz) - dz
         return clamp(value, 0.0, 1.0)
@@ -164,7 +164,7 @@ class AnalogueReader:
         """Return a value (upper bound excluded) chosen by the current voltage value."""
         if not isinstance(steps, int):
             raise ValueError(f"range expects an int value, got: {steps}")
-        percent = self.percent(samples,deadzone)
+        percent = self.percent(samples, deadzone)
         if int(percent) == 1:
             return steps - 1
         return int(percent * steps)
@@ -173,7 +173,7 @@ class AnalogueReader:
         """Return a value from a list chosen by the current voltage value."""
         if not isinstance(values, list):
             raise ValueError(f"choice expects a list, got: {values}")
-        percent = self.percent(samples,deadzone)
+        percent = self.percent(samples, deadzone)
         if percent == 1.0:
             return values[-1]
         return values[int(percent * len(values))]
@@ -267,7 +267,7 @@ class Knob(AnalogueReader):
     def __init__(self, pin, deadzone=0.01):
         super().__init__(pin, deadzone)
 
-    def percent(self, samples=None,deadzone=None):
+    def percent(self, samples=None, deadzone=None):
         """Return the knob's position as relative percentage."""
         # Reverse range to provide increasing range.
         return 1.0 - super().percent(samples, deadzone)

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -279,9 +279,9 @@ class Knob(AnalogueReader):
         # Reverse range to provide increasing range.
         return 1.0 - super().percent(samples, deadzone)
 
-    def read_position(self, steps=100, samples=None):
+    def read_position(self, steps=100, samples=None, deadzone=None):
         """Returns the position as a value between zero and provided integer."""
-        return self.range(steps, samples)
+        return self.range(steps, samples, deadzone)
 
 
 class DigitalReader:

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -155,7 +155,9 @@ class AnalogueReader:
 
     def percent(self, samples=None, deadzone=None):
         """Return the percentage of the component's current relative range."""
-        dz = deadzone or self._deadzone
+        dz = self._deadzone
+        if deadzone is not None:
+            dz = deadzone
         value = self._sample_adc(samples) / MAX_UINT16
         value = value * (1.0 + 2.0 * dz) - dz
         return clamp(value, 0.0, 1.0)

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -150,7 +150,7 @@ class AnalogueReader:
     def percent(self, samples=None):
         """Return the percentage of the component's current relative range."""
         value = self._sample_adc(samples) / MAX_UINT16
-        value = value*(1.0+2.0*deadzone)-deadzone
+        value = value*(1.0+2.0*self.deadzone)-self.deadzone
         return max(0.0,min(1.0,value))
 
     def range(self, steps=100, samples=None):
@@ -258,7 +258,7 @@ class Knob(AnalogueReader):
     """
 
     def __init__(self, pin):
-        super().__init__(pin)
+        super().__init__(pin,deadzone=0.01)
 
     def percent(self, samples=None):
         """Return the knob's position as relative percentage."""

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -247,10 +247,10 @@ class Knob(AnalogueReader):
     The default ``samples`` value can also be set using the ``set_samples()``
     method, which will then be used on all analogue read calls for that
     component.
-    
+
     An optional ``deadzone`` parameter can be used to place deadzones at both
     positions (all the way left and right) of the knob to make sure the full range
-    is available on all builds. The default value is 0.01 (resulting in 1% of the 
+    is available on all builds. The default value is 0.01 (resulting in 1% of the
     travel used as deadzone on each side). There is usually no need to change this.
 
     Additionally, the ``choice()`` method can be used to select a value from a

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -147,7 +147,7 @@ class AnalogueReader:
             raise ValueError(f"set_samples expects an int value, got: {samples}")
         self._samples = samples
        
-     def set_deadzone(self, deadzone):
+    def set_deadzone(self, deadzone):
         """Override the default number of sample reads with the given value."""
         if not isinstance(deadzone, float):
             raise ValueError(f"set_deadzone expects an float value, got: {deadzone}")

--- a/software/tests/experimental/test_knobs.py
+++ b/software/tests/experimental/test_knobs.py
@@ -320,7 +320,7 @@ def test_access_by_index(mockHardware: MockHardware, knob_bank: KnobBank):
     assert round(knob_bank.knobs[2].percent(deadzone=0.01), 2) == 0.67
     assert round(knob_bank.knobs[2].percent(deadzone=0.0), 2) == 0.67
     assert round(knob_bank.current.percent(deadzone=0.01), 2) == 0.81
-    assert round(knob_bank.current.percent(deadzone=0.01), 2) == 0.80
+    assert round(knob_bank.current.percent(deadzone=0.0), 2) == 0.80
 
 
 # KnobBank.Builder tests

--- a/software/tests/experimental/test_knobs.py
+++ b/software/tests/experimental/test_knobs.py
@@ -136,13 +136,16 @@ def test_access_range(mockHardware: MockHardware, locked_knob: LockableKnob):
 
 
 def test_access_read_position(mockHardware: MockHardware, locked_knob: LockableKnob):
-    assert locked_knob.read_position() == 49
+    assert locked_knob.read_position(deadzone=0.01) == 49
+    assert locked_knob.read_position(deadzone=0.0) == 49
 
     mockHardware.set_ADC_u16_value(locked_knob, MAX_UINT16)
-    assert locked_knob.read_position() == 0
+    assert locked_knob.read_position(deadzone=0.01) == 0
+    assert locked_knob.read_position(deadzone=0.0) == 0
 
     mockHardware.set_ADC_u16_value(locked_knob, 0)
-    assert locked_knob.read_position() == 99
+    assert locked_knob.read_position(deadzone=0.01) == 99
+    assert locked_knob.read_position(deadzone=0.0) == 99
 
 
 # Disabled Knob Tests

--- a/software/tests/experimental/test_knobs.py
+++ b/software/tests/experimental/test_knobs.py
@@ -26,44 +26,53 @@ def test_starting_state(locked_knob: LockableKnob):
 
 def test_unlocked_knob_changes_value(mockHardware: MockHardware, locked_knob: LockableKnob):
     assert locked_knob.state == LockableKnob.STATE_UNLOCKED
-    assert round(locked_knob.percent(), 2) == 0.50
+    assert round(locked_knob.percent(deadzone=0.01), 2) == 0.50
+    assert round(locked_knob.percent(deadzone=0.0), 2) == 0.50
 
     mockHardware.set_ADC_u16_value(locked_knob, MAX_UINT16 / 3)
-    assert round(locked_knob.percent(), 2) == 0.67
+    assert round(locked_knob.percent(deadzone=0.01), 2) == 0.67
+    assert round(locked_knob.percent(deadzone=0.0), 2) == 0.67
 
 
 def test_locked_knob_stays_constant(mockHardware: MockHardware, locked_knob: LockableKnob):
-    assert round(locked_knob.percent(), 2) == 0.50
+    assert round(locked_knob.percent(deadzone=0.01), 2) == 0.50
+    assert round(locked_knob.percent(deadzone=0.0), 2) == 0.50
 
     locked_knob.lock()
     assert locked_knob.state == LockableKnob.STATE_LOCKED
 
     mockHardware.set_ADC_u16_value(locked_knob, MAX_UINT16 / 3)
-    assert round(locked_knob.percent(), 2) == 0.50
+    assert round(locked_knob.percent(deadzone=0.01), 2) == 0.50
+    assert round(locked_knob.percent(deadzone=0.0), 2) == 0.50
 
 
 def test_request_unlock_outside_threshold(mockHardware: MockHardware, locked_knob: LockableKnob):
-    assert round(locked_knob.percent(), 2) == 0.50
+    assert round(locked_knob.percent(deadzone=0.01), 2) == 0.50
+    assert round(locked_knob.percent(deadzone=0.0), 2) == 0.50
 
     locked_knob.lock()
     mockHardware.set_ADC_u16_value(locked_knob, 0)
     locked_knob.request_unlock()
 
-    assert round(locked_knob.percent(), 2) == 0.50
+    assert round(locked_knob.percent(deadzone=0.01), 2) == 0.50
+    assert round(locked_knob.percent(deadzone=0.0), 2) == 0.50
 
 
 def test_request_unlock_within_threshold(mockHardware: MockHardware, locked_knob: LockableKnob):
-    assert round(locked_knob.percent(), 2) == 0.50
+    assert round(locked_knob.percent(deadzone=0.01), 2) == 0.50
+    assert round(locked_knob.percent(deadzone=0.0), 2) == 0.50
 
     locked_knob.lock()
     mockHardware.set_ADC_u16_value(locked_knob, 0)
     locked_knob.request_unlock()
 
-    assert round(locked_knob.percent(), 2) == 0.50
+    assert round(locked_knob.percent(deadzone=0.01), 2) == 0.50
+    assert round(locked_knob.percent(deadzone=0.0), 2) == 0.50
     assert locked_knob.state == LockableKnob.STATE_UNLOCK_REQUESTED
 
     mockHardware.set_ADC_u16_value(locked_knob, (MAX_UINT16 / 2) + 10)
-    assert round(locked_knob.percent(), 2) == 0.50
+    assert round(locked_knob.percent(deadzone=0.01), 2) == 0.50
+    assert round(locked_knob.percent(deadzone=0.0), 2) == 0.50
     assert locked_knob.state == LockableKnob.STATE_UNLOCKED
 
 
@@ -94,13 +103,16 @@ def test_state_changes(locked_knob: LockableKnob):
 
 
 def test_access_percent(mockHardware: MockHardware, locked_knob: LockableKnob):
-    assert round(locked_knob.percent(), 2) == 0.50
+    assert round(locked_knob.percent(deadzone=0.01), 2) == 0.50
+    assert round(locked_knob.percent(deadzone=0.0), 2) == 0.50
 
     mockHardware.set_ADC_u16_value(locked_knob, MAX_UINT16)
-    assert round(locked_knob.percent(), 2) == 0
+    assert round(locked_knob.percent(deadzone=0.01), 2) == 0
+    assert round(locked_knob.percent(deadzone=0.0), 2) == 0
 
     mockHardware.set_ADC_u16_value(locked_knob, 0)
-    assert round(locked_knob.percent(), 2) == 1
+    assert round(locked_knob.percent(deadzone=0.01), 2) == 1
+    assert round(locked_knob.percent(deadzone=0.0), 2) == 1
 
 
 def test_access_choice(mockHardware: MockHardware, locked_knob: LockableKnob):
@@ -167,100 +179,148 @@ def test_next_mode(knob_bank: KnobBank):
 
 def test_access_by_name(mockHardware: MockHardware, knob_bank: KnobBank):
     # knob starts in the middle, knob 1
-    assert round(knob_bank.param1.percent(), 2) == 0.50
-    assert round(knob_bank.param2.percent(), 2) == 0
-    assert round(knob_bank.current.percent(), 2) == 0.50
+    assert round(knob_bank.param1.percent(deadzone=0.01), 2) == 0.50
+    assert round(knob_bank.param1.percent(deadzone=0.0), 2) == 0.50
+    assert round(knob_bank.param2.percent(deadzone=0.01), 2) == 0
+    assert round(knob_bank.param2.percent(deadzone=0.0), 2) == 0
+    assert round(knob_bank.current.percent(deadzone=0.01), 2) == 0.50
+    assert round(knob_bank.current.percent(deadzone=0.0), 2) == 0.50
 
     # change to knob 2, then move the knob
     knob_bank.next()
     mockHardware.set_ADC_u16_value(knob_bank.current, MAX_UINT16 / 3)
 
-    assert round(knob_bank.param1.percent(), 2) == 0.50
-    assert round(knob_bank.param2.percent(), 2) == 0
-    assert round(knob_bank.current.percent(), 2) == 0
+    assert round(knob_bank.param1.percent(deadzone=0.01), 2) == 0.50
+    assert round(knob_bank.param1.percent(deadzone=0.0), 2) == 0.50
+    assert round(knob_bank.param2.percent(deadzone=0.01), 2) == 0
+    assert round(knob_bank.param2.percent(deadzone=0.0), 2) == 0
+    assert round(knob_bank.current.percent(deadzone=0.01), 2) == 0
+    assert round(knob_bank.current.percent(deadzone=0.0), 2) == 0
 
     mockHardware.set_ADC_u16_value(knob_bank.current, MAX_UINT16)
 
-    assert round(knob_bank.param1.percent(), 2) == 0.50
-    assert round(knob_bank.param2.percent(), 2) == 0
-    assert round(knob_bank.current.percent(), 2) == 0
+    assert round(knob_bank.param1.percent(deadzone=0.01), 2) == 0.50
+    assert round(knob_bank.param1.percent(deadzone=0.0), 2) == 0.50
+    assert round(knob_bank.param2.percent(deadzone=0.01), 2) == 0
+    assert round(knob_bank.param2.percent(deadzone=0.0), 2) == 0
+    assert round(knob_bank.current.percent(deadzone=0.01), 2) == 0
+    assert round(knob_bank.current.percent(deadzone=0.0), 2) == 0
 
     mockHardware.set_ADC_u16_value(knob_bank.current, MAX_UINT16 / 3)
 
-    assert round(knob_bank.param1.percent(), 2) == 0.50
-    assert round(knob_bank.param2.percent(), 2) == 0.67
-    assert round(knob_bank.current.percent(), 2) == 0.67
+    assert round(knob_bank.param1.percent(deadzone=0.01), 2) == 0.50
+    assert round(knob_bank.param1.percent(deadzone=0.0), 2) == 0.50
+    assert round(knob_bank.param2.percent(deadzone=0.01), 2) == 0.67
+    assert round(knob_bank.param2.percent(deadzone=0.0), 2) == 0.67
+    assert round(knob_bank.current.percent(deadzone=0.01), 2) == 0.67
+    assert round(knob_bank.current.percent(deadzone=0.0), 2) == 0.67
 
 
 def test_access_by_index(mockHardware: MockHardware, knob_bank: KnobBank):
     # knob starts in the middle, knob 1
-    assert round(knob_bank.knobs[0].percent(), 2) == 0
-    assert round(knob_bank.knobs[1].percent(), 2) == 0.50
-    assert round(knob_bank.knobs[2].percent(), 2) == 0
-    assert round(knob_bank.current.percent(), 2) == 0.50
+    assert round(knob_bank.knobs[0].percent(deadzone=0.01), 2) == 0
+    assert round(knob_bank.knobs[0].percent(deadzone=0.0), 2) == 0
+    assert round(knob_bank.knobs[1].percent(deadzone=0.01), 2) == 0.50
+    assert round(knob_bank.knobs[1].percent(deadzone=0.0), 2) == 0.50
+    assert round(knob_bank.knobs[2].percent(deadzone=0.01), 2) == 0
+    assert round(knob_bank.knobs[2].percent(deadzone=0.0), 2) == 0
+    assert round(knob_bank.current.percent(deadzone=0.01), 2) == 0.50
+    assert round(knob_bank.current.percent(deadzone=0.0), 2) == 0.50
 
     # change to knob 2, then move the knob
     knob_bank.next()
     mockHardware.set_ADC_u16_value(knob_bank.current, MAX_UINT16 / 3)
 
-    assert round(knob_bank.knobs[0].percent(), 2) == 0
-    assert round(knob_bank.knobs[1].percent(), 2) == 0.50
-    assert round(knob_bank.knobs[2].percent(), 2) == 0
-    assert round(knob_bank.current.percent(), 2) == 0
+    assert round(knob_bank.knobs[0].percent(deadzone=0.01), 2) == 0
+    assert round(knob_bank.knobs[0].percent(deadzone=0.0), 2) == 0
+    assert round(knob_bank.knobs[1].percent(deadzone=0.01), 2) == 0.50
+    assert round(knob_bank.knobs[1].percent(deadzone=0.0), 2) == 0.50
+    assert round(knob_bank.knobs[2].percent(deadzone=0.01), 2) == 0
+    assert round(knob_bank.knobs[2].percent(deadzone=0.0), 2) == 0
+    assert round(knob_bank.current.percent(deadzone=0.01), 2) == 0
+    assert round(knob_bank.current.percent(deadzone=0.0), 2) == 0
 
     mockHardware.set_ADC_u16_value(knob_bank.current, MAX_UINT16)
 
-    assert round(knob_bank.knobs[0].percent(), 2) == 0
-    assert round(knob_bank.knobs[1].percent(), 2) == 0.50
-    assert round(knob_bank.knobs[2].percent(), 2) == 0
-    assert round(knob_bank.current.percent(), 2) == 0
+    assert round(knob_bank.knobs[0].percent(deadzone=0.01), 2) == 0
+    assert round(knob_bank.knobs[0].percent(deadzone=0.0), 2) == 0
+    assert round(knob_bank.knobs[1].percent(deadzone=0.01), 2) == 0.50
+    assert round(knob_bank.knobs[1].percent(deadzone=0.0), 2) == 0.50
+    assert round(knob_bank.knobs[2].percent(deadzone=0.01), 2) == 0
+    assert round(knob_bank.knobs[2].percent(deadzone=0.0), 2) == 0
+    assert round(knob_bank.current.percent(deadzone=0.01), 2) == 0
+    assert round(knob_bank.current.percent(deadzone=0.0), 2) == 0
 
     mockHardware.set_ADC_u16_value(knob_bank.current, MAX_UINT16 / 3)
 
-    assert round(knob_bank.knobs[0].percent(), 2) == 0
-    assert round(knob_bank.knobs[1].percent(), 2) == 0.50
-    assert round(knob_bank.knobs[2].percent(), 2) == 0.67
-    assert round(knob_bank.current.percent(), 2) == 0.67
+    assert round(knob_bank.knobs[0].percent(deadzone=0.01), 2) == 0
+    assert round(knob_bank.knobs[0].percent(deadzone=0.0), 2) == 0
+    assert round(knob_bank.knobs[1].percent(deadzone=0.01), 2) == 0.50
+    assert round(knob_bank.knobs[1].percent(deadzone=0.0), 2) == 0.50
+    assert round(knob_bank.knobs[2].percent(deadzone=0.01), 2) == 0.67
+    assert round(knob_bank.knobs[2].percent(deadzone=0.0), 2) == 0.67
+    assert round(knob_bank.current.percent(deadzone=0.01), 2) == 0.67
+    assert round(knob_bank.current.percent(deadzone=0.0), 2) == 0.67
 
     # change to knob 0 (disabled), then move the knob
     knob_bank.next()
 
     mockHardware.set_ADC_u16_value(knob_bank.current, MAX_UINT16)
 
-    assert round(knob_bank.knobs[0].percent(), 2) == 0
-    assert round(knob_bank.knobs[1].percent(), 2) == 0.50
-    assert round(knob_bank.knobs[2].percent(), 2) == 0.67
-    assert round(knob_bank.current.percent(), 2) == 0
+    assert round(knob_bank.knobs[0].percent(deadzone=0.01), 2) == 0
+    assert round(knob_bank.knobs[0].percent(deadzone=0.0), 2) == 0
+    assert round(knob_bank.knobs[1].percent(deadzone=0.01), 2) == 0.50
+    assert round(knob_bank.knobs[1].percent(deadzone=0.0), 2) == 0.50
+    assert round(knob_bank.knobs[2].percent(deadzone=0.01), 2) == 0.67
+    assert round(knob_bank.knobs[2].percent(deadzone=0.0), 2) == 0.67
+    assert round(knob_bank.current.percent(deadzone=0.01), 2) == 0
+    assert round(knob_bank.current.percent(deadzone=0.0), 2) == 0
 
     mockHardware.set_ADC_u16_value(knob_bank.current, MAX_UINT16 / 4)
 
-    assert round(knob_bank.knobs[0].percent(), 2) == 0
-    assert round(knob_bank.knobs[1].percent(), 2) == 0.50
-    assert round(knob_bank.knobs[2].percent(), 2) == 0.67
-    assert round(knob_bank.current.percent(), 2) == 0
+    assert round(knob_bank.knobs[0].percent(deadzone=0.01), 2) == 0
+    assert round(knob_bank.knobs[0].percent(deadzone=0.0), 2) == 0
+    assert round(knob_bank.knobs[1].percent(deadzone=0.01), 2) == 0.50
+    assert round(knob_bank.knobs[1].percent(deadzone=0.0), 2) == 0.50
+    assert round(knob_bank.knobs[2].percent(deadzone=0.01), 2) == 0.67
+    assert round(knob_bank.knobs[2].percent(deadzone=0.0), 2) == 0.67
+    assert round(knob_bank.current.percent(deadzone=0.01), 2) == 0
+    assert round(knob_bank.current.percent(deadzone=0.0), 2) == 0
 
     # change to knob 1, then move the knob
     knob_bank.next()
     mockHardware.set_ADC_u16_value(knob_bank.current, MAX_UINT16 / 5)
 
-    assert round(knob_bank.knobs[0].percent(), 2) == 0
-    assert round(knob_bank.knobs[1].percent(), 2) == 0.50
-    assert round(knob_bank.knobs[2].percent(), 2) == 0.67
-    assert round(knob_bank.current.percent(), 2) == 0.50
+    assert round(knob_bank.knobs[0].percent(deadzone=0.01), 2) == 0
+    assert round(knob_bank.knobs[0].percent(deadzone=0.0), 2) == 0
+    assert round(knob_bank.knobs[1].percent(deadzone=0.01), 2) == 0.50
+    assert round(knob_bank.knobs[1].percent(deadzone=0.0), 2) == 0.50
+    assert round(knob_bank.knobs[2].percent(deadzone=0.01), 2) == 0.67
+    assert round(knob_bank.knobs[2].percent(deadzone=0.0), 2) == 0.67
+    assert round(knob_bank.current.percent(deadzone=0.01), 2) == 0.50
+    assert round(knob_bank.current.percent(deadzone=0.0), 2) == 0.50
 
     mockHardware.set_ADC_u16_value(knob_bank.current, MAX_UINT16 / 2)
 
-    assert round(knob_bank.knobs[0].percent(), 2) == 0
-    assert round(knob_bank.knobs[1].percent(), 2) == 0.50
-    assert round(knob_bank.knobs[2].percent(), 2) == 0.67
-    assert round(knob_bank.current.percent(), 2) == 0.50
+    assert round(knob_bank.knobs[0].percent(deadzone=0.01), 2) == 0
+    assert round(knob_bank.knobs[0].percent(deadzone=0.0), 2) == 0
+    assert round(knob_bank.knobs[1].percent(deadzone=0.01), 2) == 0.50
+    assert round(knob_bank.knobs[1].percent(deadzone=0.0), 2) == 0.50
+    assert round(knob_bank.knobs[2].percent(deadzone=0.01), 2) == 0.67
+    assert round(knob_bank.knobs[2].percent(deadzone=0.0), 2) == 0.67
+    assert round(knob_bank.current.percent(deadzone=0.01), 2) == 0.50
+    assert round(knob_bank.current.percent(deadzone=0.0), 2) == 0.50
 
     mockHardware.set_ADC_u16_value(knob_bank.current, MAX_UINT16 / 5)
 
-    assert round(knob_bank.knobs[0].percent(), 2) == 0
-    assert round(knob_bank.knobs[1].percent(), 2) == 0.81
-    assert round(knob_bank.knobs[2].percent(), 2) == 0.67
-    assert round(knob_bank.current.percent(), 2) == 0.81
+    assert round(knob_bank.knobs[0].percent(deadzone=0.01), 2) == 0
+    assert round(knob_bank.knobs[0].percent(deadzone=0.0), 2) == 0
+    assert round(knob_bank.knobs[1].percent(deadzone=0.01), 2) == 0.81
+    assert round(knob_bank.knobs[1].percent(deadzone=0.0), 2) == 0.80
+    assert round(knob_bank.knobs[2].percent(deadzone=0.01), 2) == 0.67
+    assert round(knob_bank.knobs[2].percent(deadzone=0.0), 2) == 0.67
+    assert round(knob_bank.current.percent(deadzone=0.01), 2) == 0.81
+    assert round(knob_bank.current.percent(deadzone=0.01), 2) == 0.80
 
 
 # KnobBank.Builder tests

--- a/software/tests/experimental/test_knobs.py
+++ b/software/tests/experimental/test_knobs.py
@@ -258,9 +258,9 @@ def test_access_by_index(mockHardware: MockHardware, knob_bank: KnobBank):
     mockHardware.set_ADC_u16_value(knob_bank.current, MAX_UINT16 / 5)
 
     assert round(knob_bank.knobs[0].percent(), 2) == 0
-    assert round(knob_bank.knobs[1].percent(), 2) == 0.80
+    assert round(knob_bank.knobs[1].percent(), 2) == 0.81
     assert round(knob_bank.knobs[2].percent(), 2) == 0.67
-    assert round(knob_bank.current.percent(), 2) == 0.80
+    assert round(knob_bank.current.percent(), 2) == 0.81
 
 
 # KnobBank.Builder tests

--- a/software/tests/test_knob.py
+++ b/software/tests/test_knob.py
@@ -73,7 +73,7 @@ def test_percent_w_deadzone(mockHardware: MockHardware, value, expected):
     "value, expected",
     [
         (0, 99),
-        (MAX_UINT16 / 4, 75),
+        (MAX_UINT16 / 4, 74),
         (MAX_UINT16 / 3, 66),
         (MAX_UINT16 / 2, 49),
         (MAX_UINT16, 0),

--- a/software/tests/test_knob.py
+++ b/software/tests/test_knob.py
@@ -82,7 +82,23 @@ def test_percent_w_deadzone(mockHardware: MockHardware, value, expected):
 def test_read_position(mockHardware: MockHardware, value, expected):
     mockHardware.set_ADC_u16_value(k1, value)
 
-    assert k1.read_position() == expected
+    assert k1.read_position(deadzone=0.0) == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (0, 99),
+        (MAX_UINT16 / 4, 75),
+        (MAX_UINT16 / 3, 67),
+        (MAX_UINT16 / 2, 49),
+        (MAX_UINT16, 0),
+    ],
+)
+def test_read_position_w_deadzone(mockHardware: MockHardware, value, expected):
+    mockHardware.set_ADC_u16_value(k1, value)
+
+    assert k1.read_position(deadzone=0.1) == expected
 
 
 def test_knobs_are_independent(mockHardware: MockHardware):

--- a/software/tests/test_knob.py
+++ b/software/tests/test_knob.py
@@ -9,8 +9,8 @@ from mock_hardware import MockHardware
     "value, expected",
     [
         (1, 1.0000),
-        (0.75, 0.7500),
-        (0.66, 0.6600),
+        (0.75, 0.755),
+        (0.66, 0.6632),
         (0.5, 0.5000),
         (0, 0.0000),
     ],
@@ -25,8 +25,8 @@ def test_set_knob_percent(mockHardware: MockHardware, value, expected):
     "value, expected",
     [
         (0, 1.0000),
-        (MAX_UINT16 / 4, 0.7500),
-        (MAX_UINT16 / 3, 0.6667),
+        (MAX_UINT16 / 4, 0.7550),
+        (MAX_UINT16 / 3, 0.6700),
         (MAX_UINT16 / 2, 0.5000),
         (MAX_UINT16, 0.0000),
     ],
@@ -41,8 +41,8 @@ def test_percent(mockHardware: MockHardware, value, expected):
     "value, expected",
     [
         (0, 99),
-        (MAX_UINT16 / 4, 74),
-        (MAX_UINT16 / 3, 66),
+        (MAX_UINT16 / 4, 75),
+        (MAX_UINT16 / 3, 67),
         (MAX_UINT16 / 2, 49),
         (MAX_UINT16, 0),
     ],

--- a/software/tests/test_knob.py
+++ b/software/tests/test_knob.py
@@ -9,8 +9,8 @@ from mock_hardware import MockHardware
     "value, expected",
     [
         (1, 1.0000),
-        (0.75, 0.7550),
-        (0.66, 0.6632),
+        (0.75, 0.7500),
+        (0.66, 0.6600),
         (0.5, 0.5000),
         (0, 0.0000),
     ],
@@ -18,7 +18,39 @@ from mock_hardware import MockHardware
 def test_set_knob_percent(mockHardware: MockHardware, value, expected):
     mockHardware.set_knob_percent(k1, value)
 
-    assert round(k1.percent(), 4) == expected
+    assert round(k1.percent(deadzone=0.0), 4) == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (1, 1.0000),
+        (0.75, 0.755),
+        (0.66, 0.6632),
+        (0.5, 0.5000),
+        (0, 0.0000),
+    ],
+)
+def test_set_knob_percent_w_deadzone(mockHardware: MockHardware, value, expected):
+    mockHardware.set_knob_percent(k1, value)
+
+    assert round(k1.percent(deadzone=0.01), 4) == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (0, 1.0000),
+        (MAX_UINT16 / 4, 0.7500),
+        (MAX_UINT16 / 3, 0.6667),
+        (MAX_UINT16 / 2, 0.5000),
+        (MAX_UINT16, 0.0000),
+    ],
+)
+def test_percent(mockHardware: MockHardware, value, expected):
+    mockHardware.set_ADC_u16_value(k1, value)
+
+    assert round(k1.percent(deadzone=0.0), 4) == expected
 
 
 @pytest.mark.parametrize(
@@ -31,10 +63,10 @@ def test_set_knob_percent(mockHardware: MockHardware, value, expected):
         (MAX_UINT16, 0.0000),
     ],
 )
-def test_percent(mockHardware: MockHardware, value, expected):
+def test_percent_w_deadzone(mockHardware: MockHardware, value, expected):
     mockHardware.set_ADC_u16_value(k1, value)
 
-    assert round(k1.percent(), 4) == expected
+    assert round(k1.percent(deadzone=0.01), 4) == expected
 
 
 @pytest.mark.parametrize(
@@ -57,5 +89,5 @@ def test_knobs_are_independent(mockHardware: MockHardware):
     mockHardware.set_ADC_u16_value(k1, 0)
     mockHardware.set_ADC_u16_value(k2, MAX_UINT16)
 
-    assert k1.percent() == 1.0
-    assert k2.percent() == 0.0
+    assert k1.percent(deadzone=0.01) == 1.0
+    assert k2.percent(deadzone=0.01) == 0.0

--- a/software/tests/test_knob.py
+++ b/software/tests/test_knob.py
@@ -74,7 +74,7 @@ def test_percent_w_deadzone(mockHardware: MockHardware, value, expected):
     [
         (0, 99),
         (MAX_UINT16 / 4, 75),
-        (MAX_UINT16 / 3, 67),
+        (MAX_UINT16 / 3, 66),
         (MAX_UINT16 / 2, 49),
         (MAX_UINT16, 0),
     ],

--- a/software/tests/test_knob.py
+++ b/software/tests/test_knob.py
@@ -98,7 +98,7 @@ def test_read_position(mockHardware: MockHardware, value, expected):
 def test_read_position_w_deadzone(mockHardware: MockHardware, value, expected):
     mockHardware.set_ADC_u16_value(k1, value)
 
-    assert k1.read_position(deadzone=0.1) == expected
+    assert k1.read_position(deadzone=0.01) == expected
 
 
 def test_knobs_are_independent(mockHardware: MockHardware):

--- a/software/tests/test_knob.py
+++ b/software/tests/test_knob.py
@@ -9,7 +9,7 @@ from mock_hardware import MockHardware
     "value, expected",
     [
         (1, 1.0000),
-        (0.75, 0.755),
+        (0.75, 0.7550),
         (0.66, 0.6632),
         (0.5, 0.5000),
         (0, 0.0000),


### PR DESCRIPTION
This fixes the issue https://github.com/Allen-Synthesis/EuroPi/issues/209 by implementing deadzones for the knobs. 
Please see the discussion in the issue for details.
This PR does not change:
- Anything about ain. I opened an extra issue for that (https://github.com/Allen-Synthesis/EuroPi/issues/211)

This PR does change:
- The deadzones are implemented in the percent() function of the AnalogueReader class.
- Also the Knob class now actually makes use of the percent() function in the AnalogueReader class instead of completely reimplementing that part.
- Also the _sample_adc() function of AnalogueReader was changed for better performance without changing the results
- Tests have been modified to account for the deadzones