### PR TITLE
Automate the process of building the uf2 dev image

### DIFF
--- a/software/create_custom_firmware_uf2.md
+++ b/software/create_custom_firmware_uf2.md
@@ -1,5 +1,11 @@
 # Creating a custom firmware.uf2 image for EuroPi
 
+The instructions below describe the steps needed to build the uf2 locally on your machine for
+development purposes. Alternatively you can run the script `software/uf2_build/build_uf2.sh` to
+build the image in a docker container. You will need to have docker installed and running. See the
+script for execution details.
+
+
 ## Compiling the firmware
 ``` Bash
 # install extra tools if not already done so

--- a/software/create_custom_firmware_uf2.md
+++ b/software/create_custom_firmware_uf2.md
@@ -2,8 +2,8 @@
 
 The instructions below describe the steps needed to build the uf2 locally on your machine for
 development purposes. Alternatively you can run the script `software/uf2_build/build_uf2.sh` to
-build the image in a docker container. You will need to have docker installed and running. See the
-script for execution details.
+build the image in a docker container. You will need to have [docker](https://docs.docker.com/get-started/)
+installed and running. See the script for execution details.
 
 
 ## Compiling the firmware

--- a/software/uf2_build/.gitignore
+++ b/software/uf2_build/.gitignore
@@ -1,0 +1,2 @@
+europi-dev.uf2
+

--- a/software/uf2_build/Dockerfile
+++ b/software/uf2_build/Dockerfile
@@ -1,0 +1,29 @@
+FROM ubuntu:22.04
+
+ENV TERM=xterm DEBIAN_FRONTEND=noninteractive
+
+RUN apt update && apt install -y \
+    cmake git-core gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential wget python3
+
+RUN git clone -b v1.19.1 --depth=1 --recursive https://github.com/micropython/micropython.git 
+
+WORKDIR micropython
+
+RUN make -C ports/rp2 submodules && make -C mpy-cross clean
+
+RUN wget https://raw.githubusercontent.com/stlehmann/micropython-ssd1306/master/ssd1306.py -O ports/rp2/modules/ssd1306.py
+
+RUN sed -i 's/progsize=256)/progsize=1024)/g' ports/rp2/modules/_boot.py
+
+RUN echo '\
+import gc\n\
+gc.collect()\n\
+from contrib.menu import *\n\
+BootloaderMenu(EUROPI_SCRIPTS).main()\n\
+' > ports/rp2/modules/main.py
+
+COPY software/uf2_build/copy_and_compile.sh /
+
+WORKDIR /
+
+ENTRYPOINT [ "sh", "copy_and_compile.sh" ]

--- a/software/uf2_build/build_uf2.sh
+++ b/software/uf2_build/build_uf2.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Run this script from the repo's root directory as `$ ./software/uf2_build/build_uf2.sh`.
-# requires docker is installed and running.
+# requires docker is installed and running. For docker help: https://docs.docker.com/get-started/
 
 # Build the `europi_buildenv`` docker image. Subsequent builds will reuse the same image.
 docker build -t europi_buildenv -f software/uf2_build/Dockerfile ./

--- a/software/uf2_build/build_uf2.sh
+++ b/software/uf2_build/build_uf2.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+# Run this script from the repo's root directory as `$ ./software/uf2_build/build_uf2.sh`.
+# requires docker is installed and running.
+
+# Build the `europi_buildenv`` docker image. Subsequent builds will reuse the same image.
+docker build -t europi_buildenv -f software/uf2_build/Dockerfile ./
+
+# Run the just built docker image, which uses the code in the current directory to build a new uf2
+# image, which will be located in `software/uf2_build/europi-dev.uf2`.
+docker run -v .:/europi europi_buildenv

--- a/software/uf2_build/copy_and_compile.sh
+++ b/software/uf2_build/copy_and_compile.sh
@@ -1,0 +1,16 @@
+#/bin/sh
+set -e
+
+echo "Copying EuroPi firmware and scripts to container..."
+mkdir micropython/ports/rp2/modules/contrib
+mkdir micropython/ports/rp2/modules/experimental
+cp -r europi/software/firmware/*.py micropython/ports/rp2/modules
+cp -r europi/software/firmware/experimental/*.py micropython/ports/rp2/modules/experimental
+cp -r europi/software/contrib/*.py micropython/ports/rp2/modules/contrib
+
+echo "Compiling micropython and firmware modules..."
+cd micropython/ports/rp2
+make
+
+echo "Copying firmware file to /europi/software/uf2_build/europi-dev.uf2"
+cp build-PICO/firmware.uf2 /europi/software/uf2_build/europi-dev.uf2


### PR DESCRIPTION
The image is build using docker and is directly based on the current release uf2 build procedure. This is intended for use during development to build the uf2 image locally. The existing github workflow will still be used to build the release. This means that we now have the uf2 build process described in three places (github workflow, documentation, uf2_build directory). In the future we should try to consolidate.