### PR TITLE
DRAFT - Add Pamela's "EuroPi" Workout

### DIFF
--- a/software/contrib/README.md
+++ b/software/contrib/README.md
@@ -69,6 +69,13 @@ Users have a copy of the original trigger signal, a sample and hold and a track 
 <i>Author: [seanbechhofer](https://github.com/seanbechhofer)</i>
 <br><i>Labels: gates, sample&hold, track&hold</i>
 
+### Pam's "EuroPi" Workout \[ [documentation](/software/contrib/pams.md) | [script](/software/contrib/pams.py) \]
+A re-imaging of [ALM/Busy Circuit's Pamela's "NEW" Workout](https://busycircuits.com/alm017/). Turns the EuroPi into a clocked modulation
+source with multiple wave shapes, optional quantization, euclidean rhythm outputs and external start/stop trigger input.
+
+<i>Author: [chrisib](https://github.com/chrisib)</i>
+<br><i>Labels: clock, euclidean, gate, lfo, quantizer, random, trigger</i>
+
 ### Poly Square \[ [documentation](/software/contrib/poly_square.md) | [script](/software/contrib/poly_square.py) \]
 Six independent oscillators which output on CVs 1-6.
 

--- a/software/contrib/menu.py
+++ b/software/contrib/menu.py
@@ -28,6 +28,7 @@ EUROPI_SCRIPTS = [
     "contrib.logic.Logic",
     "contrib.master_clock.MasterClock",
     "contrib.noddy_holder.NoddyHolder",
+    "contrib.pams.PamsWorkout",
     "contrib.piconacci.Piconacci",
     "contrib.polyrhythmic_sequencer.PolyrhythmSeq",
     "contrib.poly_square.PolySquare",

--- a/software/contrib/pams.md
+++ b/software/contrib/pams.md
@@ -27,6 +27,8 @@ clock multiplier or divider, chosen from the following:
 
 ## External CV Routing
 
+NOTE: THIS FEATURE IS NOT IMPLEMENTED YET!!
+
 Many of the master clock or per-channel configuration options have a `CV` option.  If
 this is selected, then the voltage used to control the given parameter.  A value of
 0V will be the equivalent of choosing the lowest option available, and a value of 10V
@@ -85,9 +87,10 @@ Each of the 6 CV output channels has the following options:
 
 The submenu for each CV output has the following options:
 
-- `Wave` -- the wave shape to output
+- `Wave` -- the wave shape to output. Square/Triangle/Sine/Random/Reset
 - `Ampl.` -- the maximum amplitude of the output as a percentage of the 10V
   hardware maximum
+- `Width` -- width of the resulting wave. See below
 - `Skip%` -- the probability that a square pulse or euclidean trigger
   will be skipped
 - `EStep` -- the number of steps in the euclidean rhythm. If zero, the
@@ -95,3 +98,14 @@ The submenu for each CV output has the following options:
 - `ETrig` -- the number of pulses in the euclidean rhythm
 - `ERot` -- rotation of the euclidean rhythm
 - `Quant` -- quantization scale
+
+The Reset wave fires only when the clock is stopped and can be used to help synchronize
+external modules (e.g. other sequencers, sequential switches, etc...)
+
+Effects of width control on different wave shapes:
+- Square: Duty cycle control. 0% is always off, 100% is always on
+- Triangle: Symmetry contro. 50% results in a symmetrical wave, 0% results in a saw wave,
+  100% results in a ramp
+- Sine: ignored
+- Random: offset voltage as a percentage of the maximum output
+- Reset: ignored

--- a/software/contrib/pams.md
+++ b/software/contrib/pams.md
@@ -10,7 +10,7 @@ BPM (TODO: define the range!).  Each output has an independently controlled
 clock multiplier or divider, chosen from the following:
 
 ```
-[x8, x6, x4, x3, x2, x1, /2, /3, /4, /6, /8, /12, /16, /24, /32]
+[x8, x6, x4, x3, x2, x1, /2, /3, /4, /6, /8, /12, /16]
 ```
 
 ## I/O Mapping

--- a/software/contrib/pams.md
+++ b/software/contrib/pams.md
@@ -19,12 +19,10 @@ clock multiplier or divider, chosen from the following:
 |---------------|-------------------------------------------------------------------|
 | `din`         | External start/stop input                                         |
 | `ain`         | Routable CV input to control other parameters                     |
-|---------------|-------------------------------------------------------------------|
 | `b1`          | Start/Stop input                                                  |
 | `b2`          | Press to enter/exit edit mode. Long-press to enter/leave sub-menu |
 | `k1`          | Scroll through the current menu                                   |
 | `k2`          | Scroll through allowed values for the current menu item           |
-|---------------|-------------------------------------------------------------------|
 | `cv1` - `cv6` | Output signals. Configuration is explained below                  |
 
 ## External CV Routing
@@ -83,7 +81,7 @@ The submenu for the main clock has the following options:
 
 Each of the 6 CV output channels has the following options:
 
-- Mod -- the clock modifier.  See above for valid ranges.
+- `Mod` -- the clock modifier.  See above for valid ranges.
 
 The submenu for each CV output has the following options:
 

--- a/software/contrib/pams.md
+++ b/software/contrib/pams.md
@@ -1,0 +1,99 @@
+# Pam's "EuroPi" Workout
+
+This program is an homage to ALM's Pamela's "NEW" Workout and Pamela's "PRO"
+Workout modules, designed for the EuroPi.  It is intended to be used as a
+main clock generator, euclidean rhythm generator, clocked LFO, clocked
+random voltage source, etc... with optional quantization.
+
+The module itself will generate the master clock signal with a configurable
+BPM (TODO: define the range!).  Each output has an independently controlled
+clock multiplier or divider, chosen from the following:
+
+```
+[/8, /6, /4, /2, x1, x2, x3, x4, x6, x8, x12, x16, x24, x32]
+```
+
+## I/O Mapping
+
+| I/O           | Usage
+|---------------|-------------------------------------------------------------------|
+| `din`         | External start/stop input                                         |
+| `ain`         | Routable CV input to control other parameters                     |
+|---------------|-------------------------------------------------------------------|
+| `b1`          | Start/Stop input                                                  |
+| `b2`          | Press to enter/exit edit mode. Long-press to enter/leave sub-menu |
+| `k1`          | Scroll through the current menu                                   |
+| `k2`          | Scroll through allowed values for the current menu item           |
+|---------------|-------------------------------------------------------------------|
+| `cv1` - `cv6` | Output signals. Configuration is explained below                  |
+
+## External CV Routing
+
+Many of the master clock or per-channel configuration options have a `CV` option.  If
+this is selected, then the voltage used to control the given parameter.  A value of
+0V will be the equivalent of choosing the lowest option available, and a value of 10V
+will be the equivalent of choosing the highest option available.
+
+Note that multiple settings can be controlled simultaneously from `ain`, which can
+result in some interesting effects.
+
+There is no attenuation available, so you will have to use an external attenuator, VCA,
+or other control to attenuate the input signal.
+
+## Menu Navigation
+
+Rotate `k1` to scroll through the current menu.  Pressing and holding `b2` for 1s will
+enter a sub-menu.  Pressing and holding `b2` again will return to the parent menu.
+
+On any given menu item, pressing `b2` (without holding) will enter edit mode for that
+item.  Rotate `k2` to choose the desired value for the item, and press `b2` again
+to apply it.
+
+The menu layout is as follows:
+
+```
+|-- Clock
+|   |-- BPM
+|   |   |-- Reset
+|-- CV1
+|   |-- Mod.
+|   |   |-- Wave Shape
+|   |   |-- Wave Amplitude
+|   |   |-- Skip Probability
+|   |   |-- Euclidean Steps
+|   |   |-- Euclidean Triggers
+|   |   |-- Euclidean Rotatioj
+|   |   |-- Quantization Scale
+|-- CV2-6
+|   |-- Same as CV1
+```
+
+## Main Clock Options
+
+The main clock menu has the following options:
+
+- `BPM` -- the main BPM for the clock. Must be in the range `[TODO_LOW, TODO_HIGH]`.
+
+The submenu for the main clock has the following options:
+
+- `Reset` -- if true, all waves & euclidean patterns will reset when the clock starts.
+  Otherwise they will continue from where they stopped
+
+## CV Channel Options
+
+Each of the 6 CV output channels has the following options:
+
+- Mod -- the clock modifier.  See above for valid ranges.
+
+The submenu for each CV output has the following options:
+
+- `Wave` -- the wave shape to output
+- `Ampl.` -- the maximum amplitude of the output as a percentage of the 10V
+  hardware maximum
+- `Skip%` -- the probability that a square pulse or euclidean trigger
+  will be skipped
+- `EStep` -- the number of steps in the euclidean rhythm. If zero, the
+  euclidean generator is disabled
+- `ETrig` -- the number of pulses in the euclidean rhythm
+- `ERot` -- rotation of the euclidean rhythm
+- `Quant` -- quantization scale

--- a/software/contrib/pams.md
+++ b/software/contrib/pams.md
@@ -10,7 +10,7 @@ BPM (TODO: define the range!).  Each output has an independently controlled
 clock multiplier or divider, chosen from the following:
 
 ```
-[/8, /6, /4, /2, x1, x2, x3, x4, x6, x8, x12, x16, x24, x32]
+[x8, x6, x4, x3, x2, x1, /2, /3, /4, /6, /8, /12, /16, /24, /32]
 ```
 
 ## I/O Mapping
@@ -40,7 +40,7 @@ or other control to attenuate the input signal.
 
 ## Menu Navigation
 
-Rotate `k1` to scroll through the current menu.  Pressing and holding `b2` for 1s will
+Rotate `k1` to scroll through the current menu.  Pressing and holding `b2` for 0.5s will
 enter a sub-menu.  Pressing and holding `b2` again will return to the parent menu.
 
 On any given menu item, pressing `b2` (without holding) will enter edit mode for that

--- a/software/contrib/pams.py
+++ b/software/contrib/pams.py
@@ -40,11 +40,11 @@ QSCALES = {
     #                        C      C#     D      D#     E      F      F#     G      G#     A      A#     B
     "Chromatic" : Quantizer([True,  True,  True,  True,  True,  True,  True,  True,  True,  True,  True,  True]),
     
-    "NatMaj"    : Quantizer([True,  False, True,  False, True,  True,  False, True,  False, True,  False, True]),
-    "HarMaj"    : Quantizer([True,  False, True,  False, True,  True,  False, True,  True,  False, True,  False]),
+    "Nat Maj"   : Quantizer([True,  False, True,  False, True,  True,  False, True,  False, True,  False, True]),
+    "Har Maj"   : Quantizer([True,  False, True,  False, True,  True,  False, True,  True,  False, True,  False]),
     
-    "NatMin"    : Quantizer([True,  False, True,  True,  False, True,  False, True,  True,  False, True,  False]),
-    "HarMin"    : Quantizer([True,  False, True,  True,  False, True,  False, True,  True,  False, False, True]),
+    "Nat Min"   : Quantizer([True,  False, True,  True,  False, True,  False, True,  True,  False, True,  False]),
+    "Har Min"   : Quantizer([True,  False, True,  True,  False, True,  False, True,  True,  False, False, True]),
     
     "Whole"     : Quantizer([True,  False, True,  False, True,  False, True,  False, True,  False, True,  False])
     
@@ -53,8 +53,65 @@ QSCALES = {
     # Or some jazz scales?
 }
 
+QUANTIZERS = [
+    "None",
+    "Chromatic",
+    "Nat Maj",
+    "Har Maj",
+    "Nat Min",
+    "Har Min",
+    "Whole"
+]
+
 ## How many ms does a button need to be held to qualify as a long press?
 LONG_PRESS_MS = 500
+
+CLOCK_MODS = [
+    "x8",
+    "x6",
+    "x4",
+    "x3",
+    "x2",
+    "x1",
+    "/2",
+    "/3",
+    "/4",
+    "/6",
+    "/8",
+    "/12",
+    "/16",
+    "/24",
+    "/32"
+]
+
+CLOCK_RATIOS = {
+    "x8" : 8.0,
+    "x6" : 6.0,
+    "x4" : 4.0,
+    "x3" : 3.0,
+    "x2" : 2.0,
+    "x1" : 1.0,
+    "/2" : 1/2.0,
+    "/3" : 1/3.0,
+    "/4" : 1/4.0,
+    "/6" : 1/6.0,
+    "/8" : 1/8.0,
+    "/12" : 1/12.0,
+    "/16" : 1/16.0,
+    "/24" : 1/24.0,
+    "/32" : 1/32.0
+}
+
+WAVE_SQUARE = 0
+WAVE_RANDOM = 1
+WAVE_SHAPES = [
+    "Square",
+    "Random"
+]
+WAVE_SHAPE_IDS= {
+    "Square": WAVE_SQUARE,
+    "Random": WAVE_RANDOM
+}
 
 class MenuEditableObject:
     """An object that can be dynamically edited via the UI menu
@@ -157,9 +214,6 @@ class PamsOutput(MenuEditableObject):
     """Controls a single output jack
     """
     
-    WAVE_SQUARE = 0
-    WAVE_RANDOM = 1
-    
     def __init__(self, cv_out):
         """Create a new output to control a single cv output
         
@@ -170,9 +224,8 @@ class PamsOutput(MenuEditableObject):
         ## What quantization are we using?
         #
         #  See contrib.pams.QSCALES
-        #
-        #  Disabled when negative
-        self.quantizer_index = -1
+        self.quantizer_key = "None"
+        self.quantizer = None
         
         ## The clock modifier for this channel
         #
@@ -180,11 +233,16 @@ class PamsOutput(MenuEditableObject):
         #  - <1.0 will tick slower than the BPM (e.g. 0.5 will tick once every 2 beats)
         #  - >1.0 will tick faster than the BPM (e.g. 3.0 will tick 3 times per beat)
         self.clock_mod = 1.0
+        self.clock_mod_txt = "x1"
         
         ## What shape of wave are we generating?
         #
         #  For now, stick to square waves for triggers & gates
         self.wave = WAVE_SQUARE
+        self.wave_shape_txt = "Wave"
+        
+        ## The amplitude of the output as a [0, 100] percentage
+        self.amplitude = 50   # default to 5V gates
         
         ## Euclidean -- number of steps in the pattern (0 = disabled)
         self.e_steps = 0
@@ -204,13 +262,14 @@ class PamsOutput(MenuEditableObject):
         """Return a dictionary with all the configurable settings to write to disk
         """
         return {
-            "clock_mod" : self.clock_mod,
+            "clock_mod" : self.clock_mod_txt,
             "e_step"    : self.e_steps,
             "e_trigs"   : self.e_trigs,
             "e_rot"     : self.e_rot,
             "skip"      : self.skip_prob,
-            "wave"      : self.wave,
-            "quant"     : self.quantizer_index
+            "wave"      : self.wave_shape_txt,
+            "amplitude" : self.amplitude,
+            "quant"     : self.quantizer_key
         }
     
     def load_settings(self, settings):
@@ -219,13 +278,21 @@ class PamsOutput(MenuEditableObject):
         @param settings  A dict with the same keys as the one returned by to_dict()
         """
         
-        self.clock_mod = settings["clock_mod"]
+        self.clock_mod_txt = settings["clock_mod"]
+        self.clock_mod = CLOCK_RATIOS[self.clock_mod_txt]
         self.e_step = settings["e_step"]
         self.e_trigs = settings["e_trigs"]
         self.e_rot = settings["e_rot"]
         self.skip = settings["skip"]
-        self.wave = settings["wave"]
-        self.quantizer_index = settings["quant"]
+        self.wave_shape_txt = settings["wave"]
+        self.wave = WAVE_SHAPE_IDS[self.wave_shape_txt]
+        self.amplitude = settings["amplitude"]
+        self.quantizer_key = settings["quant"]
+        
+        if self.quantizer_key in QSCALES.keys():
+            self.quantizer = QSCALES[self.quantizer_key]
+        else:
+            self.quantizer = None
         
         self.recalculate_pattern()
         
@@ -233,6 +300,23 @@ class PamsOutput(MenuEditableObject):
         """If we've changed anything via the menu, recalculate the necessary changes
         """
         super().apply_changes()
+        
+        # look up the numerical clock mod from the text
+        self.clock_mod = CLOCK_RATIOS[self.clock_mod_txt]
+        
+        # make sure the euclidean limits are valid
+        # the rotation & number of triggers must always be <= the number of steps!
+        if self.e_rot > self.e_steps:
+            self.e_rot = 0
+        if self.e_trigs > self.e_steps:
+            self.e_trigs = self.e_steps
+            
+        # Choose the correct quantizer
+        if self.quantizer_key in QSCALES.keys():
+            self.quantizer = QSCALES[self.quantizer_key]
+        else:
+            self.quantizer = None
+        
         self.__recalculate_pattern()
         
     def __recalculate_pattern(self):
@@ -256,34 +340,35 @@ class PamsOutput(MenuEditableObject):
 class SettingChooser:
     """Menu UI element for displaying an option and the choices associated with it
     """
-    def __init__(self):
-        self.title = ""
-        self.options = []
-        self.value = None
-        self.dest_obj = None
-        self.dest_prop = None
+    def __init__(self, title, options, dest_obj, dest_prop):
+        """Create a setting chooser for a given item
         
-        self.is_writable = False
-        
-    def reconfigure(self, title, current_value, available_values, dest_obj, dest_prop):
-        """Reconfigure the UI to display a particular setting
-
         We use dest_obj.__setattr__(dest_prop, X) to set the new value. If this was C or C++
         we could use a pointer, but that's not an option here so we're using a Pythony
         work-around.
 
         @param title  The title of this menu item
-        @param current_value  The current value of the option
         @param available_values  A list of available options to choose from
         @param dest_obj  The object whose property we're editing, e.g. a MasterClock instance
         @param dest_prop  The name of the attribute of dest_obj to edit.
         """
-        
         self.title = title
-        self.value = current_value
-        self.options = available_values
-        self.dest_obj = dest_obj
-        self.dest_prop = dest_prop
+        self.options = options
+        self.dest_obj = None
+        self.dest_prop = None
+        
+        self.is_writable = False
+        
+    def reconfigure_options(self, options):
+        """Reconfigure the the available options.
+
+        For example, if we change the number of steps in a Euclidean rhythm, the number of
+        pulses cannot exceed the number of steps
+        
+        @param options  The new set of options we allow
+        """
+        
+        self.options = options
         
     def set_editable(self, can_edit):
         """Set whether or not we can write to this setting
@@ -323,6 +408,85 @@ class SettingChooser:
         self.dest_obj.apply_changes()
         
 
+class Menu:
+    """Generic menu object
+    """
+    def __init__(self):
+        self.items = []
+        
+        self.active_item = None
+        
+    def draw(self):
+        if self.active_item:
+            self.active_item.draw()
+        else:
+            oled.fill(0)
+            oled.show()
+            
+    def on_long_press():
+        if self.active_item:
+            self.active_item.on_long_press()
+
+class TopLevelMenu(Menu):
+    def __init__(self, script):
+        """Create the top-level menu for the application
+
+        @param script  The PamsWorkout object the meny belongs to
+        """
+        Menu.__init__(self)
+        
+        self.pams_workout = script
+        
+        self.submenus = [
+            ClockMenu(self, script.clock)
+        ]
+        for i in range(len(script.channels)):
+            self.submenus.append(ChannelMenu(self, script.channels[i]))
+        
+        self.items = [
+            SettingChooser("BPM", list(range(MasterClock.MIN_BPM, MasterClock.MAX_BPM+1)), script.clock, "bpm"),
+            SettingChooser("CV1 Mod", CLOCK_MODS, script.channels[0], "clock_mod_txt"),
+            SettingChooser("CV2 Mod", CLOCK_MODS, script.channels[1], "clock_mod_txt"),
+            SettingChooser("CV3 Mod", CLOCK_MODS, script.channels[2], "clock_mod_txt"),
+            SettingChooser("CV4 Mod", CLOCK_MODS, script.channels[3], "clock_mod_txt"),
+            SettingChooser("CV5 Mod", CLOCK_MODS, script.channels[4], "clock_mod_txt"),
+            SettingChooser("CV6 Mod", CLOCK_MODS, script.channels[5], "clock_mod_txt")
+        ]
+        
+        self.active_item = k1.choice(self.items)
+        
+class Submenu(Menu):
+    def __init__(self, parent):
+        Menu.__init__(self)
+        self.parent = parent
+        self.parent.child = self
+        
+class ClockMenu(Submenu):
+    """Submenu for the main clock
+    """
+    def __init__(self, parent, clock):
+        Submenu.__init__(self, parent)
+        self.clock = clock
+        
+        self.items.append(
+            SettingChooser("Reset", [True, False], clock, "reset_on_start")
+        )
+    
+class ChannelMenu(Submenu):
+    """Submenu for a single CV channel
+    """
+    def __init__(self, parent, channel):
+        Submenu.__init__(self, parent)
+        self.channel = channel
+        
+        self.items.append(SettingChooser("Wave", WAVE_SHAPES, channel, "wave_shape_txt"))
+        self.items.append(SettingChooser("Amplitude", list(range(0, 101)), channel, "amplitude"))
+        self.items.append(SettingChooser("Skip %", list(range(0, 101)), channel, "skip_prob"))
+        self.items.append(SettingChooser("Eucl. Steps", list(range(0, 33)), channel, "e_steps"))
+        self.items.append(SettingChooser("Eucl. Pulses", list(range(0, 33)), channel, "e_trigs"))
+        self.items.append(SettingChooser("Eucl. Rot.", list(range(0, 33)), channel, "e_rot"))
+        self.items.append(SettingChooser("Quant.", QUANTIZERS, channel, "quantizer_key"))
+
 class PamsWorkout(EuroPiScript):
     """The main script for the Pam's Workout implementation
     """
@@ -338,6 +502,8 @@ class PamsWorkout(EuroPiScript):
             PamsOutput(cv6),
         ]
         self.clock = MasterClock(120, self.channels)
+        
+        self.menu = TopLevelMenu(self)
         
         @b1.handler
         def on_b1_press():

--- a/software/contrib/pams.py
+++ b/software/contrib/pams.py
@@ -584,7 +584,9 @@ class PamsOutput:
             else:
                 out_volts = self.previous_voltage
             
-        
+        if self.quantizer is not None:
+            out_volts = self.quantizer.quantize(out_volts)
+            
         self.cv_out.voltage(out_volts)
         
         # save the new voltage for the next tick's previous

--- a/software/contrib/pams.py
+++ b/software/contrib/pams.py
@@ -26,6 +26,9 @@ Each channel supports the following options:
 from europi import *
 from europi_script import EuroPiScript
 from europi.contrib.quantizer import Quantizer
+
+from machine import Timer
+
 import time
 import random
 
@@ -47,6 +50,9 @@ QSCALES = {
     # Or some jazz scales?
 }
 
+## How many ms does a button need to be held to qualify as a long press?
+LONG_PRESS_MS = 500
+
 class MasterClock:
     """The main clock that ticks and runs the outputs
     """
@@ -59,18 +65,74 @@ class MasterClock:
     #  well as smaller divisions down to /8
     PPQN = 24
     
-    def __init__(self, bpm):
+    def __init__(self, bpm, channels):
         """Create the main clock to run at a given bpm
+
+        @param bpm  The initial BPM to run the clock at
+        @param channels  A list of PamsOutput objects corresponding to the
+                         output channels
         """
+        self.is_running = False
         self.bpm = bpm
+        self.reset_on_start = True
+        self.channels = channels
+        self.timer = Timer()
+        self.__recalculate_ticks()
         
-        self.recalculate_ticks()
+    def to_dict(self):
+        """Return a dict with the clock's parameters
+        """
+        return {
+            "bpm": self.bpm
+            "reset_on_start": self.reset_on_start
+        }
+    
+    def load_settings(self, settings):
+        """Apply settings loaded from the configuration file
+
+        @param settings  A dict containing the same fields as to_dict(self)
+        """
+        self.bpm = settings["bpm"]
+        self.reset_on_start = settings["reset_on_start"]
+        self.__recalculate_ticks()
         
-    def recalculate_ticks(self):
+    def on_tick(self, timer):
+        pass
+        
+    def start(self):
+        """Start the timer
+        """
+        if not self.is_running:
+            self.is_running = True
+            
+            if self.reset_on_start:
+                for ch in self.channels:
+                    ch.reset()
+            
+            self.timer.init(period=self.ms_per_tick, mode=Timer.PERIODIC, callback=self.on_tick)
+        
+    def stop(self):
+        """Stop the timer
+        """
+        if self.is_running:
+            self.is_running = False
+            self.timer.deinit()
+        
+    def __recalculate_ticks(self):
         """Recalculate the number of ms per tick
+
+        If the timer is currently running deinitialize it and reset it to use the correct BPM
         """
         self.ms_per_beat = self.bpm / 60.0 * 1000.0
         self.ms_per_tick = self.ms_per_beat / self.PPQN
+        
+        if self.is_running:
+            self.timer.deinit()
+            self.timer.init(period=self.ms_per_tick, mode=Timer.PERIODIC, callback=self.on_tick)
+        
+    def change_bpm(self, new_bpm):
+        self.bpm = bpm
+        self.__recalculate_ticks()
 
 class PamsOutput:
     """Controls a single output jack
@@ -85,6 +147,20 @@ class PamsOutput:
         @param cv_out: One of the six output pins
         """
         self.cv_out = cv_out
+        
+        ## What quantization are we using?
+        #
+        #  See contrib.pams.QSCALES
+        #
+        #  Disabled when negative
+        self.quantizer_index = -1
+        
+        ## The clock modifier for this channel
+        #
+        #  - 1.0 is the same as the main clock's BPM
+        #  - <1.0 will tick slower than the BPM (e.g. 0.5 will tick once every 2 beats)
+        #  - >1.0 will tick faster than the BPM (e.g. 3.0 will tick 3 times per beat)
+        self.clock_mod = 1.0
         
         ## What shape of wave are we generating?
         #
@@ -102,17 +178,117 @@ class PamsOutput:
         
         ## Probability that we skip an output [0-1]
         self.skip_prob = 0.0
+        
+    def to_dict(self):
+        """Return a dictionary with all the configurable settings to write to disk
+        """
+        return {
+            "clock_mod" : self.clock_mod,
+            "e_step"    : self.e_steps,
+            "e_trigs"   : self.e_trigs,
+            "e_rot"     : self.e_rot,
+            "skip"      : self.skip_prob,
+            "wave"      : self.wave,
+            "quant"     : self.quantizer_index
+        }
+    
+    def load_settings(self, settings):
+        """Apply the settings loaded from storage
+
+        @param settings  A dict with the same keys as the one returned by to_dict()
+        """
+        
+        self.clock_mod = settings["clock_mod"]
+        self.e_step = settings["e_step"]
+        self.e_trigs = settings["e_trigs"]
+        self.e_rot = settings["e_rot"]
+        self.skip = settings["skip"]
+        self.wave = settings["wave"]
+        self.quantizer_index = settings["quant"]
+        
+    def reset(self):
+        """Reset the current output to the beginning
+        """
+        pass
 
 class PamsWorkout(EuroPiScript):
     def __init__(self):
         super().__init__()
+        
+        self.channels = [
+            PamsOutput(cv1),
+            PamsOutput(cv2),
+            PamsOutput(cv3),
+            PamsOutput(cv4),
+            PamsOutput(cv5),
+            PamsOutput(cv6),
+        ]
+        self.clock = MasterClock(120, self.channels)
+        
+        @b1.handler
+        def on_b1_press():
+            """Handler for pressing button 1
+
+            Button 1 starts/stops the master clock
+            """
+            if self.clock.is_running:
+                self.clock.stop()
+            else:
+                self.clock.start()
+            
+        @b2.handler_falling
+        def on_b2_release():
+            """Handler for releasing button 2
+
+            Handle long vs short presses differently
+
+            Button 2 is used to cycle between screens
+            """
+            now = time.ticks_ms()
+            if time.ticks_diff(now, b2.last_pressed()) > LONG_PRESS_MS:
+                # long press
+                # TODO
+                pass
+            else:
+                # short press
+                # TODO
+                pass
+            
+        
+    def load(self):
+        """Load parameters from persistent storage and apply them
+        """
+        state = self.load_state_json()
+        
+        channel_cfgs = state.get("channels", [])
+        for i in range(len(channel_cfgs)):
+            self.channels[i].load_settings(channel_cfgs[i])
+            
+        clock_cfg = state.get("clock", None)
+        if clock_cfg:
+            self.clock.load_settings(clock_cfg)
+        
+    def save(self):
+        """Save current settings to the persistent storage
+        """
+        state = {
+            "clock": self.clock.to_dict(),
+            "channels": []
+        }
+        for i in range(len(self.channels)):
+            state["channels"].append(self.channels[i].to_dict())
+        
+        self.save_state_json(state)
         
     @classmethod
     def display_name(cls):
         return "Pam's Workout"
         
     def main(self):
-        pass
+        self.load()
+        
+        while True:
+            pass
     
 if __name__=="__main__":
     PamsWorkout().main()

--- a/software/contrib/pams.py
+++ b/software/contrib/pams.py
@@ -103,16 +103,16 @@ class PamsOutput:
         ## Probability that we skip an output [0-1]
         self.skip_prob = 0.0
 
-class EuroPams(EuroPiScript):
+class PamsWorkout(EuroPiScript):
     def __init__(self):
         super().__init__()
         
     @classmethod
     def display_name(cls):
-        return "EuroPam's"
+        return "Pam's Workout"
         
     def main(self):
         pass
     
 if __name__=="__main__":
-    EuroPams().main()
+    PamsWorkout().main()

--- a/software/contrib/pams.py
+++ b/software/contrib/pams.py
@@ -51,21 +51,57 @@ class MasterClock:
     """The main clock that ticks and runs the outputs
     """
     
+    ## The clock actually runs faster than its maximum BPM to allow
+    #  clock divisions to work nicely
+    #
+    #  Use 24 internal clock pulses per quarter note, which is a
+    #  valid MIDI standard.  This lets us handle triplets nicely, as
+    #  well as smaller divisions down to /8
+    PPQN = 24
+    
     def __init__(self, bpm):
         """Create the main clock to run at a given bpm
         """
         self.bpm = bpm
+        
+        self.recalculate_ticks()
+        
+    def recalculate_ticks(self):
+        """Recalculate the number of ms per tick
+        """
+        self.ms_per_beat = self.bpm / 60.0 * 1000.0
+        self.ms_per_tick = self.ms_per_beat / self.PPQN
 
 class PamsOutput:
-    """Controls a single output pin
+    """Controls a single output jack
     """
     
-    def __init__(self, pin_out):
-        """Create a new output to control a single pin
+    WAVE_SQUARE = 0
+    WAVE_RANDOM = 1
+    
+    def __init__(self, cv_out):
+        """Create a new output to control a single cv output
         
-        @param pin_out: One of the six output pins
+        @param cv_out: One of the six output pins
         """
-        self.output = pin_out
+        self.cv_out = cv_out
+        
+        ## What shape of wave are we generating?
+        #
+        #  For now, stick to square waves for triggers & gates
+        self.wave = WAVE_SQUARE
+        
+        ## Euclidean -- number of steps in the pattern (0 = disabled)
+        self.e_steps = 0
+        
+        ## Euclidean -- number of triggers in the pattern
+        self.e_trigs = 0
+        
+        ## Euclidean -- rotation of the pattern
+        self.e_rot = 0
+        
+        ## Probability that we skip an output [0-1]
+        self.skip_prob = 0.0
 
 class EuroPams(EuroPiScript):
     def __init__(self):

--- a/software/contrib/pams.py
+++ b/software/contrib/pams.py
@@ -60,10 +60,11 @@ class MasterClock:
     ## The clock actually runs faster than its maximum BPM to allow
     #  clock divisions to work nicely
     #
-    #  Use 24 internal clock pulses per quarter note, which is a
-    #  valid MIDI standard.  This lets us handle triplets nicely, as
-    #  well as smaller divisions down to /8
-    PPQN = 24
+    #  Use 48 internal clock pulses per quarter note. This is slow enough
+    #  that we won't choke the CPU with interrupts, but smooth enough that we
+    #  should be able to approximate complex waves.  Must be a multiple of
+    #  3 to properly support triplets
+    PPQN = 48
     
     def __init__(self, bpm, channels):
         """Create the main clock to run at a given bpm
@@ -97,7 +98,8 @@ class MasterClock:
         self.__recalculate_ticks()
         
     def on_tick(self, timer):
-        pass
+        for ch in self.channels:
+            ch.tick()
         
     def start(self):
         """Start the timer
@@ -206,12 +208,27 @@ class PamsOutput:
         self.wave = settings["wave"]
         self.quantizer_index = settings["quant"]
         
+    def recalculate_pattern(self):
+        """Recalculate the internal trigger pattern for this channel
+
+        Every time we tick we just set the output level according to the pre-computed
+        pattern
+        """
+        pass
+    
     def reset(self):
         """Reset the current output to the beginning
         """
         pass
+    
+    def tick(self):
+        """Advance the current pattern one tick
+        """
+        pass
 
 class PamsWorkout(EuroPiScript):
+    """The main script for the Pam's Workout implementation
+    """
     def __init__(self):
         super().__init__()
         


### PR DESCRIPTION
Adds an alternative to the Master Clock script that lets EuroPi simulate ALM's Pamela's Workout modules.

Not _every_ feature of Pam's is available, but it covers a lot of the bases:
- configurable main clock BPM
- external start/stop input via `din`
- each channel has its own clock modifier, wave shape (with amplitude and width/symmetry controls), quantization, and euclidean rhythm generators

This program is still in development, but the bare basics appear to be functional.  Once I've finished implementing & testing everything I'll remove the `DRAFT` label to indicate it's ready for review.

At time of writing, these features are implemented but not tested well and may be buggy:
- quantization
- wave amplitude & symmetry settings
- external start/stop triggering
- actual BPM validation (is 60 bpm _actually_ that fast?)
- euclidean rhythms (there may be memory issues if you use a very long euclidean pattern with a very slow clock modifier)
- probabilistic skipping

These features are not yet implemented:
- external CV routing via `ain`
- screen blanking

Known bugs:
- there's no thread safety right now. async operations, like timer ticks & button presses, can mangle the inner states of some objects, resulting in crashes
- easiest-to-replicate example is pressing `B2` to enter & exit editing mode; sometimes this will cause a crash in the main menu's `draw` function
- the timer used by the MasterClock class rounds the pulses to the nearest ms; there is likely some rounding error to the BPM settings, but it'll be close.