### PR TITLE
Add Mouser link for buttons on the BOM

### DIFF
--- a/hardware/EuroPi/bill_of_materials.md
+++ b/hardware/EuroPi/bill_of_materials.md
@@ -19,7 +19,7 @@ Please note that a few of these are multi-packs of components, and there may wel
 | D1 - D4 | 4 | 1N5817 | Schottky Diode | [CPC](https://cpc.farnell.com/multicomp-pro/1n5817/schottky-rectifier-1a-20v-do-204al/dp/SC15528)
 | LED1 - LED6 | 6 | L-424HDT | 3mm LED | [CPC](https://cpc.farnell.com/kingbright/l-424hdt/led-flat-top-3mm-red/dp/SC11541)
 | VR1 - VR2 | 2 | 10k | 10 Kiloohm Linear Rotary Potentiometer | [CPC](https://cpc.farnell.com/alps/rk09k11310kb/potentiometer-10k-lin/dp/RE04560), [Thonk](https://www.thonk.co.uk/shop/alpha-9mm-pots-vertical-t18/) (B10K - T18 Shaft - Alpha Vertical Potentiometer)
-| SW1 - SW2 | 2 | D6R00 F1 LFS | C&K Tactile Switch (Non-Illuminated) | [Thonk](https://www.thonk.co.uk/shop/radio-music-switch/)
+| SW1 - SW2 | 2 | D6RXX F1 LFS | C&K Tactile Switch (Non-Illuminated) | [Thonk](https://www.thonk.co.uk/shop/radio-music-switch/), [Mouser (Black)](https://www.mouser.co.uk/ProductDetail/CK/D6R90F1LFS?qs=WS%2FiepCTwPDejJXcQ7Ir1g%3D%3D&countrycode=US&currencycode=USD)
 | OLED1 | 1 | 0.91" SSD1306 | I2C OLED Display | [CPC](https://cpc.farnell.com/winstar/wea012832fwpp3n00000/oled-display-128x32-white-i2c/dp/SC15661), [The Pi Hut](https://thepihut.com/products/0-91-oled-display-module)
 | J1 - J8 | 8 | PJ398SM | Thonkiconn 3.5mm Mono Jack | [Thonk](https://www.thonk.co.uk/shop/thonkiconn/), [Banananuts](https://www.thonk.co.uk/shop/bananuts/), [Cosmonuts](https://www.thonk.co.uk/shop/cosmonuts/)
 | CONN0 | 2 (pairs) | 20x1 2.54mm | Pico Connection Header (Male + Female) | [Male](https://cpc.farnell.com/harwin/m22-2012005/header-vertical-1row-20way/dp/CN14644), [Female](https://cpc.farnell.com/multicomp/2212s-20sg-85/socket-pcb-1-row-20way/dp/CN14539)


### PR DESCRIPTION
Add Mouser link for the buttons on the bom.
Also change part number to have Xs instead of 00, as those 2 digits only specify the colour