### PR TITLE
fix calibration not working in quick start using custom uf2

### DIFF
--- a/software/firmware/calibrate.py
+++ b/software/firmware/calibrate.py
@@ -2,6 +2,7 @@ from machine import Pin, ADC, PWM, freq
 from time import sleep
 from europi import oled, b1, b2
 from europi_script import EuroPiScript
+from os import stat, mkdir
 
 
 class Calibrate(EuroPiScript):
@@ -51,6 +52,11 @@ class Calibrate(EuroPiScript):
         def wait_for_b1(value):
             while b1.value() != value:
                 sleep(0.05)
+
+        try:
+            stat("/lib")
+        except OSError:
+            mkdir("/lib")
 
         # Calibration start
 

--- a/software/firmware/calibrate.py
+++ b/software/firmware/calibrate.py
@@ -53,6 +53,8 @@ class Calibrate(EuroPiScript):
             while b1.value() != value:
                 sleep(0.05)
 
+        # Test if /lib exists. If not: Create it
+
         try:
             stat("/lib")
         except OSError:


### PR DESCRIPTION
This is a potential (untested) fix for an issue with the custom quick start uf2 mentioned on discord by Salvadi.
The issue is that the calibration won't complete, likely because the code is unable to create the calibration file.
I think this is due to the missing /lib folder after setting up europi using the custom uf2 image.
So this fix checks if that folder is present and if not creates it.
Again, this is untested as I don't have the hardware right now. 
So maybe someone else can test it on hardware? If not I will test it later.