### PR TITLE
remove unnecessary 'self' from quantizer super init call

### DIFF
--- a/software/contrib/quantizer.py
+++ b/software/contrib/quantizer.py
@@ -37,7 +37,7 @@ class ScreensaverScreen(Screensaver):
     not necessary for now
     """
     def __init__(self, quantizer):
-        super().__init__(self)
+        super().__init__()
         self.quantizer = quantizer
 
     def on_button1(self):


### PR DESCRIPTION
Reproduced locally and tested the fix recommended in the issue and discussed in discord.

Fixes issue #284 