### PR TITLE
Add parameters to centre_text

### DIFF
--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -534,9 +534,16 @@ class Display(SSD1306_I2C):
             self.write_cmd(ssd1306.SET_COM_OUT_DIR | ((rotate & 1) << 3))
             self.write_cmd(ssd1306.SET_SEG_REMAP | (rotate & 1))
 
-    def centre_text(self, text):
-        """Split the provided text across 3 lines of display."""
-        self.fill(0)
+    def centre_text(self, text, clear_first=True, auto_show=True):
+        """Split the provided text across 3 lines of display.
+
+        @param text  The text to display, containing at most 3 lines
+        @param clear_first  If true, the screen buffer is cleared before rendering the text
+        @param auto_show  If true, oled.show() is called after rendering the text. If false, you must call
+                          oled.show() yourself
+        """
+        if clear_first:
+            self.fill(0)
         # Default font is 8x8 pixel monospaced font which can be split to a
         # maximum of 4 lines on a 128x32 display, but we limit it to 3 lines
         # for readability.
@@ -549,7 +556,9 @@ class Display(SSD1306_I2C):
             x_offset = int((self.width - ((len(content) + 1) * 7)) / 2) - 1
             y_offset = int((index * 9) + padding_top) - 1
             self.text(content, x_offset, y_offset)
-        self.show()
+
+        if auto_show:
+            self.show()
 
 
 class Output:


### PR DESCRIPTION
Add the `clear_first` and `auto_show` keyword arguments to `centre_text`. These are needed by the changes merged as part of #309