### PR TITLE
Remove contrib folder within firmware

### DIFF
--- a/software/firmware/contrib/consequencer.md
+++ b/software/firmware/contrib/consequencer.md
@@ -1,9 +1,0 @@
-# EuroPi Consequencer
-
-Consequencer is a gate and stepped CV sequencer inspired by Grids from Mutable Instruments and the randomness created by the Turing Machine.
-
-Thanks for checking out this project, however, this page has moved.
-
-Please click the link below to find out more.
-
-https://github.com/gamecat69/EuroPiApps/blob/main/software/contrib/consequencer.md


### PR DESCRIPTION
There is a contrib folder copy within software/firmware which appears redundant - I think it was created by accident in a consequencer PR in the past as it only contains a copy of the consequencer.md file.