### PR TITLE
Fix ain.choice and ain.range

### DIFF
--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -218,6 +218,9 @@ class AnalogueInput(AnalogueReader):
             INPUT_CALIBRATION_VALUES[-1] - INPUT_CALIBRATION_VALUES[0],
         )
         value = reading / max_value
+        dz = self._deadzone
+        if deadzone is not None:
+        deadzonesdz = deadzone
         value = value * (1.0 + 2.0 * dz) - dz
         return clamp(value, 0.0, 1.0)
 

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -220,7 +220,7 @@ class AnalogueInput(AnalogueReader):
         value = reading / max_value
         dz = self._deadzone
         if deadzone is not None:
-        deadzonesdz = deadzone
+            dz = deadzone
         value = value * (1.0 + 2.0 * dz) - dz
         return clamp(value, 0.0, 1.0)
 

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -209,7 +209,7 @@ class AnalogueInput(AnalogueReader):
                 )
         self._gradients.append(self._gradients[-1])
 
-    def percent(self, samples=None):
+    def percent(self, samples=None, deadzone=None):
         """Current voltage as a relative percentage of the component's range."""
         # Determine the percent value from the max calibration value.
         reading = self._sample_adc(samples) - INPUT_CALIBRATION_VALUES[0]
@@ -217,7 +217,9 @@ class AnalogueInput(AnalogueReader):
             reading,
             INPUT_CALIBRATION_VALUES[-1] - INPUT_CALIBRATION_VALUES[0],
         )
-        return max(reading / max_value, 0.0)
+        value = reading / max_value
+        value = value * (1.0 + 2.0 * dz) - dz
+        return clamp(value, 0.0, 1.0)
 
     def read_voltage(self, samples=None):
         raw_reading = self._sample_adc(samples)


### PR DESCRIPTION
As mentioned by chrisib on discord ain.choice was throwing a bug after the deadzones where added to Knobs, since ain.percent doesn't have a deadzone parameter.
The same issue should be present for ain.range.
This should fix the issue by adding the deadzones to ain.percent (but they should be 0 for ain in most cases).