### PR TITLE
Add Kompari-inspired contrib script

### DIFF
--- a/software/contrib/README.md
+++ b/software/contrib/README.md
@@ -61,6 +61,14 @@ The division of the master clock that each LFO runs at, as well as each of their
 <i>Author: [roryjamesallen](https://github.com/roryjamesallen)</i>
 <br><i>Labels: LFO</i>
 
+### Kompari \[ [documentation](/software/contrib/kompari.md) | [script](/software/contrib/kompari.py) \]
+
+Compares `AIN` to `K1` and `K2`, outputting 5V digital signals on `CV1`-`CV5`, and an analogue output signal based on
+comparing all 3 sources.
+
+<i>Author: [chrisib](https://github.com/chrisib)</i>
+<br><i>Labels: logic, gates, binary operators</i>
+
 ### Logic \[ [documentation](/software/contrib/logic.md) | [script](/software/contrib/logic.py) \]
 
 Treats both inputs as digital on/off signals and outputs the results of binary AND, OR, XOR, NAND, NOR, and XNOR operations on outputs 1-6.

--- a/software/contrib/kompari.md
+++ b/software/contrib/kompari.md
@@ -11,6 +11,6 @@ Outputs:
 - `CV1` +5V if `K1` < `AIN`, otherwise 0
 - `CV2` +5V if `AIN` < `K2`, otherwise 0
 - `CV3` +5V if `K1` < `AIN` < `K2`, otherwise 0
-- `CV4` +5V if `K1` >= `AIN`, otherwise 0 (inverse of `CV1`)
-- `CV5` +5V if `AIN` >= `K2`, otherwise 0 (inverse of `CV2`)
+- `CV4` `max(K1, AIN)`
+- `CV5` `min(AIN, K2)`
 - `CV6` `max(K1, min(AIN, K2))`

--- a/software/contrib/kompari.md
+++ b/software/contrib/kompari.md
@@ -1,0 +1,16 @@
+# Kompari
+
+This program is a EuriPi re-imagining of Allen Synthesis' Kompari module.
+
+## Inputs & Outputs
+
+`AIN` is used for the input signal.  `K1` and `K2` define the lower & upper bounds for comparisons based on
+the knob position.
+
+Outputs:
+- `CV1` +5V if `K1` < `AIN`, otherwise 0
+- `CV2` +5V if `AIN` < `K2`, otherwise 0
+- `CV3` +5V if `K1` < `AIN` < `K2`, otherwise 0
+- `CV4` +5V if `K1` >= `AIN`, otherwise 0 (inverse of `CV1`)
+- `CV5` +5V if `AIN` >= `K2`, otherwise 0 (inverse of `CV2`)
+- `CV6` `max(K1, min(AIN, K2))`

--- a/software/contrib/kompari.py
+++ b/software/contrib/kompari.py
@@ -7,8 +7,8 @@ Outputs:
 - CV1: +5V if K1 < AIN, otherwise 0
 - CV2: +5V if AIN < K2, otherwise 0
 - CV3: +5V if K1 < AIN < K2, otherwise 0
-- CV4: The inverse of CV1
-- CV5: The inverse of CV2
+- CV4: max( K1, AIN )
+- CV5: min( AIN, K2 )
 - CV6: max( K1, min( AIN, K2 ) ) )
 
 B1, B2, and DIN are not used
@@ -43,23 +43,21 @@ class Kompari(EuroPiScript):
 
             if lower_bound < x:
                 cv1.voltage(self.HIGH_VOLTAGE)
-                cv4.voltage(self.LOW_VOLTAGE)
             else:
                 cv1.voltage(self.LOW_VOLTAGE)
-                cv4.voltage(self.HIGH_VOLTAGE)
 
             if x < upper_bound:
                 cv2.voltage(self.HIGH_VOLTAGE)
-                cv5.voltage(self.LOW_VOLTAGE)
             else:
                 cv2.voltage(self.LOW_VOLTAGE)
-                cv5.voltage(self.HIGH_VOLTAGE)
 
             if lower_bound < x and x < upper_bound:
                 cv3.voltage(self.HIGH_VOLTAGE)
             else:
                 cv3.voltage(self.LOW_VOLTAGE)
 
+            cv4.voltage(max(lower_bound, x) * MAX_OUTPUT_VOLTAGE)
+            cv5.voltage(min(x, upper_bound) * MAX_OUTPUT_VOLTAGE)
             cv6.voltage(max(lower_bound, min(x, upper_bound)) * MAX_OUTPUT_VOLTAGE)
 
             oled.fill(0)

--- a/software/contrib/kompari.py
+++ b/software/contrib/kompari.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""A EuroPi re-imagining of the Kompari module
+
+Input A is provided in AIN.  K1 and K2 provide the lower and upper bounds
+
+Outputs:
+- CV1: +5V if K1 < AIN, otherwise 0
+- CV2: +5V if AIN < K2, otherwise 0
+- CV3: +5V if K1 < AIN < K2, otherwise 0
+- CV4: The inverse of CV1
+- CV5: The inverse of CV2
+- CV6: max( K1, min( AIN, K2 ) ) )
+
+B1, B2, and DIN are not used
+
+@author Chris Iverach-Brereton
+@year 2023
+"""
+
+from europi import *
+from europi_script import EuroPiScript
+
+class Kompari(EuriPiScript):
+    """The main Kompari script.  See module comment for usage
+    """
+    HIGH_VOLTAGE = 5.0
+    LOW_VOLTAGE = 0.0
+
+    def __init__(self):
+        super().__init__()
+
+    @classmethod
+    def display_name(cls):
+        return "Kompari"
+
+    def main(self):
+        """Run the main loop
+        """
+        while True:
+            lower_bound = k1.percent()
+            upper_bound = k2.percent()
+            x = ain.percent()
+
+            if lower_bound < x:
+                cv1.voltage(self.HIGH_VOLTAGE)
+                cv4.voltage(self.LOW_VOLTAGE)
+            else:
+                cv1.voltage(self.LOW_VOLTAGE)
+                cv4.voltage(self.HIGH_VOLTAGE)
+
+            if x < upper_bound:
+                cv2.voltage(self.HIGH_VOLTAGE)
+                cv5.voltage(self.LOW_VOLTAGE)
+            else:
+                cv2.voltage(self.LOW_VOLTAGE)
+                cv5.voltage(self.HIGH_VOLTAGE)
+
+            if lower_bound < x and x < upper_bound:
+                cv3.voltage(self.HIGH_VOLTAGE)
+            else:
+                cv3.voltage(self.LOW_VOLTAGE)
+
+            cv6.voltage(max(lower_bound, min(x, upper_bound)) * MAX_OUTPUT_VOLTAGE)
+
+            oled.fill(0)
+            oled.centre_text(f"{lower_bound:0.1f}  {x:0.1f}  {upper_bound:0.1f}")
+            oled.show()
+
+if __name__ == "__main__":
+    Kompari().main()

--- a/software/contrib/kompari.py
+++ b/software/contrib/kompari.py
@@ -20,7 +20,7 @@ B1, B2, and DIN are not used
 from europi import *
 from europi_script import EuroPiScript
 
-class Kompari(EuriPiScript):
+class Kompari(EuroPiScript):
     """The main Kompari script.  See module comment for usage
     """
     HIGH_VOLTAGE = 5.0

--- a/software/contrib/menu.py
+++ b/software/contrib/menu.py
@@ -26,6 +26,7 @@ EUROPI_SCRIPTS = [
     "contrib.harmonic_lfos.HarmonicLFOs",
     "contrib.hello_world.HelloWorld",
     "contrib.knob_playground.KnobPlayground",
+    "contrib.kompari.Kompari",
     "contrib.logic.Logic",
     "contrib.master_clock.MasterClock",
     "contrib.noddy_holder.NoddyHolder",


### PR DESCRIPTION
Add a new contrib script that simulates the functionality of Kompari, within the limits of positive-only voltages and a single input channel.