### PR TITLE
Remove side effecting list comprehensions

### DIFF
--- a/software/contrib/coin_toss.py
+++ b/software/contrib/coin_toss.py
@@ -103,9 +103,11 @@ class CoinToss(EuroPiScript):
 
             sleep_ms(10)
             if self.gate_mode:
+                # Only turn off clock triggers.
                 cv3.off()
                 cv6.off()
             else:
+                # Turn of all cvs in trigger mode.
                 turn_off_all_cvs()
 
             # Draw threshold line

--- a/software/contrib/coin_toss.py
+++ b/software/contrib/coin_toss.py
@@ -29,7 +29,7 @@ class CoinToss(EuroPiScript):
         def toggle_gate():
             """Toggle between gate and trigger mode."""
             self.gate_mode = not self.gate_mode
-            [o.off() for o in cvs]
+            turn_off_all_cvs()
 
     def tempo(self):
         """Read the current tempo set by k1 within set range."""
@@ -54,7 +54,7 @@ class CoinToss(EuroPiScript):
                 if din.value() != self._prev_clock:
                     # We've detected a new clock value.
                     self._prev_clock = 1 if self._prev_clock == 0 else 0
-                    # If the previous value was just set to 1 then we are seeing 
+                    # If the previous value was just set to 1 then we are seeing
                     # a high value for the first time, break wait and return.
                     if self._prev_clock == 1:
                         return
@@ -73,7 +73,7 @@ class CoinToss(EuroPiScript):
             b.value(coin > self.threshold)
         else:
             (a if coin < self.threshold else b).on()
-        
+
         if not draw:
             return
 
@@ -100,14 +100,13 @@ class CoinToss(EuroPiScript):
             if counter % 4 == 0:
                 self.toss(cv4, cv5, False)
                 cv6.on()  # Second column clock trigger (1/4x speed)
-            
+
             sleep_ms(10)
             if self.gate_mode:
-                # Only turn off clock triggers.
-                [o.off() for o in (cv3, cv6)]
+                cv3.off()
+                cv6.off()
             else:
-                # Turn of all cvs in trigger mode.
-                [o.off() for o in cvs]
+                turn_off_all_cvs()
 
             # Draw threshold line
             oled.hline(0, int(self.threshold * OLED_HEIGHT), FRAME_WIDTH, 1)

--- a/software/contrib/consequencer.py
+++ b/software/contrib/consequencer.py
@@ -702,7 +702,7 @@ class pattern:
 
 if __name__ == '__main__':
     # Reset module display state.
-    [cv.off() for cv in cvs]
+    turn_off_all_cvs()
     dm = Consequencer()
     dm.main()
 

--- a/software/contrib/hamlet.py
+++ b/software/contrib/hamlet.py
@@ -353,7 +353,7 @@ class pattern:
 if __name__ == '__main__':
     # Reset module display state.
     oled.fill(0)
-    [cv.off() for cv in cvs]
+    turn_off_all_cvs()
     hm = Hamlet()
     hm.main()
 

--- a/software/contrib/piconacci.py
+++ b/software/contrib/piconacci.py
@@ -109,7 +109,7 @@ class Piconacci(EuroPiScript):
 
     def main(self):
         # Reset all outputs
-        [cv.off() for cv in cvs]
+        turn_off_all_cvs()
         while True:
             # If the state has changed, update display
             if self.display_update_required:

--- a/software/contrib/polyrhythmic_sequencer.py
+++ b/software/contrib/polyrhythmic_sequencer.py
@@ -212,7 +212,8 @@ class PolyrhythmSeq(EuroPiScript):
         @din.handler_falling
         def triggers_off():
             # Turn off all of the trigger CV outputs.
-            [seq.trigger_cv.off() for seq in self.seqs]
+            for seq in self.seqs:
+                seq.trigger_cv.off()
             self.trigger_and.off()
             self.trigger_xor.off()
 
@@ -264,7 +265,8 @@ class PolyrhythmSeq(EuroPiScript):
         if self.counter != 0 and ticks_diff(ticks_ms(), din.last_triggered()) > self.reset_timeout:
             self.step = 0
             self.counter = 0
-            [s.reset() for s in self.seqs]
+            for s in self.seqs:
+                s.reset()
             self.trigger_and.off()
             self.trigger_xor.off()
 

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -92,12 +92,21 @@ def clamp(value, low, high):
     return max(min(value, high), low)
 
 
+def turn_off_all_cvs():
+    """Calls cv.off() for every cv in cvs. This is done commonly enough in
+    contrib scripts that a function seems useful.
+    """
+    for cv in cvs:
+        cv.off()
+
+
 def reset_state():
     """Return device to initial state with all components off and handlers reset."""
     if not TEST_ENV:
         oled.fill(0)
-    [cv.off() for cv in cvs]
-    [d.reset_handler() for d in (b1, b2, din)]
+    turn_off_all_cvs()
+    for d in (b1, b2, din):
+        d.reset_handler()
 
 
 def bootsplash():


### PR DESCRIPTION
A small cleanup pull to remove list comprehensions that exist solely for their side effects. The removed list comprehensions have been replaced with for loops or calls to a new utility function in the firmware, `turn_off_all_cvs`.