### PR TITLE
Add envelope generator script

### DIFF
--- a/software/contrib/README.md
+++ b/software/contrib/README.md
@@ -30,6 +30,13 @@ Recording of CV can be primed so that you can record a movement without missing 
 <i>Author: [anselln](https://github.com/anselln)</i>
 <br><i>Labels: sequencer, CV, performance</i>
 
+### Envelope Generator \[ documentation](/software/contrib/envelope_generator.md) | [script](/software/contrib/envelope_generator.py) \]
+An attack release envelope with optional sustain and looping functionality.
+Envelopes are triggered or gated by the digital input, and the envelope is output, along with a copy of the digital input and an inverted copy of the envelope.
+
+<i>Author: [roryjamesallen](https://github.com/roryjamesallen)</i>
+<br><i>Labels: Envelope Generator</i>
+
 ### Euclid \[ [documentation](/software/contrib/euclid.md) | [script](/software/contrib/euclid.py) \]
 Euclidean rhythm generator. Each channel can generate an independent euclidean rhythm.
 

--- a/software/contrib/envelope_generator.md
+++ b/software/contrib/envelope_generator.md
@@ -1,4 +1,4 @@
-# Diagnostic
+# Envelope Generator
 
 author: Rory Allen
 

--- a/software/contrib/envelope_generator.md
+++ b/software/contrib/envelope_generator.md
@@ -1,0 +1,20 @@
+# Diagnostic
+
+author: Rory Allen
+
+date: 2023-04-11
+
+labels: utility
+
+A simple one channel envelope generator with exponential attack and decay, sustain option, and looping capability
+
+Inputs and Outputs:
+- **digital in:** trigger an envelope
+- **analog in:** added to knob 2 to determine fall time
+- **button 1:** change sustain mode between AR (Attack Release) and ASR (Attack Sustain Release)
+- **button 2:** change looping mode between Once and Loop (Loop mode overrides sustain mode to AR)
+- **knob 1:** rise time
+- **knob 2:** fall time
+- **cv 1:** a copy of the digital input
+- **cv 2:** the generated envelope
+- **cv 3:** the inversion of the generated envelope

--- a/software/contrib/envelope_generator.py
+++ b/software/contrib/envelope_generator.py
@@ -35,7 +35,7 @@ class EnvelopeGenerator(EuroPiScript):
 
         self.envelope_display_bounds = [0, 0, int(OLED_WIDTH), int(OLED_HEIGHT / 2)]
         
-        self.direction = 3
+        self.direction = 3  # Rising = 1, Falling = 0, Sustain = 3
         self.envelope_value = 0
         
         self.envelope_out = cv2

--- a/software/contrib/envelope_generator.py
+++ b/software/contrib/envelope_generator.py
@@ -25,7 +25,7 @@ class EnvelopeGenerator(EuroPiScript):
         
         self.log_multiplier = OLED_HEIGHT / log(OLED_HEIGHT)
         
-        self.envelope_display_bounds = [0, 0, int(OLED_WIDTH / 1.7), int(OLED_HEIGHT / 2)]
+        self.envelope_display_bounds = [0, 0, int(OLED_WIDTH), int(OLED_HEIGHT / 2)]
         
         self.sustain_mode = 0	#0 is attack release (no sustain), 1 is attack sustain release
         self.looping_mode = 0
@@ -104,13 +104,13 @@ class EnvelopeGenerator(EuroPiScript):
     def update_display(self):
         if ticks_ms() - self.last_refreshed_display >= 30:
             
-            oled.rect(self.envelope_display_bounds[0], self.envelope_display_bounds[1], self.envelope_display_bounds[2], self.envelope_display_bounds[3], 1)
+            oled.hline(self.envelope_display_bounds[0], self.envelope_display_bounds[3], self.envelope_display_bounds[2], 1)
             
             try:
                 rise_width = (self.increment_factor[0] - 1) / ((self.increment_factor[0] - 1) + (self.increment_factor[1] - 1))
-                rise_width_pixels = int(rise_width * self.envelope_display_bounds[2]) - 1
+                rise_width_pixels = int(rise_width * self.envelope_display_bounds[2])
                 oled.line(self.envelope_display_bounds[0], (self.envelope_display_bounds[3] - 1), rise_width_pixels, self.envelope_display_bounds[1], 1)
-                oled.line(rise_width_pixels, self.envelope_display_bounds[1], (self.envelope_display_bounds[2] - 1), (self.envelope_display_bounds[3] - 1), 1)
+                oled.line((rise_width_pixels - 1), self.envelope_display_bounds[1], (self.envelope_display_bounds[2] - 1), (self.envelope_display_bounds[3] - 1), 1)
                 
                 current_envelope_position = 0
                 if self.direction == 1 or self.direction == 3:
@@ -138,13 +138,13 @@ class EnvelopeGenerator(EuroPiScript):
                 sustain_mode_text = 'ar'
             else:
                 sustain_mode_text = 'asr'
-            oled.text(sustain_mode_text, 80, -2, 1)
+            oled.text(sustain_mode_text, 42, 20, 1)
             
             if self.looping_mode == 0:
                 looping_mode_text = 'once'
             else:
                 looping_mode_text = 'loop'
-            oled.text(looping_mode_text, 80, 9, 1)
+            oled.text(looping_mode_text, 80, 20, 1)
             
             oled.show()
             oled.fill(0)

--- a/software/contrib/envelope_generator.py
+++ b/software/contrib/envelope_generator.py
@@ -2,7 +2,7 @@ from time import sleep
 from europi import oled, din, cv1, cv2, cv3, k1, k2, b1, b2, ain, OLED_WIDTH, OLED_HEIGHT
 from europi_script import EuroPiScript
 
-from time import sleep_ms, ticks_ms
+from time import sleep_ms, ticks_ms, ticks_diff
 from math import log
 
 

--- a/software/contrib/envelope_generator.py
+++ b/software/contrib/envelope_generator.py
@@ -185,14 +185,14 @@ class EnvelopeGenerator(EuroPiScript):
                 sustain_mode_text = 'ar'
             else:
                 sustain_mode_text = 'asr'
-            oled.text(sustain_mode_text, 42, 20, 1)
+            oled.text(sustain_mode_text, 50 + (4 if sustain_mode_text == 'ar' else 0), 20, 1)
             
             #Display current envelope looping mode
             if self.looping_mode == 0:
                 looping_mode_text = 'once'
             else:
                 looping_mode_text = 'loop'
-            oled.text(looping_mode_text, 80, 20, 1)
+            oled.text(looping_mode_text, 94, 20, 1)
             
             oled.show()
             oled.fill(0)

--- a/software/contrib/envelope_generator.py
+++ b/software/contrib/envelope_generator.py
@@ -62,9 +62,13 @@ class EnvelopeGenerator(EuroPiScript):
         
     def change_sustain_mode(self):
         self.sustain_mode = 1 - self.sustain_mode
+        #Save state to file
+        self.save_state()
         
     def change_looping_mode(self):
         self.looping_mode = 1 - self.looping_mode
+        #Save state to file
+        self.save_state()
         
     def copy_digital_input(self):
         self.din_copy_out.value(din.value())
@@ -116,8 +120,6 @@ class EnvelopeGenerator(EuroPiScript):
         
     def update_display(self):
         if ticks_diff(ticks_ms(), self.last_refreshed_display) >= self.display_refresh_rate:
-            #Save state to file
-            self.save_state()
             
             #Draw slope graph axis
             oled.hline(self.envelope_display_bounds[0], self.envelope_display_bounds[3], self.envelope_display_bounds[2], 1)

--- a/software/contrib/envelope_generator.py
+++ b/software/contrib/envelope_generator.py
@@ -115,7 +115,7 @@ class EnvelopeGenerator(EuroPiScript):
         self.envelope_inverted_out.voltage(self.max_output_voltage - self.envelope_value)
         
     def update_display(self):
-        if ticks_ms() - self.last_refreshed_display >= self.display_refresh_rate:
+        if ticks_diff(ticks_ms(), self.last_refreshed_display) >= self.display_refresh_rate:
             #Save state to file
             self.save_state()
             

--- a/software/contrib/envelope_generator.py
+++ b/software/contrib/envelope_generator.py
@@ -25,7 +25,7 @@ class EnvelopeGenerator(EuroPiScript):
         
         self.log_multiplier = OLED_HEIGHT / log(OLED_HEIGHT)
         
-        self.envelope_display_bounds = [0, 0, int(OLED_WIDTH / 3), int(OLED_HEIGHT / 2)]
+        self.envelope_display_bounds = [0, 0, int(OLED_WIDTH / 1.7), int(OLED_HEIGHT / 2)]
         
         self.sustain_mode = 0	#0 is attack release (no sustain), 1 is attack sustain release
         self.looping_mode = 0
@@ -138,13 +138,13 @@ class EnvelopeGenerator(EuroPiScript):
                 sustain_mode_text = 'ar'
             else:
                 sustain_mode_text = 'asr'
-            oled.text(sustain_mode_text, 48, -2, 1)
+            oled.text(sustain_mode_text, 80, -2, 1)
             
             if self.looping_mode == 0:
                 looping_mode_text = 'once'
             else:
                 looping_mode_text = 'loop'
-            oled.text(looping_mode_text, 48, 9, 1)
+            oled.text(looping_mode_text, 80, 9, 1)
             
             oled.show()
             oled.fill(0)

--- a/software/contrib/envelope_generator.py
+++ b/software/contrib/envelope_generator.py
@@ -26,6 +26,9 @@ class EnvelopeGenerator(EuroPiScript):
         #Time in ms between incrementing value of envelope
         self.increment_delay = 1
         
+        #0 will start a new envelope at the current value, 1 will start it from zero
+        self.retrig_mode = 0
+        
         #Display refresh rate in ms
         self.display_refresh_rate = 30
         self.last_refreshed_display = self.display_refresh_rate
@@ -50,6 +53,8 @@ class EnvelopeGenerator(EuroPiScript):
         return "EnvelopeGen"
 
     def receive_trigger_rise(self):
+        if self.retrig_mode == 1:
+            self.envelope_value = 0
         self.direction = 1
     
     def receive_trigger_fall(self):
@@ -68,7 +73,8 @@ class EnvelopeGenerator(EuroPiScript):
         return abs(a - b)
     
     def update_increment_factor(self):
-        self.increment_factor = [(k1.range(self.max_increment_factor, 256) + 1), (k2.range(self.max_increment_factor, 256) + 1 + (ain.percent(256) * self.max_increment_factor))]
+        increment_factor_rising = k1.range(self.max_increment_factor, 512) / 2
+        self.increment_factor = [(increment_factor_rising + 1), (k2.range(self.max_increment_factor, 256) + 1 + (ain.percent(256) * self.max_increment_factor))]
         
     def log(self, number):
         return log(max(number, 1))
@@ -213,3 +219,4 @@ class EnvelopeGenerator(EuroPiScript):
 
 if __name__ == "__main__":
     EnvelopeGenerator().main()
+

--- a/software/contrib/envelope_generator.py
+++ b/software/contrib/envelope_generator.py
@@ -74,7 +74,7 @@ class EnvelopeGenerator(EuroPiScript):
             self.envelope_value += increment
             if self.difference(self.envelope_value, self.max_output_voltage) <= self.voltage_threshold:				#If the threshold is reached
                 self.envelope_value = self.max_output_voltage
-                if self.sustain_mode == 1:																			#If mode uses sustain
+                if self.sustain_mode == 1 and self.looping_mode == 0:												#If mode uses sustain and mode isn't set to looping
                     self.direction = 3																				#Waiting (holding max voltage)
                 else:
                     self.direction = 0

--- a/software/contrib/envelope_generator.py
+++ b/software/contrib/envelope_generator.py
@@ -1,0 +1,174 @@
+from time import sleep
+from europi import oled, din, cv1, cv2, cv3, k1, k2, b1, b2, ain, OLED_WIDTH, OLED_HEIGHT
+from europi_script import EuroPiScript
+
+from time import sleep_ms, ticks_ms
+from math import log
+
+
+class EnvelopeGenerator(EuroPiScript):
+    def __init__(self):
+        super().__init__()
+        state = self.load_state_json()
+
+        self.max_output_voltage = 10
+        self.envelope_value = 0
+        self.direction = 1
+        
+        self.voltage_threshold = 0.1		#Distance of envelope voltage from max voltage/0 before 'jumping' to it - prevents large logarithmic calculations
+        
+        self.max_increment_factor = 256		#Length of the longest envelope (not in any meaningful unit)
+        self.update_increment_factor()
+        self.increment_delay = 1			#Time in ms between incrementing value of envelope
+        
+        self.last_refreshed_display = 30
+        
+        self.log_multiplier = OLED_HEIGHT / log(OLED_HEIGHT)
+        
+        self.envelope_display_bounds = [0, 0, int(OLED_WIDTH / 3), int(OLED_HEIGHT / 2)]
+        
+        self.sustain_mode = 0	#0 is attack release (no sustain), 1 is attack sustain release
+        self.looping_mode = 0
+        
+        self.envelope_out = cv1
+        self.envelope_inverted_out = cv2
+        self.din_copy_out = cv3
+
+        din.handler(self.receive_trigger_rise)
+        din.handler_falling(self.receive_trigger_fall)
+        b1.handler(self.change_sustain_mode)
+        b2.handler(self.change_looping_mode)
+        
+
+    @classmethod
+    def display_name(cls):
+        return "EnvelopeGen"
+
+    def receive_trigger_rise(self):
+        self.direction = 1
+    
+    def receive_trigger_fall(self):
+        self.direction = 0
+        
+    def change_sustain_mode(self):
+        self.sustain_mode = 1 - self.sustain_mode
+        
+    def change_looping_mode(self):
+        self.looping_mode = 1 - self.looping_mode
+        
+    def copy_digital_input(self):
+        self.din_copy_out.value(din.value())
+
+    def difference(self, a, b):
+        return abs(a - b)
+    
+    def update_increment_factor(self):
+        self.increment_factor = [(k1.range(self.max_increment_factor) + 1), (k2.range(self.max_increment_factor) + 1 + (ain.percent(128) * self.max_increment_factor))]
+        
+    def log(self, number):
+        return log(max(number, 1))
+
+    def update_envelope_value(self):
+        if self.direction == 1:																						#If envelope is rising
+            increment = self.difference(self.envelope_value, self.max_output_voltage) / self.increment_factor[0]	#Logarithmic increase
+            self.envelope_value += increment
+            if self.difference(self.envelope_value, self.max_output_voltage) <= self.voltage_threshold:				#If the threshold is reached
+                self.envelope_value = self.max_output_voltage
+                if self.sustain_mode == 1:																			#If mode uses sustain
+                    self.direction = 3																				#Waiting (holding max voltage)
+                else:
+                    self.direction = 0
+                
+            else:
+                sleep_ms(self.increment_delay)																		#Otherwise continute envelope rise
+            
+        elif self.direction == 0:																					#If envelope is falling
+            increment = self.difference(0, self.envelope_value) / self.increment_factor[1]							#Logarithmic decrease
+            self.envelope_value -= increment
+            if self.difference(0, self.envelope_value) <= self.voltage_threshold:									#If the threshold is reached
+                self.envelope_value = 0
+                if self.looping_mode == 0:
+                    self.direction = 3																				#Waiting (holding zero voltage)
+                else:
+                    self.direction = 1
+            else:
+                sleep_ms(self.increment_delay)																		#Otherwise continute envelope rise
+            
+        self.update_output_voltage()
+            
+        
+    def update_output_voltage(self):
+        self.envelope_out.voltage(self.envelope_value)
+        self.envelope_inverted_out.voltage(self.max_output_voltage - self.envelope_value)
+        
+    def update_display(self):
+        if ticks_ms() - self.last_refreshed_display >= 30:
+            
+            oled.rect(self.envelope_display_bounds[0], self.envelope_display_bounds[1], self.envelope_display_bounds[2], self.envelope_display_bounds[3], 1)
+            
+            try:
+                rise_width = (self.increment_factor[0] - 1) / ((self.increment_factor[0] - 1) + (self.increment_factor[1] - 1))
+                rise_width_pixels = int(rise_width * self.envelope_display_bounds[2]) - 1
+                oled.line(self.envelope_display_bounds[0], (self.envelope_display_bounds[3] - 1), rise_width_pixels, self.envelope_display_bounds[1], 1)
+                oled.line(rise_width_pixels, self.envelope_display_bounds[1], (self.envelope_display_bounds[2] - 1), (self.envelope_display_bounds[3] - 1), 1)
+                
+                current_envelope_position = 0
+                if self.direction == 1 or self.direction == 3:
+                    current_envelope_position = int((self.envelope_value / self.max_output_voltage) * rise_width_pixels)
+                elif self.direction == 0:
+                    current_envelope_position = self.envelope_display_bounds[2] - 1 - int((self.envelope_value / self.max_output_voltage) * (self.envelope_display_bounds[2] - rise_width_pixels))
+                oled.vline(current_envelope_position, self.envelope_display_bounds[1], (self.envelope_display_bounds[3] - 1), 1)
+                
+            except ZeroDivisionError:
+                oled.vline(self.envelope_display_bounds[0], self.envelope_display_bounds[1], self.envelope_display_bounds[3], 1)
+                oled.hline(self.envelope_display_bounds[0], self.envelope_display_bounds[1], self.envelope_display_bounds[2], 1)
+                oled.vline(self.envelope_display_bounds[2], self.envelope_display_bounds[1], self.envelope_display_bounds[3], 1)
+            
+            if self.direction == 1:
+                direction_text = 'rise'
+            elif self.direction == 0:
+                direction_text = 'fall'
+            elif self.direction == 3 and self.envelope_value == self.max_output_voltage:
+                direction_text = 'hold'
+            else:
+                direction_text = 'off'
+            oled.text(direction_text, 0, 20, 1)
+            
+            if self.sustain_mode == 0:
+                sustain_mode_text = 'ar'
+            else:
+                sustain_mode_text = 'asr'
+            oled.text(sustain_mode_text, 48, -2, 1)
+            
+            if self.looping_mode == 0:
+                looping_mode_text = 'once'
+            else:
+                looping_mode_text = 'loop'
+            oled.text(looping_mode_text, 48, 9, 1)
+            
+            oled.show()
+            oled.fill(0)
+            self.last_refreshed_display = ticks_ms()
+
+    def save_state(self):
+        """Save the current state variables as JSON."""
+        # Don't save if it has been less than 5 seconds since last save.
+        if self.last_saved() < 5000:
+            return
+
+        state = {
+            #"counter": self.counter,
+            #"enabled": self.enabled,
+        }
+        self.save_state_json(state)
+
+    def main(self):
+        while True:
+            self.copy_digital_input()
+            self.update_display()
+            self.update_increment_factor()
+            self.update_envelope_value()
+            #sleep(1)
+
+if __name__ == "__main__":
+    EnvelopeGenerator().main()

--- a/software/contrib/envelope_generator.py
+++ b/software/contrib/envelope_generator.py
@@ -127,7 +127,12 @@ class EnvelopeGenerator(EuroPiScript):
             oled.vline((self.envelope_display_bounds[2] - 1), self.envelope_display_bounds[1], self.envelope_display_bounds[3], 1)
             
             try:
-                rise_width = (self.increment_factor[0] - 1) / ((self.increment_factor[0] - 1) + (self.increment_factor[1] - 1))
+                rise_width = (self.increment_factor[0] - 1) / ((self.increment_factor[0] - 1) + (self.increment_factor[1] - 1))	#If envelope has zero rise and zero fall this will throw a ZeroDivisonError
+                draw_envelope = True
+            except ZeroDivisionError:
+                draw_envelope = False
+            
+            if draw_envelope == True:
                 rise_width_pixels = int(rise_width * self.envelope_display_bounds[2])
                 fall_width = 1 - rise_width
                 fall_width_pixels = int(self.envelope_display_bounds[2] - rise_width_pixels)
@@ -164,9 +169,7 @@ class EnvelopeGenerator(EuroPiScript):
                 elif self.direction == 0:
                     current_envelope_position = self.envelope_display_bounds[2] - 1 - int((self.envelope_value / self.max_output_voltage) * (self.envelope_display_bounds[2] - rise_width_pixels))
                 oled.vline(current_envelope_position, self.envelope_display_bounds[1], (self.envelope_display_bounds[3] - 1), 1)
-                
-            #If envelope has zero rise and zero fall
-            except ZeroDivisionError:
+            else:
                 oled.vline(self.envelope_display_bounds[0], self.envelope_display_bounds[1], self.envelope_display_bounds[3], 1)
                 oled.hline(self.envelope_display_bounds[0], self.envelope_display_bounds[1], self.envelope_display_bounds[2], 1)
                 oled.vline((self.envelope_display_bounds[2] - 1), self.envelope_display_bounds[1], self.envelope_display_bounds[3], 1)

--- a/software/contrib/menu.py
+++ b/software/contrib/menu.py
@@ -20,7 +20,7 @@ EUROPI_SCRIPTS = [
     "contrib.consequencer.Consequencer",
     "contrib.cvecorder.CVecorder",
     "contrib.diagnostic.Diagnostic",
-    "contrib.envelope_generator.EnvelopeGen"
+    "contrib.envelope_generator.EnvelopeGen",
     "contrib.euclid.EuclideanRhythms",
     "contrib.hamlet.Hamlet",
     "contrib.harmonic_lfos.HarmonicLFOs",

--- a/software/contrib/menu.py
+++ b/software/contrib/menu.py
@@ -20,7 +20,7 @@ EUROPI_SCRIPTS = [
     "contrib.consequencer.Consequencer",
     "contrib.cvecorder.CVecorder",
     "contrib.diagnostic.Diagnostic",
-    "contrib.envelope_generator.EnvelopeGen",
+    "contrib.envelope_generator.EnvelopeGenerator",
     "contrib.euclid.EuclideanRhythms",
     "contrib.hamlet.Hamlet",
     "contrib.harmonic_lfos.HarmonicLFOs",

--- a/software/contrib/menu.py
+++ b/software/contrib/menu.py
@@ -20,6 +20,7 @@ EUROPI_SCRIPTS = [
     "contrib.consequencer.Consequencer",
     "contrib.cvecorder.CVecorder",
     "contrib.diagnostic.Diagnostic",
+    "contrib.envelope_generator.EnvelopeGen"
     "contrib.euclid.EuclideanRhythms",
     "contrib.hamlet.Hamlet",
     "contrib.harmonic_lfos.HarmonicLFOs",


### PR DESCRIPTION
A simple envelope generator script:
din triggers an envelope (and sustains it if on asr mode)
k1 controls rise time
k2 controls fall time
ain is added to k2 to control fall time (i'm planning to allow ain to be routed to other parameters)
b1 changes mode between ar (Attack Release) and asr (Attack Sustain Release)
b2 changes mode between once and looping envelopes

The envelope is displayed as linear (currently) but the actual output is logarithmic, so works well for audio