### PR TITLE
Add Load/Save feature to Pam's

### DIFF
--- a/software/contrib/pams.md
+++ b/software/contrib/pams.md
@@ -6,7 +6,7 @@ main clock generator, euclidean rhythm generator, clocked LFO, clocked
 random voltage source, etc... with optional quantization.
 
 The module itself will generate the master clock signal with a configurable
-BPM (1-300 BPM supported). Each output has an independently controlled
+BPM (1-240 BPM supported). Each output has an independently controlled
 clock multiplier or divider, chosen from the following:
 
 ```
@@ -92,7 +92,7 @@ by the current configuration for that channel.
 
 The main clock menu has the following options:
 
-- `BPM` -- the main BPM for the clock. Must be in the range `[1, 300]`.
+- `BPM` -- the main BPM for the clock. Must be in the range `[1, 240]`.
 
 The submenu for the main clock has the following options:
 

--- a/software/contrib/pams.md
+++ b/software/contrib/pams.md
@@ -158,7 +158,7 @@ The submenu for each CV output has the following options:
 - `Mute` -- if a channel is muted its output will always be zero. A muted channel can still be edited.
 - `Save` -- save the channel's current settings to one of 6 banks. Banks are shared across all channels
 - `Load` -- load a channel's settings from one of 6 banks. Banks are shared across all channels
-- `Reset` -- if set to `Y` all channel settings are reset to their defaults
+- `Reset` -- if set to `OK` all channel settings are reset to their defaults. Setting to `Cancel` takes no action
 
 The values of the `Attack`, `Decay`, `Sustain`, and `Release` settings are ignored if the wave whape is not set to
 `ADSR`

--- a/software/contrib/pams.md
+++ b/software/contrib/pams.md
@@ -156,8 +156,8 @@ The submenu for each CV output has the following options:
 - `Quant` -- quantization scale
 - `Q Root` -- quantizer root: transposes the quantized output up by the number of semitones above C.
 - `Mute` -- if a channel is muted its output will always be zero. A muted channel can still be edited.
-- `Save` -- save the channel's current settings to one of 8 banks. Banks are shared across all channels
-- `Load` -- load a channel's settings from one of 8 banks. Banks are shared across all channels
+- `Save` -- save the channel's current settings to one of 6 banks. Banks are shared across all channels
+- `Load` -- load a channel's settings from one of 6 banks. Banks are shared across all channels
 - `Reset` -- if set to `Y` all channel settings are reset to their defaults
 
 The values of the `Attack`, `Decay`, `Sustain`, and `Release` settings are ignored if the wave whape is not set to
@@ -324,7 +324,6 @@ The trigger turns on immediately and stays on for each PPQN pulse until it's sta
 
 | BPM | Trigger length (ms, approx.) | PPQN pulses |
 |-----|------------------------------|-------------|
-| 300 | 12.5                         | 3           |
 | 240 | 10.4                         | 2           |
 | 120 | 10.4                         | 1           |
 | 90  | 13.9                         | 1           |

--- a/software/contrib/pams.md
+++ b/software/contrib/pams.md
@@ -69,6 +69,8 @@ CV1
  |    +-- Quantization Scale*
  |    +-- Quantizer Root*
  |    +-- Mute
+ |    +-- Save
+ |    +-- Load
  |    +-- Reset
  |
 CV2 to 6
@@ -154,6 +156,8 @@ The submenu for each CV output has the following options:
 - `Quant` -- quantization scale
 - `Q Root` -- quantizer root: transposes the quantized output up by the number of semitones above C.
 - `Mute` -- if a channel is muted its output will always be zero. A muted channel can still be edited.
+- `Save` -- save the channel's current settings to one of 8 banks. Banks are shared across all channels
+- `Load` -- load a channel's settings from one of 8 banks. Banks are shared across all channels
 - `Reset` -- if set to `Y` all channel settings are reset to their defaults
 
 The values of the `Attack`, `Decay`, `Sustain`, and `Release` settings are ignored if the wave whape is not set to

--- a/software/contrib/pams.py
+++ b/software/contrib/pams.py
@@ -1276,7 +1276,7 @@ class PamsMenu:
         try:
             gc.collect()
             bank = setting.get_value()
-            if bank > 0 and bank <= len(self.pams_workout.banks):
+            if bank >= 0 and bank < len(self.pams_workout.banks):
                 self.pams_workout.banks[bank] = channel.to_dict()
         except Exception as err:
             print(f"Failed to save settings: {err}")


### PR DESCRIPTION
Adds two new channel actions: `Save` and `Load`.  The application has 6 banks for saving channel settings. These banks are shared across all channels, making this a (relatively) easy way to copy settings from one channel to another, or to save presets for different pieces and load them during a performance.

Saving/loading channels was causing issues with memory usage, so the number of channels was kept intentionally small. I tried with 8 channels initially, but was consistently getting memory allocation errors after loading/saving a few times.  This is mitigated with manual `gc.collect()` calls, but we're really pushing against the limits here.

## Save

Saves the channel's current settings to the selected bank.

## Load

Loads the settings from the given bank and applies them to the current channel.

## Misc Changes

- reduced max BPM to 240; 300 BPM was consistently not able to keep up with realtime
- very minor code refactoring/cleanup