### PR TITLE
avoid making display calls while building docs

### DIFF
--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -530,8 +530,9 @@ class Display(SSD1306_I2C):
             rotate = 0
         else:
             rotate = 1
-        self.write_cmd(ssd1306.SET_COM_OUT_DIR | ((rotate & 1) << 3))
-        self.write_cmd(ssd1306.SET_SEG_REMAP | (rotate & 1))
+        if not TEST_ENV:
+            self.write_cmd(ssd1306.SET_COM_OUT_DIR | ((rotate & 1) << 3))
+            self.write_cmd(ssd1306.SET_SEG_REMAP | (rotate & 1))
 
     def centre_text(self, text):
         """Split the provided text across 3 lines of display."""


### PR DESCRIPTION
The doc generation build is broken by the most recent merge. That code added the ability to rotate the display, which happens on Display creation, which happens when you import europi.py. Since the doc generation system mocks out the ssd1306 library we can't make any calls to it while importing the europi lib.