### PR TITLE
Add I²C Parameters to Config

### DIFF
--- a/software/CONFIGURATION.md
+++ b/software/CONFIGURATION.md
@@ -12,6 +12,9 @@ default configuration:
     "rotate_display": false,
     "display_width": 128,
     "display_height": 32,
+    "display_sda": 0,
+    "display_scl": 1,
+    "display_channel": 0
     "max_output_voltage": 10,
     "max_input_voltage": 12,
     "gate_voltage": 5
@@ -24,6 +27,9 @@ default configuration:
 - `rotate_display` must be one of `false` or `true`
 - `display_width` is the width of the screen in pixels. The standard EuroPi screen is 128 pixels wide
 - `display_height` is the height of the screen in pixels. The standard EuroPi screen is 32 pixels tall
+- `display_sda` is the I²C SDA pin used for the display. Only SDA capable pins can be selected
+- `display_scl` is the I²C SCL pin used for the display. Only SCL capable pins can be selected
+- `display_channel` is the I²C channel used for the display, either 0 or 1.
 - `volts_per_octave` must be one of `1.0` (Eurorack standard) or `1.2` (Buchla standard)
 - `max_output_voltage` is an integer in the range `[0, 10]` indicating the maximum voltage CV output can generate.
   The hardware is capable of 10V maximum

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -65,7 +65,9 @@ experimental_config = load_experimental_config()
 # OLED component display dimensions.
 OLED_WIDTH = europi_config["display_width"]
 OLED_HEIGHT = europi_config["display_height"]
-I2C_CHANNEL = 0
+I2C_SDA = europi_config["display_sda"]
+I2C_SCL = europi_config["display_scl"]
+I2C_CHANNEL = europi_config["display_channel"]
 I2C_FREQUENCY = 400000
 
 # Standard max int consts.
@@ -499,8 +501,8 @@ class Display(SSD1306_I2C):
 
     def __init__(
         self,
-        sda,
-        scl,
+        sda=I2C_SDA,
+        scl=I2C_SCL,
         width=OLED_WIDTH,
         height=OLED_HEIGHT,
         channel=I2C_CHANNEL,
@@ -627,7 +629,7 @@ k2 = Knob(PIN_K2)
 b1 = Button(PIN_B1)
 b2 = Button(PIN_B2)
 
-oled = Display(0, 1)
+oled = Display()
 cv1 = Output(PIN_CV1)
 cv2 = Output(PIN_CV2)
 cv3 = Output(PIN_CV3)

--- a/software/firmware/europi_config.py
+++ b/software/firmware/europi_config.py
@@ -63,6 +63,21 @@ class EuroPiConfig:
                 range=range(8, 1024),
                 default=32
             ),
+            configuration.choice(
+                name="display_sda",
+                choices=[0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 26],
+                default=0,
+            ),
+            configuration.choice(
+                name="display_scl",
+                choices=[1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 27],
+                default=1,
+            ),
+            configuration.integer(
+                name="display_channel",
+                range=range(0, 1),
+                default=0
+            ),
 
             # Synthesizer family settings
             configuration.integer(

--- a/software/firmware/europi_config.py
+++ b/software/firmware/europi_config.py
@@ -75,7 +75,7 @@ class EuroPiConfig:
             ),
             configuration.integer(
                 name="display_channel",
-                range=range(0, 1),
+                range=range(0, 2),
                 default=0
             ),
 


### PR DESCRIPTION
- Add I²C SDA, SCL, and Channel to config options
- Use these parameters in `europi.py` for the Display initialisation
- Use SDA and SCL as default values in Display initialisation, allowing for initialisation with zero parameters i.e. `oled = Display()`
Other parameters already used default values set as global variables, so SDA and SCL seemed to have been missed as an oversight rather than deliberate choice.

This sets up the config settings for the future, preparing it for the implementation of suggestions like buttons to set multiple config settings based on model in an interactive config editor