### PR TITLE
Add error logging to bootloader

### DIFF
--- a/software/firmware/bootloader.py
+++ b/software/firmware/bootloader.py
@@ -3,6 +3,7 @@ import time
 from collections import OrderedDict
 
 import machine
+import os
 
 import europi
 from europi import (
@@ -144,4 +145,15 @@ class BootloaderMenu(EuroPiScript):
             europi.b1._handler_both(europi.b2, self.exit_to_menu)
             europi.b2._handler_both(europi.b1, self.exit_to_menu)
 
-            script_class().main()
+            try:
+                script_class().main()
+            except Exception as e:
+                log_file = open("error_log.log", "a")
+                log_file.write(f'\n\n{time.ticks_ms()}: {e}')
+                log_file.close()
+                
+                oled.centre_text("CRASH\nLOGGED\nSUCCESSFULLY")
+                time.sleep(1)
+                os.remove("saved_state_BootloaderMenu.txt")
+                
+                machine.reset()

--- a/software/firmware/bootloader.py
+++ b/software/firmware/bootloader.py
@@ -149,11 +149,11 @@ class BootloaderMenu(EuroPiScript):
                 script_class().main()
             except Exception as e:
                 log_file = open("error_log.log", "a")
-                log_file.write(f'\n\n{time.ticks_ms()}: {e}')
+                log_file.write(f"\n\n{time.ticks_ms()}: {e}")
                 log_file.close()
-                
+
                 oled.centre_text("CRASH\nLOGGED\nSUCCESSFULLY")
                 time.sleep(1)
                 os.remove("saved_state_BootloaderMenu.txt")
-                
+
                 machine.reset()


### PR DESCRIPTION
Implementing the suggestion in #140 

This doesn't yet implement a rolling log and doesn't take into account the actual exception, so might record exceptions that wouldn't otherwise halt the script.

Currently any exception will be logged along with the current ticks_ms (just as a way to show the rough relative time), the script will halt, the error will be logged to a file, and the OLED will show 'error logged successfully'. After this, the bootloader script saved state will be deleted and `machine.reset()` called to load back into the menu