### PR TITLE
Use I²C Config Values to Initialise CustomFontDisplay

### DIFF
--- a/software/firmware/experimental/custom_font.py
+++ b/software/firmware/experimental/custom_font.py
@@ -4,7 +4,7 @@ from machine import I2C
 from machine import Pin
 from ssd1306 import SSD1306_I2C
 
-from europi import OLED_WIDTH, I2C_FREQUENCY, OLED_HEIGHT, I2C_CHANNEL, TEST_ENV, CHAR_HEIGHT
+from europi import OLED_WIDTH, I2C_FREQUENCY, OLED_HEIGHT, I2C_SDA, I2C_SCL, I2C_CHANNEL, TEST_ENV, CHAR_HEIGHT
 from europi import Display as BasicDisplay
 
 
@@ -70,7 +70,7 @@ class CustomFontDisplay(BasicDisplay):
     def __init__(self, default_font=None):  # by default will use the monospaced 8x8 font
         self.writers = {}  # re-usable large font writer instances
         self.default_font = default_font
-        super().__init__(0, 1)
+        super().__init__(I2C_SDA, I2C_SCL, channel=I2C_CHANNEL)
 
     def _writer(self, font):
         """Returns the large font writer for the specified font."""

--- a/software/firmware/experimental/custom_font.py
+++ b/software/firmware/experimental/custom_font.py
@@ -4,7 +4,16 @@ from machine import I2C
 from machine import Pin
 from ssd1306 import SSD1306_I2C
 
-from europi import OLED_WIDTH, I2C_FREQUENCY, OLED_HEIGHT, I2C_SDA, I2C_SCL, I2C_CHANNEL, TEST_ENV, CHAR_HEIGHT
+from europi import (
+    OLED_WIDTH,
+    I2C_FREQUENCY,
+    OLED_HEIGHT,
+    I2C_SDA,
+    I2C_SCL,
+    I2C_CHANNEL,
+    TEST_ENV,
+    CHAR_HEIGHT,
+)
 from europi import Display as BasicDisplay
 
 


### PR DESCRIPTION
Relies on #340 

Use configured I²C values to initialise CustomFontDisplay instead of just 0 and 1

This might be the point where it becomes worth having the discussion about elevating custom font functionality out of experimental, as larger displays are a nice opportunity for certain scripts e.g. Pams to use larger fonts for parameters when they're in edit mode. I think that the functionality can be included with very little overhead, but the fonts themselves should be picked more carefully as they're quite big (10kb - 22kb), so maybe normal vs big font would be a nice middle ground rather than a wide range of fonts