### PR TITLE
Remove USB workaround

### DIFF
--- a/software/contrib/menu.py
+++ b/software/contrib/menu.py
@@ -2,11 +2,6 @@
 # Reset the module state and display bootsplash screen.
 from europi import bootsplash, usb_connected
 
-#  This is a fix for a USB connection issue documented in GitHub issue #179, and its removal condition is set out in GitHub issue #184
-if usb_connected.value() == 0:
-    from time import sleep
-
-    sleep(0.5)
 
 bootsplash()
 


### PR DESCRIPTION
Workaround added in #183, removal conditions set out in #184 appear to have been met, and using MicroPython 1.20.0 or greater this issue no longer occurs, even with delay removed from `menu.py`