### PR TITLE
Add Organisms script

### DIFF
--- a/software/contrib/menu.py
+++ b/software/contrib/menu.py
@@ -30,6 +30,7 @@ EUROPI_SCRIPTS = [
     "contrib.logic.Logic",
     "contrib.master_clock.MasterClock",
     "contrib.noddy_holder.NoddyHolder",
+    "contrib.organisms.Organisms",
     "contrib.pams.PamsWorkout",
     "contrib.piconacci.Piconacci",
     "contrib.polyrhythmic_sequencer.PolyrhythmSeq",

--- a/software/contrib/organisms.md
+++ b/software/contrib/organisms.md
@@ -30,12 +30,12 @@ The resulting 6 CV outputs are essentially LFOs with a slight stepping nature, a
 They are truly generative, as their attributes (speed for example) have a real effect on their future (a faster organism is more likely to fight often and therefore affect its own speed)
 
 
-    digital in: n/a
+    digital in: frantic mode (gate)
     analogue in: n/a
     knob 1: simulation speed
     knob 2: boredom multiplier
-    button 1: n/a
-    button 2: n/a
+    button 1: start/stop
+    button 2: frantic mode (hold down)
     cv1: organism 1's position
     cv2: organism 2's position
     cv3: organism 3's position

--- a/software/contrib/organisms.md
+++ b/software/contrib/organisms.md
@@ -11,7 +11,7 @@ This script births 6 *organisms* on start-up which all live in *the simulation*,
 
 ## The Organisms
 - Each organism has a 'boredom' attribute expressed as a percentage between 0 and 100
-- Each organism has a 'speed' attribute expressed as a number between 1 and 10
+- Each organism has a 'speed' attribute expressed as a number between 1 and 6, and which can be identified by the visual size of the organism
 - When moving, each organism has a 'destination' expressed as a set of coordinates
 
 ## Each tick of the simulation...
@@ -20,9 +20,11 @@ This script births 6 *organisms* on start-up which all live in *the simulation*,
 - If an organism has just begun to walk, it will pick a new destination on the screen
 - If an organism is already walking, it will move towards its destination at its own speed
 - If an organism reaches its destination (or would exceed it in the next tick) it stops walking
-- If two organisms come within a certain distance of each other, they will "fight" - a white rectangle around the OLED indicates that a fight is taking place
+- If two organisms come within a certain distance of each other, they will "fight" - a white circle at the midpoint of the two organisms indicates the location of the fight that is taking place
 - When two organisms fight, there is a 50% chance that either will win
 - The winner's speed increases by 1, and the loser's decreases by 1
+- All energy must be maintained, so an organism with a speed of 1 cannot lose a fight, as it has nothing left to lose, and an organism with a speed of 6 cannot win a fight, as it has reached the speed limit
+- Organisms remember their most recent opponent, and will not fight them again until they've fought someone else first
 
 The resulting 6 CV outputs are essentially LFOs with a slight stepping nature, as the clock runs in discrete ticks.
 They are truly generative, as their attributes (speed for example) have a real effect on their future (a faster organism is more likely to fight often and therefore affect its own speed)

--- a/software/contrib/organisms.md
+++ b/software/contrib/organisms.md
@@ -33,7 +33,7 @@ They are truly generative, as their attributes (speed for example) have a real e
     digital in: n/a
     analogue in: n/a
     knob 1: simulation speed
-    knob 2: n/a
+    knob 2: boredom multiplier
     button 1: n/a
     button 2: n/a
     cv1: organism 1's position

--- a/software/contrib/organisms.py
+++ b/software/contrib/organisms.py
@@ -19,6 +19,7 @@ class Organism:
         self.maximum_speed = 6
         self.fighting = False
         self.last_opponent = None
+        self.display_active = False
 
         self.cv_out = cv_out
         
@@ -26,6 +27,9 @@ class Organism:
         self.fighting = value
         if opponent != None:
             self.last_opponent = opponent
+            
+    def set_display_active(self, value):
+        self.display_active = value
 
     def generate_random_coordinates(self):
         return (randint(10, OLED_WIDTH - 11), randint(6, OLED_HEIGHT - 7))
@@ -116,6 +120,10 @@ class Organism:
             (self.x / OLED_WIDTH), (self.y / OLED_HEIGHT)
         )  # The total 'value' of the organism's location between 0 and square root of 2
         organism_location_voltage = organism_location_value * 7.07
+        
+        if self.display_active:
+            self.display()
+        
         self.cv_out.voltage(organism_location_voltage)
         
         self.fighting = False
@@ -161,20 +169,25 @@ class Organisms(EuroPiScript):
         start_x = OLED_WIDTH
 
         for offset_index, offset in enumerate(x_offsets):
-            if offset_index == 10:
-                self.organisms[0].display()
-            elif offset_index == 20:
-                self.organisms[1].display()
-            elif offset_index == 30:
-                self.organisms[2].display()
-            elif offset_index == 40:
-                self.organisms[3].display()
-            elif offset_index == 50:
-                self.organisms[4].display()
-            elif offset_index == 60:
-                self.organisms[5].display()
+            oled.fill(0)
             
-            oled.fill_rect(0, 13, max((start_x - letters[-1][1]) + (8 * 18), 0), 9, 0)
+            if offset_index == 10:
+                self.organisms[0].set_display_active(True)
+            elif offset_index == 20:
+                self.organisms[1].set_display_active(True)
+            elif offset_index == 30:
+                self.organisms[2].set_display_active(True)
+            elif offset_index == 40:
+                self.organisms[3].set_display_active(True)
+            elif offset_index == 50:
+                self.organisms[4].set_display_active(True)
+            elif offset_index == 60:
+                self.organisms[5].set_display_active(True)
+                
+            for organism in self.organisms:
+                organism.tick()
+            
+            oled.fill_rect(0, 12, max((start_x - letters[-1][1]) + (8 * 18), 0), 10, 0)
             
             for letter_index, letter in enumerate(letters):
                 letter[1] += offset
@@ -216,7 +229,6 @@ class Organisms(EuroPiScript):
                                         
                 for organism in self.organisms:
                     organism.tick()
-                    organism.display()
 
                 oled.show()
 

--- a/software/contrib/organisms.py
+++ b/software/contrib/organisms.py
@@ -5,7 +5,7 @@ from europi import *
 from europi_script import EuroPiScript
 
 
-class Organism():
+class Organism:
     def __init__(self, cv_out):
         self.x, self.y = self.generate_random_coordinates()
         self.destination = (self.x, self.y)
@@ -13,66 +13,74 @@ class Organism():
         self.walking = False
         self.boredom = 0
         self.speed = 1
-        
+
         self.cv_out = cv_out
-        
+
     def generate_random_coordinates(self):
-        return (randint(0, OLED_WIDTH-1), randint(0, OLED_HEIGHT-1))
-    
+        return (randint(0, OLED_WIDTH - 1), randint(0, OLED_HEIGHT - 1))
+
     def calculate_boredom(self):
-        if self.walking == False:	#If the organism is not walking it will get increasingly bored
+        if self.walking == False:  # If the organism is not walking it will get increasingly bored
             self.boredom += 1
         else:
-            self.boredom -= 2	#If it is walking it will very quickly become not bored
-        self.boredom = clamp(self.boredom, 0, 100)	#Boredom is a percentage so cannot go below 0 or above 100
-    
+            self.boredom -= 2  # If it is walking it will very quickly become not bored
+        self.boredom = clamp(
+            self.boredom, 0, 100
+        )  # Boredom is a percentage so cannot go below 0 or above 100
+
     def calculate_hypotenuse(self, adjacent, opposite):
-        return sqrt((adjacent ** 2) + (opposite ** 2))
-    
+        return sqrt((adjacent**2) + (opposite**2))
+
     def choose_new_destination(self):
         self.destination = self.generate_random_coordinates()
         self.walking = True
-        
+
     def alter_speed(self, amount):
         self.speed = clamp((self.speed + amount), 1, 10)
-    
+
     def tick(self):
         self.calculate_boredom()
-        
-        if self.boredom > randint(0,99):	#The organism gets so bored that it chooses a new destination and begins walking
+
+        if self.boredom > randint(
+            0, 99
+        ):  # The organism gets so bored that it chooses a new destination and begins walking
             self.choose_new_destination()
-            
-        if self.walking:	#If the organism is walking
+
+        if self.walking:  # If the organism is walking
             adjacent = self.destination[0] - self.x
             opposite = self.destination[1] - self.y
             angle = abs(atan(opposite / adjacent))
-            
+
             total_distance_remaining = self.calculate_hypotenuse(adjacent, opposite)
-            if abs(total_distance_remaining) <= self.speed:	#The organism reaches its destination (or would exceed it in the next tick)
+            if (
+                abs(total_distance_remaining) <= self.speed
+            ):  # The organism reaches its destination (or would exceed it in the next tick)
                 self.x, self.y = self.destination[0], self.destination[1]
                 self.walking = False
-            
+
             distance_x = cos(angle) * self.speed * (1 if adjacent >= 0 else -1)
             self.x += distance_x
-            
+
             distance_y = sin(angle) * self.speed * (1 if opposite >= 0 else -1)
             self.y += distance_y
-            
-        organism_location_value = self.calculate_hypotenuse((self.x / OLED_WIDTH), (self.y / OLED_HEIGHT))	#The total 'value' of the organism's location between 0 and square root of 2
+
+        organism_location_value = self.calculate_hypotenuse(
+            (self.x / OLED_WIDTH), (self.y / OLED_HEIGHT)
+        )  # The total 'value' of the organism's location between 0 and square root of 2
         organism_location_voltage = organism_location_value * 7.07
         self.cv_out.voltage(organism_location_voltage)
-            
-    
+
+
 class Organisms(EuroPiScript):
     def __init__(self):
         super().__init__()
-        
+
         self.tick = 0
-        
+
         self.organisms = self.generate_organisms()
-        
+
         self.fight_radius = 5
-        
+
     @classmethod
     def display_name(cls):
         return "Life"
@@ -83,33 +91,36 @@ class Organisms(EuroPiScript):
             cv_out = cvs[organism_index]
             new_organism = Organism(cv_out)
             organisms.append(new_organism)
-        
+
         return organisms
 
     def main(self):
         while True:
             self.tick += 1
-            
+
             oled.fill(0)
-    
+
             for organism in self.organisms:
                 organism.tick()
                 oled.pixel(int(organism.x), int(organism.y), 1)
-                
+
             for index_1, organism_1 in enumerate(self.organisms):
                 for index_2, organism_2 in enumerate(self.organisms):
-                    if abs(organism_1.x - organism_2.x) <= self.fight_radius and abs(organism_1.y - organism_2.y) <= self.fight_radius:	#If the organisms are close enough to fight
+                    if (
+                        abs(organism_1.x - organism_2.x) <= self.fight_radius
+                        and abs(organism_1.y - organism_2.y) <= self.fight_radius
+                    ):  # If the organisms are close enough to fight
                         if randint(0, 1) == 1:
                             organism_1.alter_speed(1)
                             organism_2.alter_speed(-1)
                         else:
                             organism_1.alter_speed(-1)
                             organism_2.alter_speed(1)
-            
+
             oled.show()
-            
+
             sleep(0.1)
+
 
 if __name__ == "__main__":
     Organisms().main()
-

--- a/software/contrib/organisms.py
+++ b/software/contrib/organisms.py
@@ -34,18 +34,29 @@ class Organism:
     def choose_new_destination(self):
         self.destination = self.generate_random_coordinates()
         self.walking = True
-        print(self.destination)
 
     def alter_speed(self, amount):
         self.speed = clamp((self.speed + amount), 1, 10)
         
     def display(self):
         int_x, int_y = int(self.x), int(self.y)
-        oled.pixel(int_x - 1, int_y, 1)
         oled.pixel(int_x, int_y, 1)
-        oled.pixel(int_x + 1, int_y, 1)
-        oled.pixel(int_x, int_y - 1, 1)
-        oled.pixel(int_x, int_y + 1, 1)
+        
+        if self.speed >= 2:
+            oled.pixel(int_x - 1, int_y, 1)
+            oled.pixel(int_x + 1, int_y, 1)
+            oled.pixel(int_x, int_y - 1, 1)
+            oled.pixel(int_x, int_y + 1, 1)
+        if self.speed >= 4:
+            oled.pixel(int_x - 1, int_y - 1, 1)
+            oled.pixel(int_x + 1, int_y - 1, 1)
+            oled.pixel(int_x - 1, int_y + 1, 1)
+            oled.pixel(int_x + 1, int_y + 1, 1)
+        if self.speed >= 6:
+            oled.pixel(int_x, int_y - 2, 1)
+            oled.pixel(int_x, int_y + 2, 1)
+            oled.pixel(int_x - 2, int_y, 1)
+            oled.pixel(int_x + 2, int_y, 1)
 
     def tick(self):
         self.calculate_boredom()

--- a/software/contrib/organisms.py
+++ b/software/contrib/organisms.py
@@ -119,7 +119,7 @@ class Organisms(EuroPiScript):
 
             oled.show()
 
-            sleep(0.1)
+            sleep(1 - k1.percent())
 
 
 if __name__ == "__main__":

--- a/software/contrib/organisms.py
+++ b/software/contrib/organisms.py
@@ -1,0 +1,115 @@
+from time import sleep
+from random import randint
+from math import degrees, sin, cos, tan, atan, sqrt
+from europi import *
+from europi_script import EuroPiScript
+
+
+class Organism():
+    def __init__(self, cv_out):
+        self.x, self.y = self.generate_random_coordinates()
+        self.destination = (self.x, self.y)
+        self.size = 1
+        self.walking = False
+        self.boredom = 0
+        self.speed = 1
+        
+        self.cv_out = cv_out
+        
+    def generate_random_coordinates(self):
+        return (randint(0, OLED_WIDTH-1), randint(0, OLED_HEIGHT-1))
+    
+    def calculate_boredom(self):
+        if self.walking == False:	#If the organism is not walking it will get increasingly bored
+            self.boredom += 1
+        else:
+            self.boredom -= 2	#If it is walking it will very quickly become not bored
+        self.boredom = clamp(self.boredom, 0, 100)	#Boredom is a percentage so cannot go below 0 or above 100
+    
+    def calculate_hypotenuse(self, adjacent, opposite):
+        return sqrt((adjacent ** 2) + (opposite ** 2))
+    
+    def choose_new_destination(self):
+        self.destination = self.generate_random_coordinates()
+        self.walking = True
+        
+    def alter_speed(self, amount):
+        self.speed = clamp((self.speed + amount), 1, 10)
+    
+    def tick(self):
+        self.calculate_boredom()
+        
+        if self.boredom > randint(0,99):	#The organism gets so bored that it chooses a new destination and begins walking
+            self.choose_new_destination()
+            
+        if self.walking:	#If the organism is walking
+            adjacent = self.destination[0] - self.x
+            opposite = self.destination[1] - self.y
+            angle = abs(atan(opposite / adjacent))
+            
+            total_distance_remaining = self.calculate_hypotenuse(adjacent, opposite)
+            if abs(total_distance_remaining) <= self.speed:	#The organism reaches its destination (or would exceed it in the next tick)
+                self.x, self.y = self.destination[0], self.destination[1]
+                self.walking = False
+            
+            distance_x = cos(angle) * self.speed * (1 if adjacent >= 0 else -1)
+            self.x += distance_x
+            
+            distance_y = sin(angle) * self.speed * (1 if opposite >= 0 else -1)
+            self.y += distance_y
+            
+        organism_location_value = self.calculate_hypotenuse((self.x / OLED_WIDTH), (self.y / OLED_HEIGHT))	#The total 'value' of the organism's location between 0 and square root of 2
+        organism_location_voltage = organism_location_value * 7.07
+        self.cv_out.voltage(organism_location_voltage)
+            
+    
+class Organisms(EuroPiScript):
+    def __init__(self):
+        super().__init__()
+        
+        self.tick = 0
+        
+        self.organisms = self.generate_organisms()
+        
+        self.fight_radius = 5
+        
+    @classmethod
+    def display_name(cls):
+        return "Life"
+
+    def generate_organisms(self, start_population=6):
+        organisms = []
+        for organism_index in range(start_population):
+            cv_out = cvs[organism_index]
+            new_organism = Organism(cv_out)
+            organisms.append(new_organism)
+        
+        return organisms
+
+    def main(self):
+        while True:
+            self.tick += 1
+            
+            oled.fill(0)
+    
+            for organism in self.organisms:
+                organism.tick()
+                oled.pixel(int(organism.x), int(organism.y), 1)
+                
+            for index_1, organism_1 in enumerate(self.organisms):
+                for index_2, organism_2 in enumerate(self.organisms):
+                    if abs(organism_1.x - organism_2.x) <= self.fight_radius and abs(organism_1.y - organism_2.y) <= self.fight_radius:	#If the organisms are close enough to fight
+                        if randint(0, 1) == 1:
+                            organism_1.alter_speed(1)
+                            organism_2.alter_speed(-1)
+                        else:
+                            organism_1.alter_speed(-1)
+                            organism_2.alter_speed(1)
+            
+            oled.show()
+            
+            sleep(0.1)
+
+if __name__ == "__main__":
+    Organisms().main()
+

--- a/software/contrib/organisms.py
+++ b/software/contrib/organisms.py
@@ -109,7 +109,9 @@ class Organisms(EuroPiScript):
                     if (
                         abs(organism_1.x - organism_2.x) <= self.fight_radius
                         and abs(organism_1.y - organism_2.y) <= self.fight_radius
+                        and organism_1 != organism_2
                     ):  # If the organisms are close enough to fight
+                        oled.rect(0, 0, OLED_WIDTH - 1, OLED_HEIGHT - 1, 1)
                         if randint(0, 1) == 1:
                             organism_1.alter_speed(1)
                             organism_2.alter_speed(-1)

--- a/software/contrib/organisms.py
+++ b/software/contrib/organisms.py
@@ -187,14 +187,12 @@ class Organisms(EuroPiScript):
     
     def begin_simulation(self):
         text = 'birthing organisms'
-        letters = []
-        for letter in text:
-            letters.append([letter,0])
+        fill_rect_width = CHAR_WIDTH * len(text)
         x_offsets = [8, 8, 8, 8, 6, 6, 6, 6, 5, 5, 5, 5, 4, 4, 4, 4, 4, 3, 3, 3, 3, 3, 3, 3, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 6, 6, 6, 6, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8]
         start_x = OLED_WIDTH
 
         for offset_index, offset in enumerate(x_offsets):
-            oled.fill(0)
+            start_x -= offset
             
             if offset_index == 10:
                 self.organisms[0].set_display_active(True)
@@ -209,14 +207,14 @@ class Organisms(EuroPiScript):
             elif offset_index == 60:
                 self.organisms[5].set_display_active(True)
                 
+            oled.fill(0)
+                
             for organism in self.organisms:
                 organism.tick(self.boredom_multiplier)
             
-            oled.fill_rect(0, 10, max((start_x - letters[-1][1]) + (8 * 18), 0), 11, 0)
-            
-            for letter_index, letter in enumerate(letters):
-                letter[1] += offset
-                oled.text(letter[0], int((start_x - letter[1]) + (8 * letter_index)), 12)
+            oled.fill_rect(start_x, 10, fill_rect_width, 10, 0)
+            oled.text(text, start_x, 12, 1)
+
             oled.show()
             sleep(0.01)
 

--- a/software/contrib/organisms.py
+++ b/software/contrib/organisms.py
@@ -150,8 +150,41 @@ class Organisms(EuroPiScript):
             organisms.append(new_organism)
 
         return organisms
+    
+    
+    def begin_simulation(self):
+        text = 'birthing organisms'
+        letters = []
+        for letter in text:
+            letters.append([letter,0])
+        x_offsets = [8, 8, 8, 8, 6, 6, 6, 6, 6, 6, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 6, 6, 6, 6, 6, 6, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8]
+        start_x = OLED_WIDTH
+
+        for offset_index, offset in enumerate(x_offsets):
+            if offset_index == 10:
+                self.organisms[0].display()
+            elif offset_index == 20:
+                self.organisms[1].display()
+            elif offset_index == 30:
+                self.organisms[2].display()
+            elif offset_index == 40:
+                self.organisms[3].display()
+            elif offset_index == 50:
+                self.organisms[4].display()
+            elif offset_index == 60:
+                self.organisms[5].display()
+            
+            oled.fill_rect(0, 13, max((start_x - letters[-1][1]) + (8 * 18), 0), 9, 0)
+            
+            for letter_index, letter in enumerate(letters):
+                letter[1] += offset
+                oled.text(letter[0], int((start_x - letter[1]) + (8 * letter_index)), 14)
+            oled.show()
 
     def main(self):
+        
+        self.begin_simulation()
+        
         while True:
             if self.running:
                 self.tick += 1

--- a/software/contrib/organisms.py
+++ b/software/contrib/organisms.py
@@ -87,10 +87,10 @@ class Organism:
             oled.pixel(int_x + 3, int_y, 1)
             oled.pixel(int_x - 3, int_y, 1)
 
-    def tick(self):
+    def tick(self, boredom_multiplier):
         self.calculate_boredom()
 
-        if self.boredom > randint(
+        if (self.boredom * boredom_multiplier) > randint(
             0, 99
         ):  # The organism gets so bored that it chooses a new destination and begins walking
             self.choose_new_destination()
@@ -141,11 +141,17 @@ class Organisms(EuroPiScript):
         
         self.running = True
         
+        self.boredom_multipliers = [0.01, 0.05, 0.1, 0.2, 0.5, 0.75, 1, 1.5, 2, 4, 8, 10]
+        self.boredom_multiplier = self.get_boredom_multiplier()
+        
         b1.handler(self.start_stop)
 
     @classmethod
     def display_name(cls):
         return "Life"
+    
+    def get_boredom_multiplier(self):
+        return k2.choice(self.boredom_multipliers)
     
     def start_stop(self):
         self.running = not self.running
@@ -185,13 +191,13 @@ class Organisms(EuroPiScript):
                 self.organisms[5].set_display_active(True)
                 
             for organism in self.organisms:
-                organism.tick()
+                organism.tick(self.boredom_multiplier)
             
-            oled.fill_rect(0, 12, max((start_x - letters[-1][1]) + (8 * 18), 0), 10, 0)
+            oled.fill_rect(0, 10, max((start_x - letters[-1][1]) + (8 * 18), 0), 11, 0)
             
             for letter_index, letter in enumerate(letters):
                 letter[1] += offset
-                oled.text(letter[0], int((start_x - letter[1]) + (8 * letter_index)), 14)
+                oled.text(letter[0], int((start_x - letter[1]) + (8 * letter_index)), 12)
             oled.show()
             sleep(0.01)
 
@@ -202,6 +208,8 @@ class Organisms(EuroPiScript):
         while True:
             if self.running:
                 self.tick += 1
+                
+                self.boredom_multiplier = self.get_boredom_multiplier()
 
                 oled.fill(0)
 
@@ -228,7 +236,7 @@ class Organisms(EuroPiScript):
                                         None	#Neither organism has any speed to 'give' so nothing happens
                                         
                 for organism in self.organisms:
-                    organism.tick()
+                    organism.tick(self.boredom_multiplier)
 
                 oled.show()
 

--- a/software/contrib/organisms.py
+++ b/software/contrib/organisms.py
@@ -157,7 +157,7 @@ class Organisms(EuroPiScript):
         letters = []
         for letter in text:
             letters.append([letter,0])
-        x_offsets = [8, 8, 8, 8, 6, 6, 6, 6, 6, 6, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 6, 6, 6, 6, 6, 6, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8]
+        x_offsets = [8, 8, 8, 8, 6, 6, 6, 6, 5, 5, 5, 5, 4, 4, 4, 4, 4, 3, 3, 3, 3, 3, 3, 3, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 6, 6, 6, 6, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8]
         start_x = OLED_WIDTH
 
         for offset_index, offset in enumerate(x_offsets):
@@ -180,6 +180,7 @@ class Organisms(EuroPiScript):
                 letter[1] += offset
                 oled.text(letter[0], int((start_x - letter[1]) + (8 * letter_index)), 14)
             oled.show()
+            sleep(0.01)
 
     def main(self):
         


### PR DESCRIPTION
This script births 6 organisms on start-up.

- Each organism has a 'boredom' attribute expressed as a percentage between 0 and 100
- Each organism has a 'speed' attribute expressed as a number between 1 and 10
- When moving, each organism has a 'destination' expressed as a set of coordinates

Upon each tick of the script's clock:
- Each organism's boredom will increase by 1 if they aren't moving, or decrease by 2 if they are
- Each organism will calculate, using boredom and a random integer, whether it should begin walking
- If an organism is to begin walking, it will pick a new destination on the screen
- If an organism is already walking, it will move towards its destination at its own speed
- If an organism reaches its destination (or would exceed it in the next tick) it stops walking
- If two organisms come within `fight_radius` of each other, they will "fight" - a white rectangle around the OLED indicates that a fight is taking place
- When two organisms fight, there is a 50% chance that either will win
- The winner's speed increases by 1, and the loser's decreases by 1

The resulting 6 CV outputs are essentially LFOs with a slight stepping nature as the clock runs in discrete ticks. They are truly generative, as their attributes (speed for example) have a real effect on their future (a faster organism is more likely to fight often and therefore affect its own speed)

K1 can be used to adjust the speed of the overall simulation