### PR TITLE
Lazy-load menu items on launch, add exception handling

### DIFF
--- a/software/contrib/menu.py
+++ b/software/contrib/menu.py
@@ -12,38 +12,39 @@ bootsplash()
 
 
 from bootloader import BootloaderMenu
+from collections import OrderedDict
 
 # Scripts that are included in the menu
-EUROPI_SCRIPTS = [
-    "contrib.bernoulli_gates.BernoulliGates",
-    "contrib.coin_toss.CoinToss",
-    "contrib.consequencer.Consequencer",
-    "contrib.cvecorder.CVecorder",
-    "contrib.diagnostic.Diagnostic",
-    "contrib.envelope_generator.EnvelopeGenerator",
-    "contrib.euclid.EuclideanRhythms",
-    "contrib.hamlet.Hamlet",
-    "contrib.harmonic_lfos.HarmonicLFOs",
-    "contrib.hello_world.HelloWorld",
-    "contrib.knob_playground.KnobPlayground",
-    "contrib.kompari.Kompari",
-    "contrib.logic.Logic",
-    "contrib.master_clock.MasterClock",
-    "contrib.noddy_holder.NoddyHolder",
-    "contrib.pams.PamsWorkout",
-    "contrib.piconacci.Piconacci",
-    "contrib.polyrhythmic_sequencer.PolyrhythmSeq",
-    "contrib.poly_square.PolySquare",
-    "contrib.probapoly.Probapoly",
-    "contrib.quantizer.QuantizerScript",
-    "contrib.radio_scanner.RadioScanner",
-    "contrib.scope.Scope",
-    "contrib.sequential_switch.SequentialSwitch",
-    "contrib.smooth_random_voltages.SmoothRandomVoltages",
-    "contrib.strange_attractor.StrangeAttractor",
-    "contrib.turing_machine.EuroPiTuringMachine",
-    "calibrate.Calibrate",
-]
+EUROPI_SCRIPTS = OrderedDict([
+    ["Bernoulli Gates", "contrib.bernoulli_gates.BernoulliGates"],
+    ["Coin Toss", "contrib.coin_toss.CoinToss"],
+    ["Consequencer", "contrib.consequencer.Consequencer"],
+    ["CVecorder", "contrib.cvecorder.CVecorder"],
+    ["Diagnostic", "contrib.diagnostic.Diagnostic"],
+    ["EnvelopeGen", "contrib.envelope_generator.EnvelopeGenerator"],
+    ["Euclid", "contrib.euclid.EuclideanRhythms"],
+    ["Hamlet", "contrib.hamlet.Hamlet"],
+    ["HarminicLFO", "contrib.harmonic_lfos.HarmonicLFOs"],
+    ["HelloWorld", "contrib.hello_world.HelloWorld"],
+    ["KnobPlayground", "contrib.knob_playground.KnobPlayground"],
+    ["Kompari", "contrib.kompari.Kompari"],
+    ["Logic", "contrib.logic.Logic"],
+    ["MasterClock", "contrib.master_clock.MasterClock"],
+    ["NoddyHolder", "contrib.noddy_holder.NoddyHolder"],
+    ["Pam's Workout", "contrib.pams.PamsWorkout"],
+    ["Piconacci", "contrib.piconacci.Piconacci"],
+    ["PolyrhythmSeq", "contrib.polyrhythmic_sequencer.PolyrhythmSeq"],
+    ["PolySquare", "contrib.poly_square.PolySquare"],
+    ["Probapoly", "contrib.probapoly.Probapoly"],
+    ["Quantizer", "contrib.quantizer.QuantizerScript"],
+    ["RadioScanner", "contrib.radio_scanner.RadioScanner"],
+    ["Scope", "contrib.scope.Scope"],
+    ["Seq. Switch", "contrib.sequential_switch.SequentialSwitch"],
+    ["SmoothRandomVoltages", "contrib.smooth_random_voltages.SmoothRandomVoltages"],
+    ["StrangeAttractor", "contrib.strange_attractor.StrangeAttractor"],
+    ["Turing Machine", "contrib.turing_machine.EuroPiTuringMachine"],
+    ["_Calibrate", "calibrate.Calibrate"],
+])
 
 
 if __name__ == "__main__":

--- a/software/contrib/menu.py
+++ b/software/contrib/menu.py
@@ -14,38 +14,48 @@ bootsplash()
 from bootloader import BootloaderMenu
 from collections import OrderedDict
 
-# Scripts that are included in the menu
+## Scripts that are included in the menu
+#
+#  Keys are the names displayed in the menu, values are the fully-qualified names
+#  of the classes to launch.  The classes MUST be EuriPiScript subclasses
+#
+#  The OLED can display up to 16 characters horizontally, so make sure the names fit
+#  that width requirement
+#
+# fmt: off
 EUROPI_SCRIPTS = OrderedDict([
-    ["Bernoulli Gates", "contrib.bernoulli_gates.BernoulliGates"],
-    ["Coin Toss", "contrib.coin_toss.CoinToss"],
-    ["Consequencer", "contrib.consequencer.Consequencer"],
-    ["CVecorder", "contrib.cvecorder.CVecorder"],
-    ["Diagnostic", "contrib.diagnostic.Diagnostic"],
-    ["EnvelopeGen", "contrib.envelope_generator.EnvelopeGenerator"],
-    ["Euclid", "contrib.euclid.EuclideanRhythms"],
-    ["Hamlet", "contrib.hamlet.Hamlet"],
-    ["HarminicLFO", "contrib.harmonic_lfos.HarmonicLFOs"],
-    ["HelloWorld", "contrib.hello_world.HelloWorld"],
-    ["KnobPlayground", "contrib.knob_playground.KnobPlayground"],
-    ["Kompari", "contrib.kompari.Kompari"],
-    ["Logic", "contrib.logic.Logic"],
-    ["MasterClock", "contrib.master_clock.MasterClock"],
-    ["NoddyHolder", "contrib.noddy_holder.NoddyHolder"],
-    ["Pam's Workout", "contrib.pams.PamsWorkout"],
-    ["Piconacci", "contrib.piconacci.Piconacci"],
-    ["PolyrhythmSeq", "contrib.polyrhythmic_sequencer.PolyrhythmSeq"],
-    ["PolySquare", "contrib.poly_square.PolySquare"],
-    ["Probapoly", "contrib.probapoly.Probapoly"],
-    ["Quantizer", "contrib.quantizer.QuantizerScript"],
-    ["RadioScanner", "contrib.radio_scanner.RadioScanner"],
-    ["Scope", "contrib.scope.Scope"],
-    ["Seq. Switch", "contrib.sequential_switch.SequentialSwitch"],
-    ["SmoothRandomVoltages", "contrib.smooth_random_voltages.SmoothRandomVoltages"],
-    ["StrangeAttractor", "contrib.strange_attractor.StrangeAttractor"],
-    ["Turing Machine", "contrib.turing_machine.EuroPiTuringMachine"],
-    ["_Calibrate", "calibrate.Calibrate"],
-])
+#   ["0123456789abcdef",  "contrib.spam.Eggs"],
+    ["Bernoulli Gates",   "contrib.bernoulli_gates.BernoulliGates"],
+    ["Coin Toss",         "contrib.coin_toss.CoinToss"],
+    ["Consequencer",      "contrib.consequencer.Consequencer"],
+    ["CVecorder",         "contrib.cvecorder.CVecorder"],
+    ["Diagnostic",        "contrib.diagnostic.Diagnostic"],
+    ["EnvelopeGen",       "contrib.envelope_generator.EnvelopeGenerator"],
+    ["Euclid",            "contrib.euclid.EuclideanRhythms"],
+    ["Hamlet",            "contrib.hamlet.Hamlet"],
+    ["HarmonicLFOs",      "contrib.harmonic_lfos.HarmonicLFOs"],
+    ["HelloWorld",        "contrib.hello_world.HelloWorld"],
+    ["KnobPlayground",    "contrib.knob_playground.KnobPlayground"],
+    ["Kompari",           "contrib.kompari.Kompari"],
+    ["Logic",             "contrib.logic.Logic"],
+    ["MasterClock",       "contrib.master_clock.MasterClock"],
+    ["NoddyHolder",       "contrib.noddy_holder.NoddyHolder"],
+    ["Pam's Workout",     "contrib.pams.PamsWorkout"],
+    ["Piconacci",         "contrib.piconacci.Piconacci"],
+    ["PolyrhythmSeq",     "contrib.polyrhythmic_sequencer.PolyrhythmSeq"],
+    ["PolySquare",        "contrib.poly_square.PolySquare"],
+    ["Probapoly",         "contrib.probapoly.Probapoly"],
+    ["Quantizer",         "contrib.quantizer.QuantizerScript"],
+    ["RadioScanner",      "contrib.radio_scanner.RadioScanner"],
+    ["Scope",             "contrib.scope.Scope"],
+    ["Seq. Switch",       "contrib.sequential_switch.SequentialSwitch"],
+    ["Smooth Rnd Volts",  "contrib.smooth_random_voltages.SmoothRandomVoltages"],
+    ["StrangeAttractor",  "contrib.strange_attractor.StrangeAttractor"],
+    ["Turing Machine",    "contrib.turing_machine.EuroPiTuringMachine"],
 
+    ["_Calibrate",        "calibrate.Calibrate"]  # this one should always be last!
+])
+# fmt: on
 
 if __name__ == "__main__":
     BootloaderMenu(EUROPI_SCRIPTS).main()

--- a/software/firmware/bootloader.py
+++ b/software/firmware/bootloader.py
@@ -164,6 +164,6 @@ class BootloaderMenu(EuroPiScript):
             except Exception:
                 # in case we have the USB cable connected, print the stack trace for debugging
                 # otherwise, just halt and show the error message
-                print(F"[ERR ] Failed to run script: {err}")
+                print(f"[ERR ] Failed to run script: {err}")
                 traceback.print_exc()
-                self.show_error("Crash", F"Script died\n{type(err)}", -1)
+                self.show_error("Crash", f"Script died\n{type(err)}", -1)

--- a/software/firmware/bootloader.py
+++ b/software/firmware/bootloader.py
@@ -10,6 +10,8 @@ from europi import (
     OLED_HEIGHT,
     OLED_WIDTH,
     oled,
+    CHAR_HEIGHT,
+    CHAR_WIDTH
 )
 from europi_script import EuroPiScript
 from ui import Menu

--- a/software/firmware/bootloader.py
+++ b/software/firmware/bootloader.py
@@ -176,7 +176,7 @@ class BootloaderMenu(EuroPiScript):
 
                 # show the type & first portion of the exception on the OLED
                 # we can only fit so many characters, so truncate as needed
-                MAX_CHARS = OLED_WIDTH//CHAR_WIDTH
+                MAX_CHARS = OLED_WIDTH // CHAR_WIDTH
                 self.show_error(
                     "Crash", f"{str(type(err))[0:MAX_CHARS]}\n{str(err)[0:MAX_CHARS]}", -1
                 )

--- a/software/firmware/bootloader.py
+++ b/software/firmware/bootloader.py
@@ -167,8 +167,7 @@ class BootloaderMenu(EuroPiScript):
                 script_class().main()
             except Exception as err:
                 # set all outputs to zero for safety
-                for cv in europi.cvs:
-                    cv.off()
+                europi.turn_off_all_cvs()
 
                 # in case we have the USB cable connected, print the stack trace for debugging
                 # otherwise, just halt and show the error message

--- a/software/firmware/bootloader.py
+++ b/software/firmware/bootloader.py
@@ -5,14 +5,7 @@ import sys
 import time
 
 from collections import OrderedDict
-from europi import (
-    reset_state,
-    OLED_HEIGHT,
-    OLED_WIDTH,
-    oled,
-    CHAR_HEIGHT,
-    CHAR_WIDTH
-)
+from europi import oled, OLED_HEIGHT, OLED_WIDTH, CHAR_HEIGHT, CHAR_WIDTH, reset_state
 from europi_script import EuroPiScript
 from ui import Menu
 

--- a/software/firmware/bootloader.py
+++ b/software/firmware/bootloader.py
@@ -98,9 +98,6 @@ class BootloaderMenu(EuroPiScript):
 
         if duration > 0:
             time.sleep(duration)
-        else:
-            while True:
-                time.sleep(1)
 
     def launch(self, selected_item):
         """Callback function for when the user chooses a menu item to launch
@@ -168,9 +165,17 @@ class BootloaderMenu(EuroPiScript):
 
             try:
                 script_class().main()
-            except Exception:
+            except Exception as err:
+                # set all outputs to zero for safety
+                for cv in europi.cvs:
+                    cv.off()
+
                 # in case we have the USB cable connected, print the stack trace for debugging
                 # otherwise, just halt and show the error message
                 print(f"[ERR ] Failed to run script: {err}")
                 sys.print_exception(err)
-                self.show_error("Crash", f"Script died\n{type(err)}", -1)
+
+                # show the type & first portion of the exception on the OLED
+                # we can only fit so many characters, so truncate as needed
+                MAX_CHARS = OLED_WIDTH//CHAR_WIDTH
+                self.show_error("Crash", f"{str(type(err))[0:MAX_CHARS]}\n{str(err)[0:MAX_CHARS]}", -1)

--- a/software/firmware/bootloader.py
+++ b/software/firmware/bootloader.py
@@ -177,4 +177,6 @@ class BootloaderMenu(EuroPiScript):
                 # show the type & first portion of the exception on the OLED
                 # we can only fit so many characters, so truncate as needed
                 MAX_CHARS = OLED_WIDTH//CHAR_WIDTH
-                self.show_error("Crash", f"{str(type(err))[0:MAX_CHARS]}\n{str(err)[0:MAX_CHARS]}", -1)
+                self.show_error(
+                    "Crash", f"{str(type(err))[0:MAX_CHARS]}\n{str(err)[0:MAX_CHARS]}", -1
+                )

--- a/software/firmware/bootloader.py
+++ b/software/firmware/bootloader.py
@@ -141,6 +141,7 @@ class BootloaderMenu(EuroPiScript):
                 if not self._is_europi_script(launch_class):
                     self.show_error("Launch Err", "Invalid script class")
                     launch_class = None
+                    self.run_request = None
             else:
                 if old_selected != self.menu.selected:
                     old_selected = self.menu.selected

--- a/software/firmware/bootloader.py
+++ b/software/firmware/bootloader.py
@@ -142,7 +142,7 @@ class BootloaderMenu(EuroPiScript):
                 old_selected = self.menu.selected
                 self.menu.draw_menu()
             time.sleep(0.1)
-        return self.scripts[self.run_request]
+        return self.run_request
 
     def main(self):
         script_class_name = self.load_state_str()

--- a/software/firmware/bootloader.py
+++ b/software/firmware/bootloader.py
@@ -1,10 +1,10 @@
-import gc
-import time
-from collections import OrderedDict
-
-import machine
-
 import europi
+import gc
+import machine
+import time
+import traceback
+
+from collections import OrderedDict
 from europi import (
     reset_state,
     OLED_HEIGHT,
@@ -12,7 +12,6 @@ from europi import (
     oled,
 )
 from europi_script import EuroPiScript
-
 from ui import Menu
 
 SCRIPT_DIR = "/lib/contrib/"
@@ -162,5 +161,9 @@ class BootloaderMenu(EuroPiScript):
 
             try:
                 script_class().main()
-            except:
-                self.show_error("Crash", "Script died")
+            except Exception as err:
+                # in case we have the USB cable connected, print the stack trace for debugging
+                # otherwise, just halt and show the error message
+                print(F"[ERR ] Failed to run script: {err}")
+                traceback.print_exc()
+                self.show_error("Crash", f"Script died\n{err}", -1)

--- a/software/firmware/bootloader.py
+++ b/software/firmware/bootloader.py
@@ -161,9 +161,9 @@ class BootloaderMenu(EuroPiScript):
 
             try:
                 script_class().main()
-            except Exception as err:
+            except Exception:
                 # in case we have the USB cable connected, print the stack trace for debugging
                 # otherwise, just halt and show the error message
                 print(F"[ERR ] Failed to run script: {err}")
                 traceback.print_exc()
-                self.show_error("Crash", f"Script died\n{err}", -1)
+                self.show_error("Crash", F"Script died\n{type(err)}", -1)

--- a/software/firmware/bootloader.py
+++ b/software/firmware/bootloader.py
@@ -180,5 +180,5 @@ class BootloaderMenu(EuroPiScript):
                 # we can only fit so many characters, so truncate as needed
                 MAX_CHARS = OLED_WIDTH // CHAR_WIDTH
                 self.show_error(
-                    "Crash", f"{str(type(err))[0:MAX_CHARS]}\n{str(err)[0:MAX_CHARS]}", -1
+                    "Crash", f"{err.__class__.__name__[0:MAX_CHARS]}\n{str(err)[0:MAX_CHARS]}", -1
                 )

--- a/software/tests/contrib/test_menu.py
+++ b/software/tests/contrib/test_menu.py
@@ -17,5 +17,5 @@ def test_menu_imports(mock_time_module):
     bootloader = BootloaderMenu(EUROPI_SCRIPTS)
     for display_name in EUROPI_SCRIPTS.keys():
         class_name = EUROPI_SCRIPTS[display_name]
-        clazz = self.get_class_for_name(class_name)
+        clazz = bootloader.get_class_for_name(class_name)
         assert bootloader._is_europi_script(clazz), f"{class_name} is not a EuroPiScript"

--- a/software/tests/contrib/test_menu.py
+++ b/software/tests/contrib/test_menu.py
@@ -15,5 +15,7 @@ def mock_time_module(monkeypatch):
 def test_menu_imports(mock_time_module):
     """User the bootloader code to test that every script declared in EUROPI_SCRIPTS can be imported."""
     bootloader = BootloaderMenu(EUROPI_SCRIPTS)
-    classes = bootloader.load_script_classes(bootloader.scripts)
-    assert EUROPI_SCRIPTS == list(classes.keys()), "Some EUROPI_SCRIPTs were not able to be loaded."
+    for display_name in EUROPI_SCRIPTS.keys():
+        class_name = EUROPI_SCRIPTS[display_name]
+        clazz = self.get_class_for_name(class_name)
+        assert bootloader._is_europi_script(clazz), f"{class_name} is not a EuroPiScript"

--- a/software/tests/test_bootloader.py
+++ b/software/tests/test_bootloader.py
@@ -26,15 +26,3 @@ class BadTestScript:
 )
 def test_is_europi_script(cls, expected):
     assert BootloaderMenu._is_europi_script(cls) == expected
-
-
-def test_build_scripts_mapping():
-    scripts = [GoodTestScript1, GoodTestScript2, BadTestScript]
-
-    config = BootloaderMenu._build_scripts_mapping(scripts)
-
-    assert len(config) == 2
-    assert list(config.keys()) == ["GoodTestScript1", "GoodTestScript2"]
-
-    assert config["GoodTestScript1"] == GoodTestScript1
-    assert config["GoodTestScript2"] == GoodTestScript2


### PR DESCRIPTION
Rather than loading & checking that _every_ class in the menu is a valid `EuroPiScript`, only check the script that's been selected from the menu.  Rely on CI to make sure the `main` branch only ever contains valid scripts, and if the user makes changes then the onus is on them to make sure they're writing good code.

The main rationale for this is to reduce the memory footprint created by the menu. Some classes, e.g. `PamsWorkout`, are pretty big. By only loading & checking what's actually going to run we should get a comparable amount of safety (e.g. if the script isn't going to run, why do we care if it's valid or not?), but should also avoid running out of RAM.

Some very basic exception handling has also been added to show an error message if the selected script is invalid (should never be seen by a normal user, but may be useful for developers), as well as a kernel panic/BSOD style error if the selected script exits with an unhandled exception. This should (hopefully) be preferable to an exception just making the module freeze up with no explanation. Not it freezes up _with_ an explanation, which is at least mildly more helpful.