### PR TITLE
Improvements to oled.centre_text()

### DIFF
--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -545,8 +545,8 @@ class Display(SSD1306_I2C):
         if clear_first:
             self.fill(0)
         # Default font is 8x8 pixel monospaced font which can be split to a
-        # maximum of 4 lines on a 128x32 display, but the maximum lines is
-        # rounded for readability
+        # maximum of 4 lines on a 128x32 display, but the maximum_lines variable
+        # is rounded down for readability
         lines = str(text).split("\n")
         maximum_lines = round(self.height / CHAR_HEIGHT)
         if len(lines) > maximum_lines:

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -14,7 +14,6 @@ For example::
 Will set the CV output 3 to a voltage of 4.5V.
 """
 
-
 import ssd1306
 import sys
 import time
@@ -553,7 +552,7 @@ class Display(SSD1306_I2C):
             raise Exception("Provided text exceeds available space on oled display.")
         padding_top = (self.height - (len(lines) * (CHAR_HEIGHT + 1))) / 2
         for index, content in enumerate(lines):
-            x_offset = int((self.width - ((len(content) + 1) * (CHAR_WIDTH- 1))) / 2) - 1
+            x_offset = int((self.width - ((len(content) + 1) * (CHAR_WIDTH - 1))) / 2) - 1
             y_offset = int((index * (CHAR_HEIGHT + 1)) + padding_top) - 1
             self.text(content, x_offset, y_offset)
 

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -14,6 +14,7 @@ For example::
 Will set the CV output 3 to a voltage of 4.5V.
 """
 
+
 import ssd1306
 import sys
 import time
@@ -230,18 +231,14 @@ class AnalogueInput(AnalogueReader):
     function of the AnalogueReader and Knob classes
     """
 
-    def __init__(
-        self, pin, min_voltage=MIN_INPUT_VOLTAGE, max_voltage=MAX_INPUT_VOLTAGE
-    ):
+    def __init__(self, pin, min_voltage=MIN_INPUT_VOLTAGE, max_voltage=MAX_INPUT_VOLTAGE):
         super().__init__(pin)
         self.MIN_VOLTAGE = min_voltage
         self.MAX_VOLTAGE = max_voltage
         self._gradients = []
         for index, value in enumerate(INPUT_CALIBRATION_VALUES[:-1]):
             try:
-                self._gradients.append(
-                    1 / (INPUT_CALIBRATION_VALUES[index + 1] - value)
-                )
+                self._gradients.append(1 / (INPUT_CALIBRATION_VALUES[index + 1] - value))
             except ZeroDivisionError:
                 raise Exception(
                     "The input calibration process did not complete properly. Please complete again with rack power turned on"
@@ -274,9 +271,7 @@ class AnalogueInput(AnalogueReader):
             )
         else:
             index = int(percent * (len(INPUT_CALIBRATION_VALUES) - 1))
-            cv = index + (
-                self._gradients[index] * (raw_reading - INPUT_CALIBRATION_VALUES[index])
-            )
+            cv = index + (self._gradients[index] * (raw_reading - INPUT_CALIBRATION_VALUES[index]))
         return clamp(cv, self.MIN_VOLTAGE, self.MAX_VOLTAGE)
 
 
@@ -359,18 +354,12 @@ class DigitalReader:
     def _bounce_wrapper(self, pin):
         """IRQ handler wrapper for falling and rising edge callback functions."""
         if self.value() == HIGH:
-            if (
-                time.ticks_diff(time.ticks_ms(), self.last_rising_ms)
-                < self.debounce_delay
-            ):
+            if time.ticks_diff(time.ticks_ms(), self.last_rising_ms) < self.debounce_delay:
                 return
             self.last_rising_ms = time.ticks_ms()
             return self._rising_handler()
         else:
-            if (
-                time.ticks_diff(time.ticks_ms(), self.last_falling_ms)
-                < self.debounce_delay
-            ):
+            if time.ticks_diff(time.ticks_ms(), self.last_falling_ms) < self.debounce_delay:
                 return
             self.last_falling_ms = time.ticks_ms()
 
@@ -564,9 +553,7 @@ class Display(SSD1306_I2C):
             raise Exception("Provided text exceeds available space on oled display.")
         padding_top = (self.height - (len(lines) * (CHAR_HEIGHT + 1))) / 2
         for index, content in enumerate(lines):
-            x_offset = (
-                int((self.width - ((len(content) + 1) * (CHAR_WIDTH - 1))) / 2) - 1
-            )
+            x_offset = int((self.width - ((len(content) + 1) * (CHAR_WIDTH- 1))) / 2) - 1
             y_offset = int((index * (CHAR_HEIGHT + 1)) + padding_top) - 1
             self.text(content, x_offset, y_offset)
 
@@ -585,9 +572,7 @@ class Output:
     calibration is important if you want to be able to output precise voltages.
     """
 
-    def __init__(
-        self, pin, min_voltage=MIN_OUTPUT_VOLTAGE, max_voltage=MAX_OUTPUT_VOLTAGE
-    ):
+    def __init__(self, pin, min_voltage=MIN_OUTPUT_VOLTAGE, max_voltage=MAX_OUTPUT_VOLTAGE):
         self.pin = PWM(Pin(pin))
         self.pin.freq(PWM_FREQ)
         self._duty = 0
@@ -610,9 +595,7 @@ class Output:
             return self._duty / MAX_UINT16
         voltage = clamp(voltage, self.MIN_VOLTAGE, self.MAX_VOLTAGE)
         index = int(voltage // 1)
-        self._set_duty(
-            OUTPUT_CALIBRATION_VALUES[index] + (self._gradients[index] * (voltage % 1))
-        )
+        self._set_duty(OUTPUT_CALIBRATION_VALUES[index] + (self._gradients[index] * (voltage % 1)))
 
     def on(self):
         """Set the voltage HIGH at 5 volts."""

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -14,7 +14,6 @@ For example::
 Will set the CV output 3 to a voltage of 4.5V.
 """
 
-
 import ssd1306
 import sys
 import time
@@ -231,14 +230,18 @@ class AnalogueInput(AnalogueReader):
     function of the AnalogueReader and Knob classes
     """
 
-    def __init__(self, pin, min_voltage=MIN_INPUT_VOLTAGE, max_voltage=MAX_INPUT_VOLTAGE):
+    def __init__(
+        self, pin, min_voltage=MIN_INPUT_VOLTAGE, max_voltage=MAX_INPUT_VOLTAGE
+    ):
         super().__init__(pin)
         self.MIN_VOLTAGE = min_voltage
         self.MAX_VOLTAGE = max_voltage
         self._gradients = []
         for index, value in enumerate(INPUT_CALIBRATION_VALUES[:-1]):
             try:
-                self._gradients.append(1 / (INPUT_CALIBRATION_VALUES[index + 1] - value))
+                self._gradients.append(
+                    1 / (INPUT_CALIBRATION_VALUES[index + 1] - value)
+                )
             except ZeroDivisionError:
                 raise Exception(
                     "The input calibration process did not complete properly. Please complete again with rack power turned on"
@@ -271,7 +274,9 @@ class AnalogueInput(AnalogueReader):
             )
         else:
             index = int(percent * (len(INPUT_CALIBRATION_VALUES) - 1))
-            cv = index + (self._gradients[index] * (raw_reading - INPUT_CALIBRATION_VALUES[index]))
+            cv = index + (
+                self._gradients[index] * (raw_reading - INPUT_CALIBRATION_VALUES[index])
+            )
         return clamp(cv, self.MIN_VOLTAGE, self.MAX_VOLTAGE)
 
 
@@ -354,12 +359,18 @@ class DigitalReader:
     def _bounce_wrapper(self, pin):
         """IRQ handler wrapper for falling and rising edge callback functions."""
         if self.value() == HIGH:
-            if time.ticks_diff(time.ticks_ms(), self.last_rising_ms) < self.debounce_delay:
+            if (
+                time.ticks_diff(time.ticks_ms(), self.last_rising_ms)
+                < self.debounce_delay
+            ):
                 return
             self.last_rising_ms = time.ticks_ms()
             return self._rising_handler()
         else:
-            if time.ticks_diff(time.ticks_ms(), self.last_falling_ms) < self.debounce_delay:
+            if (
+                time.ticks_diff(time.ticks_ms(), self.last_falling_ms)
+                < self.debounce_delay
+            ):
                 return
             self.last_falling_ms = time.ticks_ms()
 
@@ -553,7 +564,9 @@ class Display(SSD1306_I2C):
             raise Exception("Provided text exceeds available space on oled display.")
         padding_top = (self.height - (len(lines) * (CHAR_HEIGHT + 1))) / 2
         for index, content in enumerate(lines):
-            x_offset = int((self.width - ((len(content) + 1) * (CHAR_WIDTH- 1))) / 2) - 1
+            x_offset = (
+                int((self.width - ((len(content) + 1) * (CHAR_WIDTH - 1))) / 2) - 1
+            )
             y_offset = int((index * (CHAR_HEIGHT + 1)) + padding_top) - 1
             self.text(content, x_offset, y_offset)
 
@@ -572,7 +585,9 @@ class Output:
     calibration is important if you want to be able to output precise voltages.
     """
 
-    def __init__(self, pin, min_voltage=MIN_OUTPUT_VOLTAGE, max_voltage=MAX_OUTPUT_VOLTAGE):
+    def __init__(
+        self, pin, min_voltage=MIN_OUTPUT_VOLTAGE, max_voltage=MAX_OUTPUT_VOLTAGE
+    ):
         self.pin = PWM(Pin(pin))
         self.pin.freq(PWM_FREQ)
         self._duty = 0
@@ -595,7 +610,9 @@ class Output:
             return self._duty / MAX_UINT16
         voltage = clamp(voltage, self.MIN_VOLTAGE, self.MAX_VOLTAGE)
         index = int(voltage // 1)
-        self._set_duty(OUTPUT_CALIBRATION_VALUES[index] + (self._gradients[index] * (voltage % 1)))
+        self._set_duty(
+            OUTPUT_CALIBRATION_VALUES[index] + (self._gradients[index] * (voltage % 1))
+        )
 
     def on(self):
         """Set the voltage HIGH at 5 volts."""

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -535,7 +535,7 @@ class Display(SSD1306_I2C):
             self.write_cmd(ssd1306.SET_SEG_REMAP | (rotate & 1))
 
     def centre_text(self, text, clear_first=True, auto_show=True):
-        """Split the provided text across 3 lines of display.
+        """Display one or more lines of text centred both horizontally and vertically.
 
         @param text  The text to display, containing at most 3 lines
         @param clear_first  If true, the screen buffer is cleared before rendering the text
@@ -551,10 +551,10 @@ class Display(SSD1306_I2C):
         maximum_lines = round(self.height / CHAR_HEIGHT)
         if len(lines) > maximum_lines:
             raise Exception("Provided text exceeds available space on oled display.")
-        padding_top = (self.height - (len(lines) * 9)) / 2
+        padding_top = (self.height - (len(lines) * (CHAR_HEIGHT + 1))) / 2
         for index, content in enumerate(lines):
-            x_offset = int((self.width - ((len(content) + 1) * 7)) / 2) - 1
-            y_offset = int((index * 9) + padding_top) - 1
+            x_offset = int((self.width - ((len(content) + 1) * (CHAR_WIDTH- 1))) / 2) - 1
+            y_offset = int((index * (CHAR_HEIGHT + 1)) + padding_top) - 1
             self.text(content, x_offset, y_offset)
 
         if auto_show:

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -537,7 +537,7 @@ class Display(SSD1306_I2C):
     def centre_text(self, text, clear_first=True, auto_show=True):
         """Display one or more lines of text centred both horizontally and vertically.
 
-        @param text  The text to display, containing at most 3 lines
+        @param text  The text to display
         @param clear_first  If true, the screen buffer is cleared before rendering the text
         @param auto_show  If true, oled.show() is called after rendering the text. If false, you must call
                           oled.show() yourself
@@ -545,8 +545,8 @@ class Display(SSD1306_I2C):
         if clear_first:
             self.fill(0)
         # Default font is 8x8 pixel monospaced font which can be split to a
-        # maximum of 4 lines on a 128x32 display, but we limit it to 3 lines
-        # for readability.
+        # maximum of 4 lines on a 128x32 display, but the maximum lines is
+        # rounded for readability
         lines = str(text).split("\n")
         maximum_lines = round(self.height / CHAR_HEIGHT)
         if len(lines) > maximum_lines:


### PR DESCRIPTION
Reviewing #328 I noticed some improvements that should have been made long ago to centre_text to allow it to work with larger displays where the 3 line rule is not applicable, and with other character sizes where some numbers were still hard coded for 8x8