### PR TITLE
Menu improvements

### DIFF
--- a/.github/workflows/compile_to_uf2.yml
+++ b/.github/workflows/compile_to_uf2.yml
@@ -21,7 +21,7 @@ jobs:
           repository: micropython/micropython
           ref: v1.19.1
           path: micropython
-      
+
       - name: install os deps
         run: sudo apt-get install -y cmake gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential
 
@@ -36,7 +36,7 @@ jobs:
           cp -r europi/software/firmware/*.py micropython/ports/rp2/modules
           cp -r europi/software/firmware/experimental/*.py micropython/ports/rp2/modules/experimental
           cp -r europi/software/contrib/*.py micropython/ports/rp2/modules/contrib
-        
+
       - name: install ssd1306 library
         run: wget https://raw.githubusercontent.com/stlehmann/micropython-ssd1306/master/ssd1306.py -O micropython/ports/rp2/modules/ssd1306.py
 
@@ -49,7 +49,7 @@ jobs:
           import gc
           gc.collect()
           from contrib.menu import *
-          BootloaderMenu(EUROPI_SCRIPT_CLASSES).main()
+          BootloaderMenu(EUROPI_SCRIPTS).main()
           EOF
 
       - name: "[debug] print modules folder"
@@ -64,7 +64,7 @@ jobs:
         run: |
           VERSION=`grep -oP '(?<=")[\d\.]+(?=")' micropython/ports/rp2/modules/version.py`
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-      
+
       - name: rename firmware file with version info
         run: cp micropython/ports/rp2/build-PICO/firmware.uf2 europi-v${{ steps.release-asset-version.outputs.VERSION }}.uf2
 

--- a/software/contrib/menu.md
+++ b/software/contrib/menu.md
@@ -1,6 +1,6 @@
 # Menu 
 A Menu which allows the user to select and execute one of the scripts available to this EuroPi. The menu will 
-include the ``EuroPiScripts`` included in the ``EUROPI_SCRIPT_CLASSES`` List. Button press handlers are added that allow
+include the ``EuroPiScripts`` included in the ``EUROPI_SCRIPTS`` List. Button press handlers are added that allow
 the user to exit the script and return to the menu by holding both buttons down for a short period of time. If the 
 module is restarted while a script is running it will boot right back into that same script.
 

--- a/software/contrib/menu.py
+++ b/software/contrib/menu.py
@@ -1,6 +1,6 @@
 """See menu.md for details."""
 # Reset the module state and display bootsplash screen.
-from europi import OLED_HEIGHT, OLED_WIDTH, bootsplash, usb_connected, oled
+from europi import bootsplash, usb_connected
 
 #  This is a fix for a USB connection issue documented in GitHub issue #179, and its removal condition is set out in GitHub issue #184
 if usb_connected.value() == 0:
@@ -11,51 +11,37 @@ if usb_connected.value() == 0:
 bootsplash()
 
 
-def progress_bar(percentage):
-    oled.hline(0, OLED_HEIGHT - 1, int(OLED_WIDTH * percentage), 1)
-    oled.show()
-
-
 from bootloader import BootloaderMenu
 
 # Scripts that are included in the menu
-scripts = [
-    ("contrib.knob_playground", "KnobPlayground"),
-    ("contrib.bernoulli_gates", "BernoulliGates"),
-    ("contrib.coin_toss", "CoinToss"),
-    ("contrib.consequencer", "Consequencer"),
-    ("contrib.cvecorder", "CVecorder"),
-    ("contrib.diagnostic", "Diagnostic"),
-    ("contrib.hamlet", "Hamlet"),
-    ("contrib.harmonic_lfos", "HarmonicLFOs"),
-    ("contrib.hello_world", "HelloWorld"),
-    ("contrib.logic", "Logic"),
-    ("contrib.master_clock", "MasterClock"),
-    ("contrib.noddy_holder", "NoddyHolder"),
-    ("contrib.piconacci", "Piconacci"),
-    ("contrib.polyrhythmic_sequencer", "PolyrhythmSeq"),
-    ("contrib.poly_square", "PolySquare"),
-    ("contrib.probapoly", "Probapoly"),
-    ("contrib.quantizer", "QuantizerScript"),
-    ("contrib.radio_scanner", "RadioScanner"),
-    ("contrib.scope", "Scope"),
-    ("contrib.sequential_switch", "SequentialSwitch"),
-    ("contrib.smooth_random_voltages", "SmoothRandomVoltages"),
-    ("contrib.strange_attractor", "StrangeAttractor"),
-    ("contrib.turing_machine", "EuroPiTuringMachine"),
-    ("calibrate", "Calibrate"),
+EUROPI_SCRIPTS = [
+    # TODO the test to catch bad imports here
+    "contrib.bernoulli_gates.BernoulliGates",
+    "contrib.coin_toss.CoinToss",
+    "contrib.consequencer.Consequencer",
+    "contrib.cvecorder.CVecorder",
+    "contrib.diagnostic.Diagnostic",
+    "contrib.hamlet.Hamlet",
+    "contrib.harmonic_lfos.HarmonicLFOs",
+    "contrib.hello_world.HelloWorld",
+    "contrib.knob_playground.KnobPlayground",
+    "contrib.logic.Logic",
+    "contrib.master_clock.MasterClock",
+    "contrib.noddy_holder.NoddyHolder",
+    "contrib.piconacci.Piconacci",
+    "contrib.polyrhythmic_sequencer.PolyrhythmSeq",
+    "contrib.poly_square.PolySquare",
+    "contrib.probapoly.Probapoly",
+    "contrib.quantizer.QuantizerScript",
+    "contrib.radio_scanner.RadioScanner",
+    "contrib.scope.Scope",
+    "contrib.sequential_switch.SequentialSwitch",
+    "contrib.smooth_random_voltages.SmoothRandomVoltages",
+    "contrib.strange_attractor.StrangeAttractor",
+    "contrib.turing_machine.EuroPiTuringMachine",
+    "calibrate.Calibrate",
 ]
 
 
-def generate_script_classes(scripts) -> "List[str]":
-    c = []
-    for i, (module, clazz) in enumerate(scripts):
-        c.append(getattr(__import__(module, None, None, [None]), clazz))
-        progress_bar(i / len(scripts))
-    return c
-
-
-EUROPI_SCRIPT_CLASSES = generate_script_classes(scripts)
-
 if __name__ == "__main__":
-    BootloaderMenu(EUROPI_SCRIPT_CLASSES).main()
+    BootloaderMenu(EUROPI_SCRIPTS).main()

--- a/software/contrib/menu.py
+++ b/software/contrib/menu.py
@@ -15,7 +15,6 @@ from bootloader import BootloaderMenu
 
 # Scripts that are included in the menu
 EUROPI_SCRIPTS = [
-    # TODO the test to catch bad imports here
     "contrib.bernoulli_gates.BernoulliGates",
     "contrib.coin_toss.CoinToss",
     "contrib.consequencer.Consequencer",

--- a/software/contrib/menu.py
+++ b/software/contrib/menu.py
@@ -1,6 +1,6 @@
 """See menu.md for details."""
 # Reset the module state and display bootsplash screen.
-from europi import bootsplash, usb_connected
+from europi import OLED_HEIGHT, OLED_WIDTH, bootsplash, usb_connected, oled
 
 #  This is a fix for a USB connection issue documented in GitHub issue #179, and its removal condition is set out in GitHub issue #184
 if usb_connected.value() == 0:
@@ -10,61 +10,52 @@ if usb_connected.value() == 0:
 
 bootsplash()
 
+
+def progress_bar(percentage):
+    oled.hline(0, OLED_HEIGHT - 1, int(OLED_WIDTH * percentage), 1)
+    oled.show()
+
+
 from bootloader import BootloaderMenu
 
-# from contrib.knob_playground import KnobPlayground
-from contrib.bernoulli_gates import BernoulliGates
-from contrib.coin_toss import CoinToss
-from contrib.consequencer import Consequencer
-from contrib.cvecorder import CVecorder
-from contrib.diagnostic import Diagnostic
-from contrib.hamlet import Hamlet
-from contrib.harmonic_lfos import HarmonicLFOs
-from contrib.hello_world import HelloWorld
-from contrib.logic import Logic
-from contrib.master_clock import MasterClock
-from contrib.noddy_holder import NoddyHolder
-from contrib.piconacci import Piconacci
-from contrib.polyrhythmic_sequencer import PolyrhythmSeq
-from contrib.poly_square import PolySquare
-from contrib.probapoly import Probapoly
-from contrib.quantizer import QuantizerScript
-from contrib.radio_scanner import RadioScanner
-from contrib.scope import Scope
-from contrib.sequential_switch import SequentialSwitch
-from contrib.smooth_random_voltages import SmoothRandomVoltages
-from contrib.strange_attractor import StrangeAttractor
-from contrib.turing_machine import EuroPiTuringMachine
-from calibrate import Calibrate
-
 # Scripts that are included in the menu
-EUROPI_SCRIPT_CLASSES = [
-    # KnobPlayground,
-    BernoulliGates,
-    CoinToss,
-    Consequencer,
-    CVecorder,
-    Diagnostic,
-    Hamlet,
-    HarmonicLFOs,
-    HelloWorld,
-    Logic,
-    MasterClock,
-    NoddyHolder,
-    Piconacci,
-    PolyrhythmSeq,
-    PolySquare,
-    Probapoly,
-    QuantizerScript,
-    RadioScanner,
-    Scope,
-    SequentialSwitch,
-    SmoothRandomVoltages,
-    StrangeAttractor,
-    EuroPiTuringMachine,
-    Calibrate,
+scripts = [
+    ("contrib.knob_playground", "KnobPlayground"),
+    ("contrib.bernoulli_gates", "BernoulliGates"),
+    ("contrib.coin_toss", "CoinToss"),
+    ("contrib.consequencer", "Consequencer"),
+    ("contrib.cvecorder", "CVecorder"),
+    ("contrib.diagnostic", "Diagnostic"),
+    ("contrib.hamlet", "Hamlet"),
+    ("contrib.harmonic_lfos", "HarmonicLFOs"),
+    ("contrib.hello_world", "HelloWorld"),
+    ("contrib.logic", "Logic"),
+    ("contrib.master_clock", "MasterClock"),
+    ("contrib.noddy_holder", "NoddyHolder"),
+    ("contrib.piconacci", "Piconacci"),
+    ("contrib.polyrhythmic_sequencer", "PolyrhythmSeq"),
+    ("contrib.poly_square", "PolySquare"),
+    ("contrib.probapoly", "Probapoly"),
+    ("contrib.quantizer", "QuantizerScript"),
+    ("contrib.radio_scanner", "RadioScanner"),
+    ("contrib.scope", "Scope"),
+    ("contrib.sequential_switch", "SequentialSwitch"),
+    ("contrib.smooth_random_voltages", "SmoothRandomVoltages"),
+    ("contrib.strange_attractor", "StrangeAttractor"),
+    ("contrib.turing_machine", "EuroPiTuringMachine"),
+    ("calibrate", "Calibrate"),
 ]
 
+
+def generate_script_classes(scripts) -> "List[str]":
+    c = []
+    for i, (module, clazz) in enumerate(scripts):
+        c.append(getattr(__import__(module, None, None, [None]), clazz))
+        progress_bar(i / len(scripts))
+    return c
+
+
+EUROPI_SCRIPT_CLASSES = generate_script_classes(scripts)
 
 if __name__ == "__main__":
     BootloaderMenu(EUROPI_SCRIPT_CLASSES).main()

--- a/software/create_custom_firmware_uf2.md
+++ b/software/create_custom_firmware_uf2.md
@@ -62,7 +62,7 @@ micropython/ports/rp2/modules/
 ├── ui.py
 └── version.py
 ```
-_boot.py should be modefied to look like this: (increase progsize)
+_boot.py should be modified to look like this: (increase progsize)
 ``` Python
 import os
 import machine, rp2
@@ -82,7 +82,7 @@ main.py could look like this: (It's important to call the garbage collector to m
 import gc
 gc.collect()
 from contrib.menu import *
-BootloaderMenu(EUROPI_SCRIPT_CLASSES).main()
+BootloaderMenu(EUROPI_SCRIPTS).main()
 ```
 
 ## Import priority

--- a/software/firmware/bootloader.py
+++ b/software/firmware/bootloader.py
@@ -142,11 +142,10 @@ class BootloaderMenu(EuroPiScript):
         if not script_class:
             script_class = self.run_menu()
             self.save_state_str(f"{script_class.__module__}.{script_class.__name__}")
+            machine.reset()
+        else:
+            # setup the exit handlers, and execute the selection
+            europi.b1._handler_both(europi.b2, self.exit_to_menu)
+            europi.b2._handler_both(europi.b1, self.exit_to_menu)
 
-        # setup the exit handlers, and execute the selection
-        reset_state()  # remove menu's button handlers
-        europi.b1._handler_both(europi.b2, self.exit_to_menu)
-        europi.b2._handler_both(europi.b1, self.exit_to_menu)
-
-        time.sleep(0.25)
-        script_class().main()
+            script_class().main()

--- a/software/firmware/bootloader.py
+++ b/software/firmware/bootloader.py
@@ -6,9 +6,6 @@ import machine
 
 import europi
 from europi import (
-    CHAR_HEIGHT,
-    CHAR_WIDTH,
-    Button,
     reset_state,
     OLED_HEIGHT,
     OLED_WIDTH,
@@ -77,8 +74,7 @@ class BootloaderMenu(EuroPiScript):
             return getattr(__import__(module, None, None, [None]), clazz)
         except Exception as e:
             print(
-                f"Warning: Ignoring bad qualified class name: {script_class_name}\n"
-                f"  caused by: {e}"
+                f"Warning: Ignoring bad qualified class name: {script_class_name}\n  caused by: {e}"
             )
             return None
 

--- a/software/firmware/bootloader.py
+++ b/software/firmware/bootloader.py
@@ -57,14 +57,19 @@ class BootloaderMenu(EuroPiScript):
             module, clazz = script_class_name.rsplit(".", 1)
             return getattr(__import__(module, None, None, [None]), clazz)
         except Exception as e:
-            print(f"Ignoring bad qualified class name: {script_class_name}\ncaused by:\n{e}")
+            print(
+                f"Warning: Ignoring bad qualified class name: {script_class_name}\n"
+                f"  caused by: {e}"
+            )
             return None
 
     @classmethod
     def load_script_classes(cls, scripts) -> "dict(str, type)":
         classes = {}
         for i, script in enumerate(scripts):
-            classes[script] = cls.get_class_for_name(script)
+            clazz = cls.get_class_for_name(script)
+            if clazz:
+                classes[script] = clazz
             cls.show_progress(i / len(scripts))
         return classes
 

--- a/software/firmware/europi_script.py
+++ b/software/firmware/europi_script.py
@@ -32,7 +32,7 @@ class EuroPiScript:
        if __name__ == "__main__":  # 4
            HelloWorld().main()
 
-    To include your script in the menu it must be added to the ``EUROPI_SCRIPT_CLASSES`` list in ``contrib/menu.py``.
+    To include your script in the menu it must be added to the ``EUROPI_SCRIPTS`` list in ``contrib/menu.py``.
 
     **Save/Load Script State**
 

--- a/software/tests/contrib/test_menu.py
+++ b/software/tests/contrib/test_menu.py
@@ -1,6 +1,8 @@
 import sys
 import pytest
 import utime
+from contrib.menu import EUROPI_SCRIPTS
+from bootloader import BootloaderMenu
 
 
 @pytest.fixture
@@ -11,4 +13,7 @@ def mock_time_module(monkeypatch):
 
 
 def test_menu_imports(mock_time_module):
-    import contrib.menu
+    """User the bootloader code to test that every script declared in EUROPI_SCRIPTS can be imported."""
+    bootloader = BootloaderMenu(EUROPI_SCRIPTS)
+    classes = bootloader.load_script_classes(bootloader.scripts)
+    assert EUROPI_SCRIPTS == list(classes.keys()), "Some EUROPI_SCRIPTs were not able to be loaded."

--- a/software/tests/mocks/ssd1306.py
+++ b/software/tests/mocks/ssd1306.py
@@ -22,3 +22,6 @@ class SSD1306_I2C:
 
     def blit(self, *args):
         pass
+
+    def hline(self, *args):
+        pass

--- a/software/tests/test_bootloader.py
+++ b/software/tests/test_bootloader.py
@@ -28,10 +28,10 @@ def test_is_europi_script(cls, expected):
     assert BootloaderMenu._is_europi_script(cls) == expected
 
 
-def test_build_scripts_config():
+def test_build_scripts_mapping():
     scripts = [GoodTestScript1, GoodTestScript2, BadTestScript]
 
-    config = BootloaderMenu._build_scripts_config(scripts)
+    config = BootloaderMenu._build_scripts_mapping(scripts)
 
     assert len(config) == 2
     assert list(config.keys()) == ["GoodTestScript1", "GoodTestScript2"]


### PR DESCRIPTION
This PR adds several improvements to the menu system.

Recently several new scripts were added pushing the allocated memory during menu load over the limit, causing it to crash. Running a `gc.collect()` during the import process alleviates the issue. Though I don't fully understand why, since python should perform a gc if it can't allocate.

During the debug of the above issue I discovered that memory used by the import of all of the scripts at menu load time is never released. This means that a script launched by the menu has less memory available to it than one launched as `main.py`. I changed the way menu works such that the list of scripts is only imported when the menu is needed, and the launch of the chosen script happens the same way no matter if the menu is loaded or not. The result is more memory for scripts and a faster load time when the menu isn't needed.

Summary of changes:
* adds regular calls to `gc.collect()` to allow the menu to load
* prevent failed allocations from crashing the script imports (they will just fail to import)
* Only import scripts when the menu needed
* reset the machine before launching the selected script
* display a progress bar while the menu is loading