### PR TITLE
Log bootloader exceptions to a file

### DIFF
--- a/software/firmware/bootloader.py
+++ b/software/firmware/bootloader.py
@@ -180,6 +180,7 @@ class BootloaderMenu(EuroPiScript):
                 try:
                     with open("last_crash.log", "w") as log_file:
                         log_file.write(f"{time.ticks_ms()}: {err}\n")
+                        sys.print_exception(err, log_file)
                 except:
                     # If we fail to create the error log, just silently fail; we don't need
                     # an additional exception to handle

--- a/software/firmware/bootloader.py
+++ b/software/firmware/bootloader.py
@@ -175,3 +175,12 @@ class BootloaderMenu(EuroPiScript):
                 self.show_error(
                     "Crash", f"{err.__class__.__name__[0:MAX_CHARS]}\n{str(err)[0:MAX_CHARS]}", -1
                 )
+
+                # Log the crash to a file for later analysis/recovery
+                try:
+                    with open("last_crash.log", "w") as log_file:
+                        log_file.write(f"{time.ticks_ms()}: {err}\n")
+                except:
+                    # If we fail to create the error log, just silently fail; we don't need
+                    # an additional exception to handle
+                    pass


### PR DESCRIPTION
In the case of a bootloader exception, log the exception to `last_crash.log`

To prevent the log from growing too much we just re-create the file, so only the last exception is ever saved.

This should resolve https://github.com/Allen-Synthesis/EuroPi/issues/140 and effectively re-implements the work that was closed in https://github.com/Allen-Synthesis/EuroPi/pull/302, though with only the last crash being recorded instead of a constantly-growing log file.