### PR TITLE
Allow menus to take up larger displays

### DIFF
--- a/software/firmware/ui.py
+++ b/software/firmware/ui.py
@@ -43,13 +43,12 @@ class Menu:
         current = self.selected
         oled.fill(0)
         line_height = CHAR_HEIGHT + 2
-        
+
         for line_number, item in enumerate(self.items):
             y_position = ((line_number - current) * line_height) + 1
             if line_number == (current + 1):
                 self._inverted_text(f"{item}", 2, y_position)
             else:
                 oled.text(f"{item}", 2, y_position, 1)
-        
-        oled.show()
 
+        oled.show()

--- a/software/firmware/ui.py
+++ b/software/firmware/ui.py
@@ -46,9 +46,12 @@ class Menu:
 
         for line_number, item in enumerate(self.items):
             y_position = ((line_number - current) * line_height) + 1
-            if line_number == (current + 1):
-                self._inverted_text(f"{item}", 2, y_position)
-            else:
-                oled.text(f"{item}", 2, y_position, 1)
+            if y_position <= (OLED_HEIGHT - line_height) and y_position > 0:	#Only draw lines which can be fully displayed
+                if line_number == (current + 1):
+                    self._inverted_text(f"{item}", 2, y_position)
+                else:
+                    oled.text(f"{item}", 2, y_position, 1)
 
         oled.show()
+
+

--- a/software/firmware/ui.py
+++ b/software/firmware/ui.py
@@ -46,12 +46,12 @@ class Menu:
 
         for line_number, item in enumerate(self.items):
             y_position = ((line_number - current) * line_height) + 1
-            if y_position <= (OLED_HEIGHT - line_height) and y_position > 0:	#Only draw lines which can be fully displayed
+            if (
+                y_position <= (OLED_HEIGHT - line_height) and y_position > 0
+            ):  # Only draw lines which can be fully displayed
                 if line_number == (current + 1):
                     self._inverted_text(f"{item}", 2, y_position)
                 else:
                     oled.text(f"{item}", 2, y_position, 1)
 
         oled.show()
-
-

--- a/software/firmware/ui.py
+++ b/software/firmware/ui.py
@@ -1,7 +1,7 @@
 """This module provides reusable UI components.
 """
 
-from europi import CHAR_HEIGHT, CHAR_WIDTH, b1, k1, oled
+from europi import CHAR_HEIGHT, CHAR_WIDTH, OLED_HEIGHT, b1, k1, oled
 
 
 class Menu:
@@ -15,16 +15,15 @@ class Menu:
     """
 
     def __init__(self, items, select_func, select_knob=k1, choice_buttons=None):
-        self.items = items
-        self.items.append("----- MENU -----")
+        self.items = ["----- MENU -----"] + items
         self.select_func = select_func
         self.select_knob = select_knob
         choice_buttons = choice_buttons or [b1]
 
         # init handlers
         def select():
-            if self.selected != len(self.items) - 1:  # ignore the '-- MENU --' item
-                self.select_func(self.items[self.selected])
+            if self.selected != 0:  # ignore the '-- MENU --' item
+                self.select_func(self.items[self.selected + 1])
 
         for b in choice_buttons:
             b.handler_falling(select)
@@ -43,9 +42,14 @@ class Menu:
         """This function should be called by your script's main loop in order to display and refresh the menu."""
         current = self.selected
         oled.fill(0)
-        oled.text(f"{self.items[current - 1]}", 2, 3, 1)
-        self._inverted_text(f"{self.items[current]}", 2, 13)
-        if current != len(self.items) - 2:
-            # don't show the title at the bottom of the menu
-            oled.text(f"{self.items[current + 1]}", 2, 23, 1)
+        line_height = CHAR_HEIGHT + 2
+        
+        for line_number, item in enumerate(self.items):
+            y_position = ((line_number - current) * line_height) + 1
+            if line_number == (current + 1):
+                self._inverted_text(f"{item}", 2, y_position)
+            else:
+                oled.text(f"{item}", 2, y_position, 1)
+        
         oled.show()
+


### PR DESCRIPTION
Relies on #340 

- Alter `ui.py` to allow the menu to be displayed on larger OLEDs
- The default values will allow the module to use the current 128x64 pixel display without alteration
- Updating `display_sda`, `display_scl`, `display_channel`, and `display_height` in `config_EuroPiConfig.json` will allow the menu to be displayed on taller diplays