### PR TITLE
Update and Sync black version

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -21,4 +21,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: psf/black@stable
+      - uses: psf/black@23.11.0

--- a/software/requirements_dev.in
+++ b/software/requirements_dev.in
@@ -1,3 +1,3 @@
-black==23.1.0
+black==23.11.0
 pip-tools==6.12.2
 pytest==6.2.5

--- a/software/requirements_dev.txt
+++ b/software/requirements_dev.txt
@@ -6,7 +6,7 @@
 #
 attrs==21.4.0
     # via pytest
-black==23.1.0
+black==23.11.0
     # via -r software/requirements_dev.in
 build==0.10.0
     # via pip-tools


### PR DESCRIPTION
This PR does two things with the linting tool 'black':

1. Syncs the version used in the CI build with the version listed in the dev requirements
2. upgrades the version to 23.11, which was the last successful version used by a CI build.

This is blocking PR #315