### PR TITLE
Add Conway's Game of Life LFO

### DIFF
--- a/software/contrib/README.md
+++ b/software/contrib/README.md
@@ -21,6 +21,12 @@ Users can morph between patterns and CV sequences during operation, with 3 gate 
 <i>Author: [gamecat69](https://github.com/gamecat69)</i>
 <br><i>Labels: sequencer, gates, triggers, drums, randomness</i>
 
+### Conway \[ [documentation](/software/contrib/conway.md) | [script](/software/contrib/conway.md) \]
+A semi-random LFO that uses [John Conway's Game Of Life](https://en.wikipedia.org/wiki/Conway%27s_Game_of_Life) to produce CV and gate signals.
+
+<i>Author: [chrisib](https://github.com/chrisib)</i>
+<br><i>Labels: lfo, gates, randomness</i>
+
 ### CVecorder \[ [documentation](/software/contrib/cvecorder.md) | [script](/software/contrib/cvecorder.py) \]
 6 channels of control voltage recording
 

--- a/software/contrib/conway.md
+++ b/software/contrib/conway.md
@@ -28,14 +28,18 @@ as an attenuator for the signal on `ain`.
 
 The six outputs are stepped CV outputs, whose values vary according to the game state.
 
-- `cv1`: outputs 0-10V depending on the percentage of the field occupied by living cells
-- `cv2`: outputs 0-10V depending on the ratio between the number of new births and the current population
-- `cv3`: outputs 0-10V depending on the ratio between the number of deaths in the most recent generation and the
-         current population
+- `cv1`: outputs 0-10V depending on the percentage of the field occupied by living cells. Under most conditions this
+         output measures between 0 and 1V, but may spike higher
+- `cv2`: outputs 0-10V depending on the ratio between the number of new births and the current population. Under
+         most conditions this output measures between 0 and 2.5V, but may spike higher
+- `cv3`: outputs 0-10V depending on the ratio between the number of births and the number of deaths in the
+         latest generation. Typically this output measures between 0 and 5V, but may spike higher.
 - `cv4`: outputs a 5V gate every generation
 - `cv5`: outputs a 5V gate signal if the number of births in the last generation was greater than the number
          of deaths
 - `cv6`: outputs a 5V gate signal if the field has reached a point of stasis
+
+
 
 ## Stasis Detection
 

--- a/software/contrib/conway.md
+++ b/software/contrib/conway.md
@@ -89,10 +89,7 @@ sparse the rate will increase.  This is normal.
 
 ## Patch Ideas
 
-The LFO will effectively stall if stasis is achieved.  By patching `cv6` into `din` you can force the simulation to
-restart if the stasis conditions are achieved.
-
-Alternatively, patch an external LFO into DIN to periodically reset the simulation.
+You can patch an external LFO into DIN to periodically reset the simulation before it reaches a state of stasis.
 
 You can create interesting feedback by patching `cv1`-`cv3` into `ain` and using the gate signals from `cv4`-`cv6`
 to control the simulation reset rate & reset density.

--- a/software/contrib/conway.md
+++ b/software/contrib/conway.md
@@ -31,11 +31,10 @@ The six outputs are stepped CV outputs, whose values vary according to the game 
 - `cv1`: outputs 0-10V depending on the percentage of the field occupied by living cells
 - `cv2`: outputs 0-10V depending on the ratio between the number of new births and the current population
 - `cv3`: outputs 0-10V depending on the ratio between the number of deaths in the most recent generation and the
-        current population
-- `cv4`: outputs a 5V gate signal if the number of births in the last generation was greater than the number
+         current population
+- `cv4`: outputs a 5V gate every generation
+- `cv5`: outputs a 5V gate signal if the number of births in the last generation was greater than the number
          of deaths
-- `cv5`: outputs a 5V gate signal if the number of deaths in the last generation was greater than the number
-         of births
 - `cv6`: outputs a 5V gate signal if the field has reached a point of stasis
 
 ## Stasis Detection

--- a/software/contrib/conway.md
+++ b/software/contrib/conway.md
@@ -28,12 +28,10 @@ as an attenuator for the signal on `ain`.
 
 The six outputs are stepped CV outputs, whose values vary according to the game state.
 
-- `cv1`: outputs 0-10V depending on the percentage of the field occupied by living cells. Under most conditions this
-         output measures between 0 and 1V, but may spike higher
-- `cv2`: outputs 0-10V depending on the ratio between the number of new births and the current population. Under
-         most conditions this output measures between 0 and 2.5V, but may spike higher
+- `cv1`: outputs 0-10V depending on the percentage of the field occupied by living cells
+- `cv2`: outputs 0-10V depending on the ratio between the number of new births and the current population
 - `cv3`: outputs 0-10V depending on the ratio between the number of births and the number of deaths in the
-         latest generation. Typically this output measures between 0 and 5V, but may spike higher.
+         latest generation
 - `cv4`: outputs a 5V gate every generation
 - `cv5`: outputs a 5V gate signal if the number of births in the last generation was greater than the number
          of deaths

--- a/software/contrib/conway.md
+++ b/software/contrib/conway.md
@@ -39,8 +39,6 @@ The six outputs are stepped CV outputs, whose values vary according to the game 
          of deaths
 - `cv6`: outputs a 5V gate signal if the field has reached a point of stasis
 
-
-
 ## Stasis Detection
 
 Because of the modest computing power available, this program uses some simple statistics to infer if the game has

--- a/software/contrib/conway.md
+++ b/software/contrib/conway.md
@@ -1,0 +1,40 @@
+# John Conway's Game of LiFO
+
+This script implements [John Conway's Game Of Life](https://en.wikipedia.org/wiki/Conway%27s_Game_of_Life) as the
+procedural kernel for multiple LFOs.
+
+The game is played on a 128x32 field (the size of the OLED). Every pixel is a cell. On every step an empty space will
+spawn a new cell if it has exactly 3 neighbours. Cells with 2 or 3 neighbours stay alive. Cells with 1 or 0 neighbours
+die of loneliness. Cells with 4 or more neighbours die of overcrowding.
+
+Every time a rising edge on `din` is received, the game advances one step, checking the above.  Initially the field
+is filled randomly with a density controlled by `k1`.  Pressing `b1` will reset the field with new random cells.
+
+Pressing `b2` will manually advance the game by one step.
+
+On every step, a number of random new cells will also spawn, based on the CV input provided on `ain`. `k2` acts
+as an attenuator for the signal on `ain`.
+
+## I/O Mapping
+
+| I/O           | Usage
+|---------------|-------------------------------------------------------------------|
+| `din`         | External clock in                                                 |
+| `ain`         | CV control over new spawn rate                                    |
+| `b1`          | Reset field                                                       |
+| `b2`          | Manually advance clock                                            |
+| `k1`          | Initial field density (on startup or `b1` press)                  |
+| `k2`          | Attenuator for `ain`                                              |
+| `cv1` - `cv6` | Output signals. See below for details                             |
+
+## Outputs
+
+The six outputs are stepped CV outputs, whose values vary according to the game state.
+
+- `cv1`: outputs 0-10V depending on the percentage of the field occupied by living cells
+- `cv2`: outputs 0-10V depending on the percentage of living cells that died during the last step
+- `cv3`: outputs 0-10V depending on the percentage of empty spaces that spawned new cells
+         (this ignores cells spawned as a result of `ain` -- only cells with 3 living neighbours count)
+- `cv4`:
+- `cv5`:
+- `cv6`: outputs a 5V gate signal that is high when more than 50% of the field is filled with cells, otherwise 0V

--- a/software/contrib/conway.md
+++ b/software/contrib/conway.md
@@ -42,6 +42,10 @@ The six outputs are stepped CV outputs, whose values vary according to the game 
 Because of the modest computing power available, this program uses some simple statistics to infer if the game has
 reached a point of stasis. There is a chance that false-positives and false-negatives can be detected.
 
+When the game is believed to have reached a state of stasis it will automatically reset, as if a signal had been
+detected on `din`.  The field will clear and be filled with random data with a density governed by `ain`, `k1`, and
+`k2`.
+
 The game is assumed to have reached a state of stasis under these conditions:
 1. At least 12 generations have passed since the last reset
 2. The number of game spaces that have changed from dead to alive or alive to dead is equal to zero OR

--- a/software/contrib/conway.md
+++ b/software/contrib/conway.md
@@ -28,7 +28,7 @@ as an attenuator for the signal on `ain`.
 
 The six outputs are stepped CV outputs, whose values vary according to the game state.
 
-- `cv1`: outputs 0-10V depending on the percentage of the field occupied by living cells
+- `cv1`: outputs 0-10V depending on the Shannon entropy of the entire field
 - `cv2`: outputs 0-10V depending on the ratio between the number of new births and the current population
 - `cv3`: outputs 0-10V depending on the ratio between the number of births and the number of deaths in the
          latest generation

--- a/software/contrib/conway.md
+++ b/software/contrib/conway.md
@@ -7,10 +7,7 @@ The game is played on a 128x32 field (the size of the OLED). Every pixel is a ce
 spawn a new cell if it has exactly 3 neighbours. Cells with 2 or 3 neighbours stay alive. Cells with 1 or 0 neighbours
 die of loneliness. Cells with 4 or more neighbours die of overcrowding.
 
-Every time a rising edge on `din` is received, the game advances one step, checking the above.  Initially the field
-is filled randomly with a density controlled by `k1`.  Pressing `b1` will reset the field with new random cells.
-
-Pressing `b2` will manually advance the game by one step.
+This program acts as a free-running LFO; it is not clockable externally.
 
 On every step, a number of random new cells will also spawn, based on the CV input provided on `ain`. `k2` acts
 as an attenuator for the signal on `ain`.
@@ -19,12 +16,12 @@ as an attenuator for the signal on `ain`.
 
 | I/O           | Usage
 |---------------|-------------------------------------------------------------------|
-| `din`         | External clock in                                                 |
-| `ain`         | CV control over new spawn rate                                    |
-| `b1`          | Reset field                                                       |
-| `b2`          | Manually advance clock                                            |
-| `k1`          | Initial field density (on startup or `b1` press)                  |
-| `k2`          | Attenuator for `ain`                                              |
+| `din`         | Clear the field & start a new random spawn                        |
+| `ain`         | Offset control for spawn density                                  |
+| `b1`          | Manual equivalent to `din`                                        |
+| `b2`          | Spawn new cells, but do not clear the field first                 |
+| `k1`          | Base spawn density                                                |
+| `k2`          | Attenuverter for `ain`                                            |
 | `cv1` - `cv6` | Output signals. See below for details                             |
 
 ## Outputs
@@ -32,9 +29,24 @@ as an attenuator for the signal on `ain`.
 The six outputs are stepped CV outputs, whose values vary according to the game state.
 
 - `cv1`: outputs 0-10V depending on the percentage of the field occupied by living cells
-- `cv2`: outputs 0-10V depending on the percentage of living cells that died during the last step
-- `cv3`: outputs 0-10V depending on the percentage of empty spaces that spawned new cells
-         (this ignores cells spawned as a result of `ain` -- only cells with 3 living neighbours count)
-- `cv4`:
-- `cv5`:
-- `cv6`: outputs a 5V gate signal that is high when more than 50% of the field is filled with cells, otherwise 0V
+- `cv2`: outputs 0-10V depending on the ratio between the number of new births and the current population
+- `cv3`: outputs 0-10V depending on the ratio between the number of deaths in the most recent generation and the
+        current population
+- `cv4`: outputs a 5V gate signal if the number of births in the last generation was greater than the number
+         of deaths
+- `cv5`: outputs a 5V gate signal if the number of deaths in the last generation was greater than the number
+         of births
+- `cv6`: outputs a 5V gate signal if the field has reached a point of stasis
+
+Stasis is considered acheived either when there are no changes in the state of the field, or if less than 5% of
+the field's spaces have changed and the number of births equals the number of deaths
+
+## Patch Ideas
+
+The LFO will effectively stall if stasis is achieved.  By patching `cv6` into `din` you can force the simulation to
+restart if the stasis conditions are achieved.
+
+Alternatively, patch an external LFO into DIN to periodically reset the simulation.
+
+You can create interesting feedback by patching `cv1`-`cv3` into `ain` and using the gate signals from `cv4`-`cv6`
+to control the simulation reset rate & reset density.

--- a/software/contrib/conway.md
+++ b/software/contrib/conway.md
@@ -38,8 +38,47 @@ The six outputs are stepped CV outputs, whose values vary according to the game 
          of births
 - `cv6`: outputs a 5V gate signal if the field has reached a point of stasis
 
-Stasis is considered acheived either when there are no changes in the state of the field, or if less than 5% of
-the field's spaces have changed and the number of births equals the number of deaths
+## Stasis Detection
+
+Because of the modest computing power available, this program uses some simple statistics to infer if the game has
+reached a point of stasis. There is a chance that a false-positive will be detected.
+
+The game is assumed to have reached a state of stasis under these conditions:
+1. At least 12 generations have passed since the last reset
+2. The number of game spaces that have changed from dead to alive or alive to dead is equal to zero OR
+3. The sum of population changes in groups of 2, 3, or 4 generations has a standard deviation of 1.0 or less
+
+To better-explain 3, consider the following 12 generations' of population changes:
+```
+[16, -17, 18, -14, 8, -23, 0, -3, 13, -12, 6, -5]
+```
+
+Grouping these changes into buckets of 2, 3, or 4 generations we produce these summed buckets:
+
+```
+Size 2: [-1, 4, -15, -3, 1, 1]
+Size 3: [17, -29, 10, -11]
+Size 4: [3, -18, 2]
+```
+
+We calculate the standard deviation of each set of buckets, giving:
+```
+Size 2: 6.69328
+Size 3: 18.08833
+Size 4: 9.672412
+```
+
+In this case, none of the deviations are less than or equal to 1.0, so the system is not in stasis.
+
+Conversely, given these populations:
+```
+[0, -9, -3, 5, -8, -9, 2, -8, -5, -6, -11, 4]
+
+Size 2: [-9, 2, -17, -6, -11, -7] -> 5.715476
+Size 3: [-12, -12, -11, -13]      -> 0.7071068
+Size 4: [-7, -23, -18]            -> 6.683312
+```
+we would assume we have reached stasis, as the standard deviation of the size-3 buckets is less than 1.0.
 
 ## Patch Ideas
 

--- a/software/contrib/conway.md
+++ b/software/contrib/conway.md
@@ -35,7 +35,7 @@ The six outputs are stepped CV outputs, whose values vary according to the game 
 - `cv4`: outputs a 5V gate every generation
 - `cv5`: outputs a 5V gate signal if the number of births in the last generation was greater than the number
          of deaths
-- `cv6`: outputs a 5V gate signal if the field has reached a point of stasis
+- `cv6`: outputs a 5V trigger if the field has reached a point of stasis
 
 ## Stasis Detection
 
@@ -95,8 +95,8 @@ sparse the rate will increase.  This is normal.
 
 You can patch an external LFO into DIN to periodically reset the simulation before it reaches a state of stasis.
 
-You can create interesting feedback by patching `cv1`-`cv3` into `ain` and using the gate signals from `cv4`-`cv6`
-to control the simulation reset rate & reset density.
+You can create interesting feedback by patching `cv1`-`cv3` into `ain` and using the gate/trigger signals from
+`cv4`-`cv6` to control the simulation reset rate & reset density.
 
 If the variation in the LFO rate causes problems you can take the outputs from Conway and connect them to an
 externally-clocked Sample & Hold module. This will smooth out the changes in the update frequency of Conway.

--- a/software/contrib/conway.md
+++ b/software/contrib/conway.md
@@ -48,6 +48,7 @@ The game is assumed to have reached a state of stasis under these conditions:
 1. At least 12 generations have passed since the last reset
 2. The number of game spaces that have changed from dead to alive or alive to dead is equal to zero OR
 3. The sum of population changes in groups of 2, 3, or 4 generations has a standard deviation of 1.0 or less
+   and the absolute value of the mean of the group is less than 1.0.
 
 To better-explain 3, consider the following 12 generations' of population changes:
 ```
@@ -62,24 +63,25 @@ Size 3: [17, -29, 10, -11]
 Size 4: [3, -18, 2]
 ```
 
-We calculate the standard deviation of each set of buckets, giving:
+We calculate the mean and standard deviation of each set of buckets, giving:
 ```
-Size 2: 6.69328
-Size 3: 18.08833
-Size 4: 9.672412
+Size 2: -2.167, 6.69328
+Size 3: -3.25, 18.08833
+Size 4: -4.333, 9.672412
 ```
 
-In this case, none of the deviations are less than or equal to 1.0, so the system is not in stasis.
+In this case none of the standard deviations nor means have a magnitude smaller than 1, so the system is not
+considered to be in stasis.
 
-Conversely, given these populations:
+Conversely, given these population changes:
 ```
-[0, -9, -3, 5, -8, -9, 2, -8, -5, -6, -11, 4]
+[-12, 6, 4, 2, -12, 6, 4, 2, -12, 6, 4, 2]
 
-Size 2: [-9, 2, -17, -6, -11, -7] -> 5.715476
-Size 3: [-12, -12, -11, -13]      -> 0.7071068
-Size 4: [-7, -23, -18]            -> 6.683312
+Size 2: [-6, 6, -6, 6, -6, 6] -> 0.0, 6.0
+Size 3: [-2, -4, -6, 12]      -> 0.0, 7.071068
+Size 4: [0, 0, 0]             -> 0.0, 0.0
 ```
-we would assume we have reached stasis, as the standard deviation of the size-3 buckets is less than 1.0.
+we would assume we have reached stasis, as the mean and standard deviation of the size-3 buckets are less than 1.0.
 
 ## LFO Rate Variablility
 

--- a/software/contrib/conway.md
+++ b/software/contrib/conway.md
@@ -80,6 +80,12 @@ Size 4: [-7, -23, -18]            -> 6.683312
 ```
 we would assume we have reached stasis, as the standard deviation of the size-3 buckets is less than 1.0.
 
+## LFO Rate Variablility
+
+Because of the implementation of Conway's Game of Life, when the field is densely-populated, e.g. immediately after a
+reset with a high spawn rate, the outputs will change relatively slow.  As cells die off and the field becomes more
+sparse the rate will increase.  This is normal.
+
 ## Patch Ideas
 
 The LFO will effectively stall if stasis is achieved.  By patching `cv6` into `din` you can force the simulation to
@@ -89,3 +95,6 @@ Alternatively, patch an external LFO into DIN to periodically reset the simulati
 
 You can create interesting feedback by patching `cv1`-`cv3` into `ain` and using the gate signals from `cv4`-`cv6`
 to control the simulation reset rate & reset density.
+
+If the variation in the LFO rate causes problems you can take the outputs from Conway and connect them to an
+externally-clocked Sample & Hold module. This will smooth out the changes in the update frequency of Conway.

--- a/software/contrib/conway.md
+++ b/software/contrib/conway.md
@@ -42,7 +42,7 @@ The six outputs are stepped CV outputs, whose values vary according to the game 
 ## Stasis Detection
 
 Because of the modest computing power available, this program uses some simple statistics to infer if the game has
-reached a point of stasis. There is a chance that a false-positive will be detected.
+reached a point of stasis. There is a chance that false-positives and false-negatives can be detected.
 
 The game is assumed to have reached a state of stasis under these conditions:
 1. At least 12 generations have passed since the last reset

--- a/software/contrib/conway.md
+++ b/software/contrib/conway.md
@@ -19,7 +19,7 @@ as an attenuator for the signal on `ain`.
 | `din`         | Clear the field & start a new random spawn                        |
 | `ain`         | Offset control for spawn density                                  |
 | `b1`          | Manual equivalent to `din`                                        |
-| `b2`          | Spawn new cells, but do not clear the field first                 |
+| `b2`          | Manual equivalent to `din`                                        |
 | `k1`          | Base spawn density                                                |
 | `k2`          | Attenuverter for `ain`                                            |
 | `cv1` - `cv6` | Output signals. See below for details                             |

--- a/software/contrib/conway.py
+++ b/software/contrib/conway.py
@@ -53,21 +53,22 @@ def bitwise_entropy(arr):
 
     @return the Shannon Entropy of the string, assuming a 50/50 chance of any bit being 1 or 0
     """
-    # 1) Count how many bits are 1 in the whole bytearray
+    # Count how many bits are 1 in the whole bytearray
     count1s = 0
     for b in arr:
         for i in range(8):
             if b & (1 << i):
                 count1s = count1s + 1
 
-    # 2) Calculate the proportion of 0 vs 1 bits in the whole bytearray
+    # Make sure we don't have all-1 or all-0 in the array; handle those cases
     num_bits = len(arr) << 3
     if count1s == 0:
         return 0.0
     elif count1s == num_bits:
         return 1.0
     else:
-        # 3) The magical entropy calculation
+        # Calculate the entropy of the string
+        # E = sum(p(x) * log_2(p(x))) = sum(p(x) * log(p(x))) / log(2)
         prob_s = [
             (num_bits - count1s) / num_bits,
             count1s / num_bits

--- a/software/contrib/conway.py
+++ b/software/contrib/conway.py
@@ -195,13 +195,18 @@ class Conway(EuroPiScript):
         spawn_level = clamp(base_spawn_level + cv_mod, 0, 1)
         return spawn_level
 
-    def random_spawn(self, fill_level):
-        """Randomly spawn cells on the field
-
-        The probablility of any space being set to True is equal to fill_level
-
-        @param fill_level  A [0, 1] value indicating the odds of any space being filled
+    def reset(self):
+        """Clear the whole field and spawn random data in it
         """
+        for i in range(len(self.field)):
+            self.field[i] = 0x00
+            self.next_field[i] = 0x00
+
+        self.num_alive = 0
+        self.population_deltas = []
+
+        # fill the field with random cells
+        fill_level = self.calculate_spawn_level()
         for i in range(NUM_PIXELS):
             x = rnd()
             is_alive = get_bit(self.field, i)
@@ -216,18 +221,8 @@ class Conway(EuroPiScript):
                 set_bit(self.next_field, i, False)
                 self.num_alive = self.num_alive - 1
 
+        # Assume the whole field has changed
         clear_bits(self.changed_spaces, True)
-
-    def reset(self):
-        """Clear the whole field and spawn random data in it
-        """
-        for i in range(len(self.field)):
-            self.field[i] = 0x00
-            self.next_field[i] = 0x00
-
-        self.num_alive = 0
-        self.population_deltas = []
-        self.random_spawn(self.calculate_spawn_level())
 
     def draw(self):
         """Show the current playing field on the OLED
@@ -331,7 +326,7 @@ class Conway(EuroPiScript):
         Handles setting the CV output, drawing to the OLED, and triggering the simulation
         """
         turn_off_all_cvs()
-        self.random_spawn(self.calculate_spawn_level())
+        self.reset()
 
         in_stasis = False
 

--- a/software/contrib/conway.py
+++ b/software/contrib/conway.py
@@ -69,9 +69,6 @@ class Conway(EuroPiScript):
         # this gets updated on every tick and on random spawns
         self.num_alive = 0
 
-        # Set to True if we want to spawn more random cells
-        self.spawn_requested = False
-
         # Set to True if we want to clear the field & respawn
         self.reset_requested = False
 
@@ -81,7 +78,7 @@ class Conway(EuroPiScript):
 
         @b2.handler
         def on_b2():
-            self.spawn_requested = True
+            self.reset_requested = True
 
         @din.handler
         def on_din():
@@ -213,11 +210,6 @@ class Conway(EuroPiScript):
         tmp = self.next_frame
         self.next_frame = self.frame
         self.frame = tmp
-
-        # If a random spawning was requested, do it here, after calculating the normal generational growth
-        if self.spawn_requested:
-            self.spawn_requested = False
-            self.random_spawn(self.calculate_spawn_level())
 
         self.changed_spaces = new_changes
 

--- a/software/contrib/conway.py
+++ b/software/contrib/conway.py
@@ -26,15 +26,6 @@ NUM_PIXELS = OLED_HEIGHT * OLED_WIDTH
 # How many volts are our gate outputs?
 GATE_VOLTAGE = 5
 
-def clamp(x, low, hi):
-    """Clamp a value to lie between low and hi
-    """
-    if x < low:
-        return low
-    elif x > hi:
-        return hi
-    else:
-        return x
 
 def stdev(l):
     """Return the standard deviation of a list of values
@@ -45,6 +36,7 @@ def stdev(l):
     """
     mean = sum(l)/len(l)
     return ( sum([((x - mean) ** 2) for x in l]) / len(l) )**0.5
+
 
 def bitwise_entropy(arr):
     """Calculate the entropy of the bit string in a bytearray

--- a/software/contrib/conway.py
+++ b/software/contrib/conway.py
@@ -302,7 +302,7 @@ class Conway(EuroPiScript):
 
             cv1.voltage(MAX_OUTPUT_VOLTAGE * self.num_alive / (NUM_PIXELS))
             cv2.voltage(MAX_OUTPUT_VOLTAGE * self.num_born / self.num_alive)
-            cv3.voltage(MAX_OUTPUT_VOLTAGE * self.num_died / self.num_alive)
+            cv3.voltage(MAX_OUTPUT_VOLTAGE * min(self.num_died, self.num_born)/max(self.num_died, self.num_born))
             cv5.voltage(GATE_VOLTAGE if self.num_born > self.num_died else 0)
 
             # If we've achieved statis, set CV6

--- a/software/contrib/conway.py
+++ b/software/contrib/conway.py
@@ -204,12 +204,13 @@ class Conway(EuroPiScript):
         """
         for i in range(NUM_PIXELS):
             x = rnd()
-            if x < fill_level and not get_bit(self.field, i):
+            is_alive = get_bit(self.field, i)
+            if x < fill_level and not is_alive:
                 # if the space isn't already filled and we want to fill it
                 set_bit(self.field, i, True)
                 set_bit(self.next_field, i, True)
                 self.num_alive = self.num_alive + 1
-            elif x >= fill_level and get_bit(self.field, i):
+            elif x >= fill_level and is_alive:
                 # if the space is filled and we want to clear it
                 set_bit(self.field, i, False)
                 set_bit(self.next_field, i, False)

--- a/software/contrib/conway.py
+++ b/software/contrib/conway.py
@@ -50,7 +50,7 @@ def bitwise_entropy(arr):
     for b in arr:
         for i in range(8):
             if b & (1 << i):
-                count1s = count1s + 1
+                count1s += 1
 
     # Make sure we don't have all-1 or all-0 in the array; handle those cases
     num_bits = len(arr) << 3
@@ -180,12 +180,12 @@ class Conway(EuroPiScript):
                 # if the space isn't already filled and we want to fill it
                 set_bit(self.field, i, True)
                 set_bit(self.next_field, i, True)
-                self.num_alive = self.num_alive + 1
+                self.num_alive += 1
             elif x >= fill_level and is_alive:
                 # if the space is filled and we want to clear it
                 set_bit(self.field, i, False)
                 set_bit(self.next_field, i, False)
-                self.num_alive = self.num_alive - 1
+                self.num_alive -= 1
 
         # Assume the whole field has changed
         set_all_bits(self.changed_spaces, True)
@@ -216,30 +216,27 @@ class Conway(EuroPiScript):
         for bit_index in range(NUM_PIXELS):
             if get_bit(self.changed_spaces, bit_index):
                 neighbourhood = self.get_neigbour_indices(bit_index)
-                num_neighbours = 0
-                for n in neighbourhood:
-                    if get_bit(self.field, n):
-                        num_neighbours = num_neighbours + 1
+                num_neighbours = sum(1 for n in neighbourhood if get_bit(self.field, n))
 
                 if get_bit(self.field, bit_index):
                     if num_neighbours == 2 or num_neighbours == 3:        # happy cell, stays alive
                         set_bit(self.next_field, bit_index, True)
                     else:                                                 # sad cell, dies
                         set_bit(self.next_field, bit_index, False)
-                        self.num_died = self.num_died + 1
-                        self.num_alive = self.num_alive - 1
+                        self.num_died += 1
+                        self.num_alive -= 1
 
-                        self.num_changes = self.num_changes + 1
+                        self.num_changes += 1
                         set_bit(self.next_changed_spaces, bit_index, 1)
                         for n in neighbourhood:
                             set_bit(self.next_changed_spaces, n, 1)
                 else:
                     if num_neighbours == 3:                               # baby cell is born!
                         set_bit(self.next_field, bit_index, True)
-                        self.num_alive = self.num_alive + 1
-                        self.num_born = self.num_born + 1
+                        self.num_alive += 1
+                        self.num_born += 1
 
-                        self.num_changes = self.num_changes + 1
+                        self.num_changes += 1
                         set_bit(self.next_changed_spaces, bit_index, 1)
                         for n in neighbourhood:
                             set_bit(self.next_changed_spaces, n, 1)

--- a/software/contrib/conway.py
+++ b/software/contrib/conway.py
@@ -262,7 +262,8 @@ class Conway(EuroPiScript):
 
             # check the standard deviation
             deviation = stdev(sums)
-            if deviation <= 1:
+            mean = sum(sums)/len(sums)
+            if deviation <= 1 and abs(mean) <= 1:
                 return True
 
         return False

--- a/software/contrib/conway.py
+++ b/software/contrib/conway.py
@@ -62,13 +62,17 @@ def bitwise_entropy(arr):
 
     # 2) Calculate the proportion of 0 vs 1 bits in the whole bytearray
     num_bits = len(arr) << 3
-    prob_s = [
-        (num_bits - count1s) / num_bits,
-        count1s / num_bits
-    ]
-
-    # 3) The magical entropy calculation
-    return -sum([ p * math.log(p) for p in prob_s]) / LOG2
+    if count1s == 0:
+        return 0.0
+    elif count1s == num_bits:
+        return 1.0
+    else:
+        # 3) The magical entropy calculation
+        prob_s = [
+            (num_bits - count1s) / num_bits,
+            count1s / num_bits
+        ]
+        return -sum([ p * math.log(p) for p in prob_s]) / LOG2
 
 
 class Conway(EuroPiScript):

--- a/software/contrib/conway.py
+++ b/software/contrib/conway.py
@@ -72,6 +72,10 @@ class Conway(EuroPiScript):
         self.field = bytearray(NUM_PIXELS >> 3)
         self.next_field = bytearray(NUM_PIXELS >> 3)
 
+        # Keep 2 separate frame buffer instances so we don't need to recreate the FB objects when we draw
+        self.frame = FrameBuffer(self.field, OLED_WIDTH, OLED_HEIGHT, MONO_HLSB)
+        self.next_frame = FrameBuffer(self.next_field, OLED_WIDTH, OLED_HEIGHT, MONO_HLSB)
+
         # Simple optimization; keep a list of spaces whose states changed & their neighbours
         # This is initially empty as the field is entirely blank
         self.changed_spaces = set()
@@ -175,8 +179,7 @@ class Conway(EuroPiScript):
     def draw(self):
         """Show the current playing field on the OLED
         """
-        fb = FrameBuffer(self.field, OLED_WIDTH, OLED_HEIGHT, MONO_HLSB)
-        oled.blit(fb, 0, 0)
+        oled.blit(self.frame, 0, 0)
         oled.show()
 
     def tick(self):
@@ -229,6 +232,10 @@ class Conway(EuroPiScript):
         tmp = self.next_field
         self.next_field = self.field
         self.field = tmp
+
+        tmp = self.next_frame
+        self.next_frame = self.frame
+        self.frame = tmp
 
         self.changed_spaces = new_changes
 

--- a/software/contrib/conway.py
+++ b/software/contrib/conway.py
@@ -276,8 +276,8 @@ class Conway(EuroPiScript):
         if len(self.population_deltas) < self.MAX_DELTAS:
             return False
 
-        # if there are no changes, we've reached static stasis
-        if self.num_changes == 0:
+        # if there are no changes or everything is dead, we've reached static stasis
+        if self.num_changes == 0 or self.num_alive == 0:
             return True
 
         # if the population is oscillating up and down predicatbly, we've probably reached stasis
@@ -294,7 +294,6 @@ class Conway(EuroPiScript):
                 return True
 
         return False
-
 
     def main(self):
         """The main loop for the program

--- a/software/contrib/conway.py
+++ b/software/contrib/conway.py
@@ -345,9 +345,10 @@ class Conway(EuroPiScript):
             else:
                 cv3.voltage(0)
 
-            # If we've achieved statis, set CV6
+            # If we've achieved statis, set CV6 & trigger a reset
             if in_stasis:
                 cv6.voltage(GATE_VOLTAGE)
+                self.reset_requested = True
 
 if __name__ == "__main__":
     Conway().main()

--- a/software/contrib/conway.py
+++ b/software/contrib/conway.py
@@ -61,8 +61,11 @@ def stdev(l):
     mean = sum(l)/len(l)
     return ( sum([((x - mean) ** 2) for x in l]) / len(l) )**0.5
 
-# Hoa many pixels are on the screen
+# How many pixels are on the screen
 NUM_PIXELS = OLED_HEIGHT * OLED_WIDTH
+
+# How many volts are our gate outputs?
+GATE_VOLTAGE = 5
 
 class Conway(EuroPiScript):
     def __init__(self):
@@ -280,7 +283,7 @@ class Conway(EuroPiScript):
             cv6.voltage(0)
 
             # turn on the FPS gate when we start calculating
-            cv4.voltage(5)
+            cv4.voltage(GATE_VOLTAGE)
 
             # calculate the next generation
             self.tick()
@@ -300,11 +303,11 @@ class Conway(EuroPiScript):
             cv1.voltage(MAX_OUTPUT_VOLTAGE * self.num_alive / (NUM_PIXELS))
             cv2.voltage(MAX_OUTPUT_VOLTAGE * self.num_born / self.num_alive)
             cv3.voltage(MAX_OUTPUT_VOLTAGE * self.num_died / self.num_alive)
-            cv5.voltage(5 if self.num_born > self.num_died else 0)
+            cv5.voltage(GATE_VOLTAGE if self.num_born > self.num_died else 0)
 
             # If we've achieved statis, set CV6
             if in_stasis:
-                cv6.voltage(5)
+                cv6.voltage(GATE_VOLTAGE)
 
 if __name__ == "__main__":
     Conway().main()

--- a/software/contrib/conway.py
+++ b/software/contrib/conway.py
@@ -125,34 +125,22 @@ class Conway(EuroPiScript):
         self.next_frame = self.frame
         self.frame = tmp
 
-    def update_cvs(self, change_gate):
-        cv1.voltage(MAX_OUTPUT_VOLTAGE * self.num_alive / (OLED_WIDTH * OLED_HEIGHT))
-
-        cv6.voltage(5.0 if change_gate else 0.0)
-
     def main(self):
         # turn off all CVs initially
         turn_off_all_cvs()
 
         self.randomize()
-        self.draw()
-        self.update_cvs(False)
-
-        change_gate = True
 
         while True:
-            change = self.reshuffle or self.tick_recvd
-
+            cv6.voltage(5)
             if self.reshuffle:
                 self.randomize()
-
-            if self.tick_recvd:
+            else:
                 self.tick()
 
-            if change:
-                change_gate = not change_gate
-                self.draw()
-                self.update_cvs(change_gate)
+            cv6.voltage(0)
+            self.draw()
+            cv1.voltage(MAX_OUTPUT_VOLTAGE * self.num_alive / (OLED_WIDTH * OLED_HEIGHT))
 
 if __name__ == "__main__":
     Conway().main()

--- a/software/contrib/conway.py
+++ b/software/contrib/conway.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Implements Conway's Game of Life as a pseudo-random LFO kernel
+"""
+
+from europi import *
+from europi_script import EuroPiScript
+
+import random
+
+class Conway(EuroPiScript):
+    def __init__(self):
+        # For ease of blitting, store the field as a bit array
+        # Each byte is 8 horizontally adjacent pixels, with the most significant bit
+        # on the left
+        self.field = bytearray(OLED_HEIGHT * OLED_WIDTH // 8)
+        self.next_field = bytearray(OLED_HEIGHT * OLED_WIDTH // 8)
+
+        self.frame = FrameBuffer(self.field, OLED_WIDTH, OLED_HEIGHT, MONO_HLSB)
+        self.next_frame = FrameBuffer(self.next_field, OLED_WIDTH, OLED_HEIGHT, MONO_HLSB)
+
+        # we want to reshuffle immediately when main() starts
+        self.reshuffle = False
+
+        # Have we received a tick on DIN or B2?
+        self.tick_recvd = False
+
+        # how many cells are currently alive?
+        # this gets updated on every tick
+        self.num_alive = 0
+
+        @b1.handler
+        def on_b1():
+            self.reshuffle = True
+
+        @b2.handler
+        def on_b2():
+            self.tick_recvd = True
+
+        @din.handler
+        def on_din():
+            self.tick_recvd = True
+
+    def get_bit(self, arr, index):
+        """Get the value of the bit at the nth position in a bytearray
+
+        Bytes are stored most significant bit first, so the 8th bit of [1] comes immediately after
+        the first bit of [0]:
+            [ B0b7 B0b6 B0b5 B0b4 B0b3 B0b2 B0b1 B0b0 B1b7 B1b6 ... ]
+        """
+        mask = 1 << ((8-index-1) % 8)
+        byte = arr[index // 8]
+        bit = 1 if byte & mask else 0
+        return bit
+
+    def set_bit(self, arr, index, value):
+        """Set the bit at the nth position in a bytearray
+
+        Bytes are stored most significant bit first
+        """
+        byte = arr[index // 8]
+        mask = 1 << ((8-index-1) % 8)
+        if value:
+            byte = byte | mask
+        else:
+            byte = byte & ~mask
+        arr[index // 8] = byte
+
+    def randomize(self):
+        self.reshuffle = False
+
+        fill_level = k1.percent()
+        for row in range(OLED_HEIGHT):
+            for col in range(OLED_WIDTH):
+                x = random.random()
+                self.set_bit(self.field, row * OLED_WIDTH + col, x < fill_level)
+
+    def draw(self):
+        oled.blit(self.frame, 0, 0)
+        oled.show()
+
+    def count_neighbours(self, row, col, field):
+        """Count how many living neighbours a space on the field has
+        """
+        count = 0
+        for i in range(-1, 2):      # -1, 0, 1
+            for j in range(-1, 2):  # -1, 0, 1
+                # ignore the centre of the 3x3 area or anything out-of-bounds
+                if (i != 0 or j != 0) and row + i >= 0 and row + i < OLED_HEIGHT and col + j >= 0 and col + j < OLED_WIDTH:
+
+                    index = (row + i) * OLED_WIDTH + col + j
+                    if self.get_bit(field, index):
+                        count = count+1
+        return count
+
+    def tick(self):
+        self.tick_recvd = False
+
+        self.num_alive = 0
+        for row in range(OLED_HEIGHT):
+            for col in range(OLED_WIDTH):
+                neighbours = self.count_neighbours(row, col, self.field)
+                bit_index = row * OLED_WIDTH + col
+
+                if self.get_bit(self.field, bit_index):
+                    if neighbours == 2 or neighbours == 3:   # happy cell, stays alive
+                        self.set_bit(self.next_field, bit_index, True)
+                        self.num_alive = self.num_alive + 1
+                    else:                                    # sad cell, dies
+                        self.set_bit(self.next_field, bit_index, False)
+                else:
+                    if neighbours == 3:                      # baby cell is born!
+                        self.set_bit(self.next_field, bit_index, True)
+                        self.num_alive = self.num_alive + 1
+                    else:                                    # empty space remains empty
+                        self.set_bit(self.next_field, bit_index, False)
+
+        # TODO: add random additional new cells according to AIN & K2
+
+        # swap field & next_field so we don't need to copy between arrays
+        tmp = self.next_field
+        self.next_field = self.field
+        self.field = tmp
+
+        tmp = self.next_frame
+        self.next_frame = self.frame
+        self.frame = tmp
+
+    def update_cvs(self, change_gate):
+        cv1.voltage(MAX_OUTPUT_VOLTAGE * self.num_alive / (OLED_WIDTH * OLED_HEIGHT))
+
+        cv6.voltage(5.0 if change_gate else 0.0)
+
+    def main(self):
+        # turn off all CVs initially
+        turn_off_all_cvs()
+
+        self.randomize()
+        self.draw()
+        self.update_cvs(False)
+
+        change_gate = True
+
+        while True:
+            change = self.reshuffle or self.tick_recvd
+
+            if self.reshuffle:
+                self.randomize()
+
+            if self.tick_recvd:
+                self.tick()
+
+            if change:
+                change_gate = not change_gate
+                self.draw()
+                self.update_cvs(change_gate)
+
+if __name__ == "__main__":
+    Conway().main()

--- a/software/contrib/conway.py
+++ b/software/contrib/conway.py
@@ -69,11 +69,12 @@ def bitwise_entropy(arr):
     else:
         # Calculate the entropy of the string
         # E = sum(p(x) * log_2(p(x))) = sum(p(x) * log(p(x))) / log(2)
-        prob_s = [
-            (num_bits - count1s) / num_bits,
-            count1s / num_bits
+        prob_1 = count1s / num_bits
+        p_x = [
+            1.0 - prob_1,
+            prob_1
         ]
-        return -sum([ p * math.log(p) for p in prob_s]) / LOG2
+        return -sum([ p * math.log(p) for p in p_x]) / LOG2
 
 
 class Conway(EuroPiScript):

--- a/software/contrib/conway.py
+++ b/software/contrib/conway.py
@@ -193,7 +193,7 @@ class Conway(EuroPiScript):
         self.next_frame = self.frame
         self.frame = tmp
 
-        # If a random spawning was requests, do it here, after calculating the normal generational growth
+        # If a random spawning was requested, do it here, after calculating the normal generational growth
         if self.spawn_requested:
             self.spawn_requested = False
             self.random_spawn(self.calculate_spawn_level())

--- a/software/contrib/conway.py
+++ b/software/contrib/conway.py
@@ -166,7 +166,6 @@ class Conway(EuroPiScript):
         """Clear the whole field and spawn random data in it
         """
         for i in range(len(self.field)):
-            self.field[i] = 0x00
             self.next_field[i] = 0x00
 
         self.num_alive = 0

--- a/software/contrib/conway.py
+++ b/software/contrib/conway.py
@@ -329,8 +329,14 @@ class Conway(EuroPiScript):
             in_stasis = self.check_for_stasis()
 
             cv1.voltage(MAX_OUTPUT_VOLTAGE * bitwise_entropy(self.field))
-            cv2.voltage(MAX_OUTPUT_VOLTAGE * self.num_born / self.num_alive)
             cv5.voltage(GATE_VOLTAGE if self.num_born > self.num_died else 0)
+
+            # Make sure we don't divide by zero
+            if self.num_alive > 0:
+                cv2.voltage(MAX_OUTPUT_VOLTAGE * self.num_born / self.num_alive)
+            else:
+                cv2.voltage(0)
+
 
             # Prevent values greater than 1 & division-by-zero errors
             hi = max(self.num_died, self.num_born)

--- a/software/contrib/conway.py
+++ b/software/contrib/conway.py
@@ -12,6 +12,7 @@ from bit indices to byte indices.
 
 from europi import *
 from europi_script import EuroPiScript
+from experimental.bitarray import *
 from random import random as rnd
 
 import math
@@ -34,45 +35,6 @@ def clamp(x, low, hi):
         return hi
     else:
         return x
-
-def get_bit(arr, index):
-    """Get the value of the bit at the nth position in a bytearray
-
-    Bytes are stored most significant bit first, so the 8th bit of [1] comes immediately after
-    the first bit of [0]:
-        [ B0b7 B0b6 B0b5 B0b4 B0b3 B0b2 B0b1 B0b0 B1b7 B1b6 ... ]
-    """
-    mask = 1 << ((8-index-1) % 8)
-    byte = arr[index >> 3]
-    bit = 1 if byte & mask else 0
-    return bit
-
-def set_bit(arr, index, value):
-    """Set the bit at the nth position in a bytearray
-
-    Bytes are stored most significant bit first, so the 8th bit of [1] comes immediately after
-    the first bit of [0]:
-        [ B0b7 B0b6 B0b5 B0b4 B0b3 B0b2 B0b1 B0b0 B1b7 B1b6 ... ]
-    """
-    byte = arr[index >> 3]
-    mask = 1 << ((8-index-1) % 8)
-    if value:
-        byte = byte | mask
-    else:
-        byte = byte & ~mask
-    arr[index >> 3] = byte
-
-def clear_bits(arr, value=0):
-    """Reset all bits in the array to the same value
-
-    @param arr  The bytearray to reset
-    @param value  If true, set all bits to 1, otherwise all bits are set to 0
-    """
-    for i in range(len(arr)):
-        if value:
-            arr[i] = 0xff
-        else:
-            arr[i] = 0x00
 
 def stdev(l):
     """Return the standard deviation of a list of values
@@ -229,7 +191,7 @@ class Conway(EuroPiScript):
                 self.num_alive = self.num_alive - 1
 
         # Assume the whole field has changed
-        clear_bits(self.changed_spaces, True)
+        set_all_bits(self.changed_spaces, True)
         self.num_changes = NUM_PIXELS
 
     def draw(self):
@@ -299,7 +261,7 @@ class Conway(EuroPiScript):
         tmp = self.next_changed_spaces
         self.next_changed_spaces = self.changed_spaces
         self.changed_spaces = tmp
-        clear_bits(self.next_changed_spaces)
+        set_all_bits(self.next_changed_spaces)
 
     def check_for_stasis(self):
         """Check the population changes over time to see if we've reached a state of stasis

--- a/software/contrib/conway.py
+++ b/software/contrib/conway.py
@@ -321,7 +321,7 @@ class Conway(EuroPiScript):
             # show the results on the OLED
             self.draw()
 
-            # check for stasis consitions
+            # check for stasis conditions
             self.population_deltas.append(self.num_born - self.num_died)
             if len(self.population_deltas) > self.MAX_DELTAS:
                 self.population_deltas.pop(0)

--- a/software/contrib/conway.py
+++ b/software/contrib/conway.py
@@ -16,6 +16,15 @@ from random import random as rnd
 
 import math
 
+# We re-use this constant a lot, so just save it for easy re-use
+LOG2 = math.log(2)
+
+# How many pixels are on the screen
+NUM_PIXELS = OLED_HEIGHT * OLED_WIDTH
+
+# How many volts are our gate outputs?
+GATE_VOLTAGE = 5
+
 def clamp(x, low, hi):
     """Clamp a value to lie between low and hi
     """
@@ -82,25 +91,23 @@ def bitwise_entropy(arr):
 
     @return the Shannon Entropy of the string, assuming a 50/50 chance of any bit being 1 or 0
     """
+    # 1) Count how many bits are 1 in the whole bytearray
     count1s = 0
-    l = len(arr) << 3
-    for i in range(l):
-        if get_bit(arr, i):
-            count1s = count1s + 1
+    for b in arr:
+        for i in range(8):
+            if b & (1 << i):
+                count1s = count1s + 1
 
+    # 2) Calculate the proportion of 0 vs 1 bits in the whole bytearray
+    num_bits = len(arr) << 3
     prob_s = [
-        (l - count1s) / l,
-        count1s / l
+        (num_bits - count1s) / num_bits,
+        count1s / num_bits
     ]
-    entropy = -sum([ p * math.log(p)/math.log(2) for p in prob_s])
-    return entropy
 
+    # 3) The magical entropy calculation
+    return -sum([ p * math.log(p) for p in prob_s]) / LOG2
 
-# How many pixels are on the screen
-NUM_PIXELS = OLED_HEIGHT * OLED_WIDTH
-
-# How many volts are our gate outputs?
-GATE_VOLTAGE = 5
 
 class Conway(EuroPiScript):
     def __init__(self):
@@ -223,6 +230,7 @@ class Conway(EuroPiScript):
 
         # Assume the whole field has changed
         clear_bits(self.changed_spaces, True)
+        self.num_changes = NUM_PIXELS
 
     def draw(self):
         """Show the current playing field on the OLED

--- a/software/contrib/menu.py
+++ b/software/contrib/menu.py
@@ -28,6 +28,7 @@ EUROPI_SCRIPTS = OrderedDict([
     ["Bernoulli Gates",   "contrib.bernoulli_gates.BernoulliGates"],
     ["Coin Toss",         "contrib.coin_toss.CoinToss"],
     ["Consequencer",      "contrib.consequencer.Consequencer"],
+    ["Conway",            "contrib.conway.Conway"],
     ["CVecorder",         "contrib.cvecorder.CVecorder"],
     ["Diagnostic",        "contrib.diagnostic.Diagnostic"],
     ["EnvelopeGen",       "contrib.envelope_generator.EnvelopeGenerator"],

--- a/software/firmware/experimental/bitarray.py
+++ b/software/firmware/experimental/bitarray.py
@@ -6,6 +6,7 @@ module serves as a loose framework on top of the bytearray object to allow
 easier bit-level access.
 """
 
+
 def make_bit_array(length):
     """Create a bit array that contains at least @length bits
 
@@ -16,10 +17,12 @@ def make_bit_array(length):
 
     @return A bytearray containing at least @length bits
     """
-    if length & 0x03:                     # bitwise check for divisibility by 8
-        byte_length = (length >> 3) + 1   # bitwise divide by 8 +1 for the extra [1, 7] bits
+    # Use bitwise operations instead of integer division and modulo operations to keep things fast
+    if length & 0x07:
+        byte_length = (length >> 3) + 1
     else:
-        byte_length = (length >> 3)       # bitwise divide by 8
+        byte_length = length >> 3
+
 
 def get_bit(arr, index):
     """Get the value of the bit at the nth position in a bytearray
@@ -33,10 +36,12 @@ def get_bit(arr, index):
 
     @return 0 or 1, depending on the state at position @index
     """
+    # Use bitwise operations instead of integer division and modulo operations to keep things fast
     byte = arr[index >> 3]
-    mask = 1 << ((8-index-1) % 8)
+    mask = 1 << ((8 - index - 1) & 0x07)
     bit = 1 if byte & mask else 0
     return bit
+
 
 def set_bit(arr, index, value):
     """Set the bit at the nth position in a bytearray
@@ -49,13 +54,15 @@ def set_bit(arr, index, value):
     @param index  The bit position within the array
     @param value  A truthy value indicating whether the bit should be set to 1 or 0
     """
+    # Use bitwise operations instead of integer division and modulo operations to keep things fast
     byte = arr[index >> 3]
-    mask = 1 << ((8-index-1) % 8)
+    mask = 1 << ((8 - index - 1) & 0x07)
     if value:
         byte = byte | mask
     else:
         byte = byte & ~mask
     arr[index >> 3] = byte
+
 
 def set_all_bits(arr, value=0):
     """Set all bits in the array to the same value
@@ -65,6 +72,6 @@ def set_all_bits(arr, value=0):
     """
     for i in range(len(arr)):
         if value:
-            arr[i] = 0xff
+            arr[i] = 0xFF
         else:
             arr[i] = 0x00

--- a/software/firmware/experimental/bitarray.py
+++ b/software/firmware/experimental/bitarray.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Support functions to allow using a bytearray as a bit array.
+
+Micropython doesn't appear to have a native bitarray implementation, so this
+module serves as a loose framework on top of the bytearray object to allow
+easier bit-level access.
+"""
+
+def make_bit_array(length):
+    """Create a bit array that contains at least @length bits
+
+    The resulting byte array will have a length rounded up to the
+    next byte if @length is not divisible by 8
+
+    @param length  The number of bits in the array
+
+    @return A bytearray containing at least @length bits
+    """
+    if length & 0x03:                     # bitwise check for divisibility by 8
+        byte_length = (length >> 3) + 1   # bitwise divide by 8 +1 for the extra [1, 7] bits
+    else:
+        byte_length = (length >> 3)       # bitwise divide by 8
+
+def get_bit(arr, index):
+    """Get the value of the bit at the nth position in a bytearray
+
+    Bytes are stored most significant bit first, so the 8th bit of [1] comes immediately after
+    the first bit of [0]:
+        [ B0b7 B0b6 B0b5 B0b4 B0b3 B0b2 B0b1 B0b0 B1b7 B1b6 ... ]
+
+    @param arr    The bytearray to operate on
+    @param index  The bit index to retrieve
+
+    @return 0 or 1, depending on the state at position @index
+    """
+    byte = arr[index >> 3]
+    mask = 1 << ((8-index-1) % 8)
+    bit = 1 if byte & mask else 0
+    return bit
+
+def set_bit(arr, index, value):
+    """Set the bit at the nth position in a bytearray
+
+    Bytes are stored most significant bit first, so the 8th bit of [1] comes immediately after
+    the first bit of [0]:
+        [ B0b7 B0b6 B0b5 B0b4 B0b3 B0b2 B0b1 B0b0 B1b7 B1b6 ... ]
+
+    @param arr    The bytearray to operate on
+    @param index  The bit position within the array
+    @param value  A truthy value indicating whether the bit should be set to 1 or 0
+    """
+    byte = arr[index >> 3]
+    mask = 1 << ((8-index-1) % 8)
+    if value:
+        byte = byte | mask
+    else:
+        byte = byte & ~mask
+    arr[index >> 3] = byte
+
+def set_all_bits(arr, value=0):
+    """Set all bits in the array to the same value
+
+    @param arr    The bytearray to reset
+    @param value  A truthy value indicating whether all bits should be set to 0 or 1
+    """
+    for i in range(len(arr)):
+        if value:
+            arr[i] = 0xff
+        else:
+            arr[i] = 0x00

--- a/software/firmware/experimental/bitarray.py
+++ b/software/firmware/experimental/bitarray.py
@@ -22,6 +22,7 @@ def make_bit_array(length):
         byte_length = (length >> 3) + 1
     else:
         byte_length = length >> 3
+    return bytearray(byte_length)
 
 
 def get_bit(arr, index):


### PR DESCRIPTION
Adds a new free-running LFO based on [John Conway's Game of Life](https://en.wikipedia.org/wiki/Conway%27s_Game_of_Life).  The simulation is _not_ clocked externally, resulting in variable FPS based on the density of the playing field. This can result in interesting, swingy gate signals, as well as an accelerating tempo immediately after the game resets.

The OLED shows the current state of the game, making for a fun visualization even if nothing is patched.

CVs 1-3 output stepped semi-random 0-10V signals based on the state of the game:
- CV1: based on the percentage of the screen covered by living cells
- CV2: based on the number of births in the most recent generation divided by the total population
- CV3: based on the ratio between births and deaths in the most recent generation

CVs 4-6 output 5V gates based on the state of the game:
- CV4: one gate per generation as an FPS indicator (FPS is variable based on the density of the playing field)
- CV5: high if more cells were born in the latest generation than died
- CV6: high if the simulation has (probably) reached a point of stasis.

Pressing either button or sending a signal to `din` will randomly reset the field with a density derived from `k1+ k2 * ain`.

Based on my testing CV6 is fairly reliable, but can occasionally trigger false-positives. I haven't run into any false-negatives with the current implementation, but there's only so much testing I can do with a single module and a semi-random system.