### PR TITLE
Add gate voltage to config

### DIFF
--- a/software/CONFIGURATION.md
+++ b/software/CONFIGURATION.md
@@ -15,7 +15,7 @@ default configuration:
     "volts_per_octave": 1.0,
     "max_output_voltage": 10,
     "max_input_voltage": 12,
-	"gate_voltage": 5
+    "gate_voltage": 5
 }
 ```
 

--- a/software/CONFIGURATION.md
+++ b/software/CONFIGURATION.md
@@ -14,7 +14,8 @@ default configuration:
     "display_height": 32,
     "volts_per_octave": 1.0,
     "max_output_voltage": 10,
-    "max_input_voltage": 12
+    "max_input_voltage": 12,
+	"gate_voltage": 5
 }
 ```
 
@@ -29,3 +30,4 @@ default configuration:
   The hardware is capable of 10V maximum
 - `max_input_voltage` is an integer in the range `[0, 12]` indicating the maximum allowed voltage into the `ain` jack.
   The hardware is capable of 12V maximum
+- `gate_voltage` is an integer in the range `[0, 12]` indicating the voltage that an output will produce when `cvx.on()` is called

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -578,6 +578,7 @@ class Output:
         self._duty = 0
         self.MIN_VOLTAGE = min_voltage
         self.MAX_VOLTAGE = max_voltage
+        self.gate_voltage = clamp(europi_config["gate_voltage"], self.MIN_VOLTAGE, self.MAX_VOLTAGE)
 
         self._gradients = []
         for index, value in enumerate(OUTPUT_CALIBRATION_VALUES[:-1]):
@@ -599,7 +600,7 @@ class Output:
 
     def on(self):
         """Set the voltage HIGH at 5 volts."""
-        self.voltage(5)
+        self.voltage(self.gate_voltage)
 
     def off(self):
         """Set the voltage LOW at 0 volts."""

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -14,7 +14,6 @@ For example::
 Will set the CV output 3 to a voltage of 4.5V.
 """
 
-
 import ssd1306
 import sys
 import time

--- a/software/firmware/europi_config.py
+++ b/software/firmware/europi_config.py
@@ -82,6 +82,11 @@ class EuroPiConfig:
                 range=range(1, 13),
                 default=12
             ),
+            configuration.integer(
+                name="gate_voltage",
+                range=range(1, 13),
+                default=5
+            ),
         ]
         # fmt: on
 


### PR DESCRIPTION
Allow the standard gate voltage set by cvx.on() to be set in the config file. Default is 5V so that current scripts output the same voltage with config unaltered