### PR TITLE
Treat `europi_config` keys like named constants

### DIFF
--- a/software/CONFIGURATION.md
+++ b/software/CONFIGURATION.md
@@ -30,7 +30,6 @@ default configuration:
 - `display_sda` is the I²C SDA pin used for the display. Only SDA capable pins can be selected
 - `display_scl` is the I²C SCL pin used for the display. Only SCL capable pins can be selected
 - `display_channel` is the I²C channel used for the display, either 0 or 1.
-- `volts_per_octave` must be one of `1.0` (Eurorack standard) or `1.2` (Buchla standard)
 - `max_output_voltage` is an integer in the range `[0, 10]` indicating the maximum voltage CV output can generate.
   The hardware is capable of 10V maximum
 - `max_input_voltage` is an integer in the range `[0, 12]` indicating the maximum allowed voltage into the `ain` jack.
@@ -41,7 +40,7 @@ default configuration:
 
 # Experimental configuration
 
-Other configuration properties are used by [experimental features](software/firmware/experimental/__init__.py)
+Other configuration properties are used by [experimental features](/software/firmware/experimental/experimental_config.py)
 and can be set using a similar static configuration file. This file is located at `/config/ExperimentalConfig.json`
 on the Raspberry Pi Pico. If this file does not exist, default settings will be loaded.  The following
 shows the default configuration:
@@ -70,7 +69,7 @@ this JSON file
 {
   "clock_multiplier": 4,
   "hard_sync": true,
-  "wave_shape: "sine"
+  "wave_shape": "sine"
 }
 ```
 would produce a Python object with these attributes:

--- a/software/CONFIGURATION.md
+++ b/software/CONFIGURATION.md
@@ -14,7 +14,7 @@ default configuration:
     "display_height": 32,
     "display_sda": 0,
     "display_scl": 1,
-    "display_channel": 0
+    "display_channel": 0,
     "max_output_voltage": 10,
     "max_input_voltage": 12,
     "gate_voltage": 5
@@ -53,3 +53,54 @@ shows the default configuration:
 ```
 
 - `volts_per_octave` must be one of `1.0` (Eurorack standard) or `1.2` (Buchla standard)
+
+
+# Accessing config members in Python code
+
+The configuration manger converts the JSON file into a `ConfigSettings` object, where the JSON keys are converted
+to Python attributes.  The attribute names are the same as their JSON strings, but converted to upper case (so as to
+appear as constants in the code) and with any alphanumeric characters replaced with `_` characters.  If the key starts
+with a number, a `K_` prefix is added. e.g.:
+
+- `language` -> `.LANGUAGE`
+- `display_channel` -> `.DISPLAY_CHANNEL`
+- `2pi` -> `K_2PI`
+- `max-frequency` -> `MAX_FREQUENCY`
+
+The `europi` namespace contains `.europi_config` and `.experimental_config` members that contain all of the
+configuration attributes described in the sections above:
+
+```python
+>>> from europi import europi_config
+>>> dir(europi_config)
+[
+  '__class__',
+  '__init__',
+  '__module__',
+  '__qualname__',
+  '__dict__',
+  '__eq__',
+  'to_attr_name',
+  'CPU_FREQ',
+  'DISPLAY_CHANNEL',
+  'DISPLAY_HEIGHT',
+  'DISPLAY_SCL',
+  'DISPLAY_SDA',
+  'DISPLAY_WIDTH',
+  'EUROPI_MODEL',
+  'GATE_VOLTAGE',
+  'MAX_INPUT_VOLTAGE',
+  'MAX_OUTPUT_VOLTAGE',
+  'PICO_MODEL',
+  'ROTATE_DISPLAY'
+]
+```
+
+In code:
+
+```python
+import europi
+
+# A voltage range we can select from in a user menu
+VOLTAGE_RANGE = range(0, europi.europi_config.MAX_OUTPUT_VOLTAGE)
+```

--- a/software/CONFIGURATION.md
+++ b/software/CONFIGURATION.md
@@ -59,8 +59,8 @@ shows the default configuration:
 
 The firmware converts the JSON file into a `ConfigSettings` object, where the JSON keys are converted
 to Python attributes.  The attribute names are the same as their JSON strings, but converted to upper case (so as to
-appear as constants in the code) and with any alphanumeric characters replaced with `_` characters.  If the key starts
-with a number, a `K_` prefix is added. e.g.:
+appear as constants in the code) and with any non-alphanumeric characters replaced with `_` characters.  If the key
+starts with a number, a `K_` prefix is added. e.g.:
 
 - `language` -> `.LANGUAGE`
 - `display_channel` -> `.DISPLAY_CHANNEL`

--- a/software/CONFIGURATION.md
+++ b/software/CONFIGURATION.md
@@ -1,7 +1,7 @@
 # Configuration Customization
 
 Certain properties of the module, such as screen rotation, CPU clock speed, and Raspberry Pi Pico model, can be
-set using a static configuration file.  This file is located at `/config/config_EuroPiConfig.json` on the
+set using a static configuration file.  This file is located at `/config/EuroPiConfig.json` on the
 Raspberry Pi Pico. If this file does not exist, default settings will be loaded.  The following shows the
 default configuration:
 ```json
@@ -42,7 +42,7 @@ default configuration:
 # Experimental configuration
 
 Other configuration properties are used by [experimental features](software/firmware/experimental/__init__.py)
-and can be set using a similar static configuration file. This file is located at `/config/config_ExperimentalConfig.json`
+and can be set using a similar static configuration file. This file is located at `/config/ExperimentalConfig.json`
 on the Raspberry Pi Pico. If this file does not exist, default settings will be loaded.  The following
 shows the default configuration:
 
@@ -58,14 +58,45 @@ shows the default configuration:
 # Accessing config members in Python code
 
 The firmware converts the JSON file into a `ConfigSettings` object, where the JSON keys are converted
-to Python attributes.  The attribute names are the same as their JSON strings, but converted to upper case (so as to
-appear as constants in the code) and with any non-alphanumeric characters replaced with `_` characters.  If the key
-starts with a number, a `K_` prefix is added. e.g.:
+to Python attributes.  The JSON object's keys must follow these rules, otherwise a `ValueError` will be raised:
 
-- `language` -> `.LANGUAGE`
-- `display_channel` -> `.DISPLAY_CHANNEL`
-- `2pi` -> `K_2PI`
-- `max-frequency` -> `MAX_FREQUENCY`
+1. The string cannot be empty
+1. The string may only contain letters, numbers, and the underscore (`_`) character
+1. The string may not begin with a number
+
+The JSON key is converted to upper-case and turned into a Python attribute of the configuration object. For example,
+this JSON file
+```json
+{
+  "clock_multiplier": 4,
+  "hard_sync": true,
+  "wave_shape: "sine"
+}
+```
+would produce a Python object with these attributes:
+```python
+>>> dir(config_object)
+[
+  '__class__',
+  '__init__',
+  '__module__',
+  '__qualname__',
+  '__dict__',
+  'to_attr_name',
+  'CLOCK_MULTIPLIER',
+  'HARD_SYNC',
+  'WAVE_SHAPE'
+]
+
+>>> config_object.CLOCK_MULTIPLIER
+4
+
+>>> config_object.HARD_SYNC
+True
+
+>>> config_object.WAVE_SHAPE
+'sine'
+```
 
 The `europi` namespace contains `.europi_config` and `.experimental_config` members that contain all of the
 configuration attributes described in the sections above:

--- a/software/CONFIGURATION.md
+++ b/software/CONFIGURATION.md
@@ -126,11 +126,18 @@ configuration attributes described in the sections above:
 ]
 ```
 
-In code:
-
+When you import the `europi` namespace into your project you can access the `europi_config` object like this:
 ```python
-from europi import europi_config
+from europi import *
 
 # A voltage range we can select from in a user menu
 VOLTAGE_RANGE = range(0, europi_config.MAX_OUTPUT_VOLTAGE)
+```
+
+Alternatively, you can access it using the fully qualified namespace too:
+```python
+import europi
+
+# A voltage range we can select from in a user menu
+VOLTAGE_RANGE = range(0, europi.europi_config.MAX_OUTPUT_VOLTAGE)
 ```

--- a/software/CONFIGURATION.md
+++ b/software/CONFIGURATION.md
@@ -98,8 +98,8 @@ configuration attributes described in the sections above:
 In code:
 
 ```python
-import europi
+from europi import europi_config
 
 # A voltage range we can select from in a user menu
-VOLTAGE_RANGE = range(0, europi.europi_config.MAX_OUTPUT_VOLTAGE)
+VOLTAGE_RANGE = range(0, europi_config.MAX_OUTPUT_VOLTAGE)
 ```

--- a/software/CONFIGURATION.md
+++ b/software/CONFIGURATION.md
@@ -98,8 +98,8 @@ True
 'sine'
 ```
 
-`europi.py` contains objects called `europi_config` and `experimental_config` which contain the configuration attributes
-described above:
+`europi.py` contains objects called `europi_config` and `experimental_config` which implement the core & experimental
+customizations described in the sections above. Below is a detailed summary of the contents of these objects:
 
 ```python
 >>> from europi import europi_config

--- a/software/CONFIGURATION.md
+++ b/software/CONFIGURATION.md
@@ -98,8 +98,8 @@ True
 'sine'
 ```
 
-The `europi` namespace contains `.europi_config` and `.experimental_config` members that contain all of the
-configuration attributes described in the sections above:
+`europi.py` contains objects called `europi_config` and `experimental_config` which contain the configuration attributes
+described above:
 
 ```python
 >>> from europi import europi_config
@@ -126,7 +126,7 @@ configuration attributes described in the sections above:
 ]
 ```
 
-When you import the `europi` namespace into your project you can access the `europi_config` object like this:
+When you import `europi` into your project you can access the `europi_config` object like this:
 ```python
 from europi import *
 
@@ -134,7 +134,7 @@ from europi import *
 VOLTAGE_RANGE = range(0, europi_config.MAX_OUTPUT_VOLTAGE)
 ```
 
-Alternatively, you can access it using the fully qualified namespace too:
+Alternatively, you can access it using the fully qualified namespace:
 ```python
 import europi
 

--- a/software/CONFIGURATION.md
+++ b/software/CONFIGURATION.md
@@ -63,7 +63,7 @@ to Python attributes.  The JSON object's keys must follow these rules, otherwise
 1. The string may not be empty
 1. The string may only contain letters, numbers, and the underscore (`_`) character
 1. The string may not begin with a number
-1. The string should be in `ALL_CAPS` -- this is not enforced, but is highly recommended
+1. The string should be in `ALL_CAPS`
 
 The JSON key is converted into a Python attribute of the configuration object. For example, this JSON file
 ```json

--- a/software/CONFIGURATION.md
+++ b/software/CONFIGURATION.md
@@ -57,7 +57,7 @@ shows the default configuration:
 
 # Accessing config members in Python code
 
-The configuration manger converts the JSON file into a `ConfigSettings` object, where the JSON keys are converted
+The firmware converts the JSON file into a `ConfigSettings` object, where the JSON keys are converted
 to Python attributes.  The attribute names are the same as their JSON strings, but converted to upper case (so as to
 appear as constants in the code) and with any alphanumeric characters replaced with `_` characters.  If the key starts
 with a number, a `K_` prefix is added. e.g.:
@@ -79,7 +79,6 @@ configuration attributes described in the sections above:
   '__module__',
   '__qualname__',
   '__dict__',
-  '__eq__',
   'to_attr_name',
   'CPU_FREQ',
   'DISPLAY_CHANNEL',

--- a/software/CONFIGURATION.md
+++ b/software/CONFIGURATION.md
@@ -6,35 +6,36 @@ Raspberry Pi Pico. If this file does not exist, default settings will be loaded.
 default configuration:
 ```json
 {
-    "europi_model": "europi",
-    "pico_model": "pico",
-    "cpu_freq": 250000000,
-    "rotate_display": false,
-    "display_width": 128,
-    "display_height": 32,
-    "display_sda": 0,
-    "display_scl": 1,
-    "display_channel": 0,
-    "max_output_voltage": 10,
-    "max_input_voltage": 12,
-    "gate_voltage": 5
+    "EUROPI_MODEL": "europi",
+    "PICO_MODEL": "pico",
+    "CPU_FREQ": 250000000,
+    "ROTATE_DISPLAY": false,
+    "DISPLAY_WIDTH": 128,
+    "DISPLAY_HEIGHT": 32,
+    "DISPLAY_SDA": 0,
+    "DISPLAY_SCL": 1,
+    "DISPLAY_CHANNEL": 0,
+    "MAX_OUTPUT_VOLTAGE": 10,
+    "MAX_INPUT_VOLTAGE": 12,
+    "GATE_VOLTAGE": 5
 }
 ```
 
-- `europi_model` specifies the type of EuroPi module. Currently only `"europi"` is supported
-- `pico_model` must be one of `"pico"` or `"pico w"`
-- `cpu_freq` must be one of `250000000` or `125000000`
-- `rotate_display` must be one of `false` or `true`
-- `display_width` is the width of the screen in pixels. The standard EuroPi screen is 128 pixels wide
-- `display_height` is the height of the screen in pixels. The standard EuroPi screen is 32 pixels tall
-- `display_sda` is the I²C SDA pin used for the display. Only SDA capable pins can be selected
-- `display_scl` is the I²C SCL pin used for the display. Only SCL capable pins can be selected
-- `display_channel` is the I²C channel used for the display, either 0 or 1.
-- `max_output_voltage` is an integer in the range `[0, 10]` indicating the maximum voltage CV output can generate.
+- `EUROPI_MODEL` specifies the type of EuroPi module. Currently only `"europi"` is supported
+- `PICO_MODEL` must be one of `"pico"` or `"pico w"`
+- `CPU_FREQ` must be one of `250000000` or `125000000`
+- `ROTATE_DISPLAY` must be one of `false` or `true`
+- `DISPLAY_WIDTH` is the width of the screen in pixels. The standard EuroPi screen is 128 pixels wide
+- `DISPLAY_HEIGHT` is the height of the screen in pixels. The standard EuroPi screen is 32 pixels tall
+- `DISPLAY_SDA` is the I²C SDA pin used for the display. Only SDA capable pins can be selected
+- `DISPLAY_SCL` is the I²C SCL pin used for the display. Only SCL capable pins can be selected
+- `DISPLAY_CHANNEL` is the I²C channel used for the display, either 0 or 1.
+- `MAX_OUTPUT_VOLTAGE` is an integer in the range `[0, 10]` indicating the maximum voltage CV output can generate.
   The hardware is capable of 10V maximum
-- `max_input_voltage` is an integer in the range `[0, 12]` indicating the maximum allowed voltage into the `ain` jack.
+- `MAX_INPUT_VOLTAGE` is an integer in the range `[0, 12]` indicating the maximum allowed voltage into the `ain` jack.
   The hardware is capable of 12V maximum
-- `gate_voltage` is an integer in the range `[0, 12]` indicating the voltage that an output will produce when `cvx.on()` is called
+- `GATE_VOLTAGE` is an integer in the range `[0, 10]` indicating the voltage that an output will produce when `cvx.on()`
+  is called. This value must not be higher than `MAX_OUTPUT_VOLTAGE`
 
 
 
@@ -47,11 +48,11 @@ shows the default configuration:
 
 ```json
 {
-    "volts_per_octave": 1.0,
+    "VOLTS_PER_OCTAVE": 1.0,
 }
 ```
 
-- `volts_per_octave` must be one of `1.0` (Eurorack standard) or `1.2` (Buchla standard)
+- `VOLTS_PER_OCTAVE` must be one of `1.0` (Eurorack standard) or `1.2` (Buchla standard)
 
 
 # Accessing config members in Python code
@@ -59,17 +60,17 @@ shows the default configuration:
 The firmware converts the JSON file into a `ConfigSettings` object, where the JSON keys are converted
 to Python attributes.  The JSON object's keys must follow these rules, otherwise a `ValueError` will be raised:
 
-1. The string cannot be empty
+1. The string may not be empty
 1. The string may only contain letters, numbers, and the underscore (`_`) character
 1. The string may not begin with a number
+1. The string should be in `ALL_CAPS` -- this is not enforced, but is highly recommended
 
-The JSON key is converted to upper-case and turned into a Python attribute of the configuration object. For example,
-this JSON file
+The JSON key is converted into a Python attribute of the configuration object. For example, this JSON file
 ```json
 {
-  "clock_multiplier": 4,
-  "hard_sync": true,
-  "wave_shape": "sine"
+  "CLOCK_MULTIPLIER": 4,
+  "HARD_SYNC": true,
+  "WAVE_SHAPE": "sine"
 }
 ```
 would produce a Python object with these attributes:

--- a/software/CONFIGURATION.md
+++ b/software/CONFIGURATION.md
@@ -40,7 +40,7 @@ default configuration:
 
 # Experimental configuration
 
-Other configuration properties are used by [experimental features](/software/firmware/experimental/experimental_config.py)
+Other configuration properties are used by [experimental features](/software/firmware/experimental/__init__.py)
 and can be set using a similar static configuration file. This file is located at `/config/ExperimentalConfig.json`
 on the Raspberry Pi Pico. If this file does not exist, default settings will be loaded.  The following
 shows the default configuration:

--- a/software/contrib/consequencer.py
+++ b/software/contrib/consequencer.py
@@ -72,8 +72,8 @@ class Consequencer(EuroPiScript):
         self.CvPattern_prev = 0
         self.reset_timeout = 1000
         self.maxRandomPatterns = 32  # This prevents a memory allocation error
-        self.maxCvVoltage = clamp(europi_config["max_output_voltage"], 0, 9)  # The maximum is 9 to maintain single digits in the voltage list
-        self.gateVoltage = europi_config["gate_voltage"]
+        self.maxCvVoltage = clamp(europi_config.MAX_OUTPUT_VOLTAGE, 0, 9)  # The maximum is 9 to maintain single digits in the voltage list
+        self.gateVoltage = europi_config.GATE_VOLTAGE
         self.gateVoltages = [0, self.gateVoltage]
 
         self.ainVal = 0

--- a/software/contrib/diagnostic.py
+++ b/software/contrib/diagnostic.py
@@ -49,7 +49,7 @@ class Diagnostic(EuroPiScript):
             5,
             10,  # max
         ]
-        self.temp_units = self.config.TEMP_UNITS
+        self.temp_units = self.config["temp_units"]
         self.use_fahrenheit = self.temp_units == "F"
 
     @classmethod

--- a/software/contrib/diagnostic.py
+++ b/software/contrib/diagnostic.py
@@ -49,7 +49,7 @@ class Diagnostic(EuroPiScript):
             5,
             10,  # max
         ]
-        self.temp_units = self.config["temp_units"]
+        self.temp_units = self.config.TEMP_UNITS
         self.use_fahrenheit = self.temp_units == "F"
 
     @classmethod

--- a/software/contrib/diagnostic.py
+++ b/software/contrib/diagnostic.py
@@ -54,7 +54,7 @@ class Diagnostic(EuroPiScript):
 
     @classmethod
     def config_points(cls):
-        return [configuration.choice(name="temp_units", choices=["C", "F"], default="C")]
+        return [configuration.choice(name="TEMP_UNITS", choices=["C", "F"], default="C")]
 
     def calc_temp(self):
         # see the pico's datasheet for the details of this calculation

--- a/software/contrib/egressus_melodiam.py
+++ b/software/contrib/egressus_melodiam.py
@@ -62,7 +62,7 @@ slewGeneratorObjects[] contains 6 object (one for each output)
 Each slewGeneratorObjects[] object is a reference to a copy of the self.slewGenerator() function.
 The self.slewGenerator() function receives a buffer filled with samples and yields one sample each time it is called using next()
 
-In order to maintain the best balance of smooth waves and Rpi pico memory usage, an algorithm is used to vary the 
+In order to maintain the best balance of smooth waves and Rpi pico memory usage, an algorithm is used to vary the
 sample rate automatically based on the selected output division.
 This causes the sample rate to be at minium when there is a slow clock and high output division.
 Conversely, when there is a fast clock and low output division a higher sample rate is used to avoid unwanted steps
@@ -91,7 +91,7 @@ KNOB_CHANGE_TOLERANCE = 0.999
 
 # Set the maximum CV voltage using a global config value
 # Important: Needs firmware v0.12.1 or higher
-MAX_CV_VOLTAGE = europi_config["max_output_voltage"]
+MAX_CV_VOLTAGE = europi_config.MAX_OUTPUT_VOLTAGE
 
 MAX_STEP_LENGTH = 32
 
@@ -316,7 +316,7 @@ class EgressusMelodiam(EuroPiScript):
 
     def generateNewRandomCVPattern(self, new=True, activePatternOnly=False):
         """Generate new CV pattern for existing bank or create a new bank
-        
+
         @param new  If true, create a new pattern/overwrite the existing one. Otherwise re-use the existing pattern
         @param activePatternOnly  If true, generate pattern for selected output. Otherwise generate pattern for all outputs
 
@@ -435,7 +435,7 @@ class EgressusMelodiam(EuroPiScript):
 
                         # Update the last sample output time
                         self.lastSlewVoltageOutputTime[idx] = ticks_ms()
-                
+
                     except StopIteration:
                         continue
 
@@ -717,7 +717,7 @@ class EgressusMelodiam(EuroPiScript):
 
     def stepUpStepDown(self, start, stop, num, buffer):
         """Produces step up, step down
-        
+
         @param start  Starting value
         @param stop   Target value
         @param num    Number of samples required
@@ -741,7 +741,7 @@ class EgressusMelodiam(EuroPiScript):
 
     def linspace(self, start, stop, num, buffer):
         """Produces a linear transition
-        
+
         @param start  Starting value
         @param stop   Target value
         @param num    Number of samples required
@@ -760,7 +760,7 @@ class EgressusMelodiam(EuroPiScript):
 
     def logUpStepDown(self, start, stop, num, buffer):
         """Produces a log up/step down transition
-        
+
         @param start  Starting value
         @param stop   Target value
         @param num    Number of samples required
@@ -793,7 +793,7 @@ class EgressusMelodiam(EuroPiScript):
 
     def stepUpExpDown(self, start, stop, num, buffer):
         """Produces a step up, exponential down transition
-        
+
         @param start  Starting value
         @param stop   Target value
         @param num    Number of samples required
@@ -816,7 +816,7 @@ class EgressusMelodiam(EuroPiScript):
 
     def smooth(self, start, stop, num, buffer):
         """Produces smooth curve using half a cosine wave
-        
+
         @param start  Starting value
         @param stop   Target value
         @param num    The number of samples required
@@ -848,7 +848,7 @@ class EgressusMelodiam(EuroPiScript):
 
     def expUpexpDown(self, start, stop, num, buffer):
         """Produces pointy exponential wave using a quarter cosine up and a quarter cosine down
-        
+
         @param start  Starting value
         @param stop   Target value
         @param num    The number of samples required
@@ -886,7 +886,7 @@ class EgressusMelodiam(EuroPiScript):
     def sharkTooth(self, start, stop, num, buffer):
         """Produces a sharktooth wave with an approximate log curve up and approximate
         exponential curve down
-        
+
         @param start  Starting value
         @param stop   Target value
         @param num    The number of samples required
@@ -924,7 +924,7 @@ class EgressusMelodiam(EuroPiScript):
     def sharkToothReverse(self, start, stop, num, buffer):
         """Produces a reverse sharktooth wave with an approximate exponential curve up and approximate
         log curve down
-        
+
         @param start  Starting value
         @param stop   Target value
         @param num    The number of samples required

--- a/software/contrib/envelope_generator.py
+++ b/software/contrib/envelope_generator.py
@@ -14,7 +14,7 @@ class EnvelopeGenerator(EuroPiScript):
         self.sustain_mode = state.get("sustain_mode", 1)
         self.looping_mode = state.get("looping_mode", 0)
 
-        self.max_output_voltage = europi_config["max_output_voltage"]
+        self.max_output_voltage = europi_config.MAX_OUTPUT_VOLTAGE
 
         #Distance of envelope voltage from max voltage/0 before 'jumping' to it - prevents large logarithmic calculations
         self.voltage_threshold = 0.1
@@ -224,4 +224,3 @@ class EnvelopeGenerator(EuroPiScript):
 
 if __name__ == "__main__":
     EnvelopeGenerator().main()
-

--- a/software/contrib/turing_machine.py
+++ b/software/contrib/turing_machine.py
@@ -210,7 +210,7 @@ class EuroPiTuringMachine(EuroPiScript):
         self.tm = TuringMachine(
             bit_count=bit_count,
             max_output_voltage=max_output_voltage,
-            clear_on_write=self.config.WRITE_VALUE == 0,
+            clear_on_write=self.config["write_value"] == 0,
             length=initial_length,
             scale=MAX_OUTPUT_VOLTAGE * initial_scale_percent,
         )
@@ -232,9 +232,9 @@ class EuroPiTuringMachine(EuroPiScript):
             .build()
         )
 
-        self.cv1_pulse_bit = self.config.CV1_PULSE_BIT
-        self.cv2_pulse_bit = self.config.CV2_PULSE_BIT
-        self.cv3_pulse_bit = self.config.CV3_PULSE_BIT
+        self.cv1_pulse_bit = self.config["cv1_pulse_bit"]
+        self.cv2_pulse_bit = self.config["cv2_pulse_bit"]
+        self.cv3_pulse_bit = self.config["cv3_pulse_bit"]
 
         @din.handler
         def clock():

--- a/software/contrib/turing_machine.py
+++ b/software/contrib/turing_machine.py
@@ -297,11 +297,11 @@ class EuroPiTuringMachine(EuroPiScript):
         bitcount_range = range(1, min(DEFAULT_BIT_COUNT, 8))
 
         return [
-            configuration.choice(name="write_value", choices=[0, 1], default=0),
+            configuration.choice(name="WRITE_VALUE", choices=[0, 1], default=0),
             # simulate the actual bits available in the pulses expander (1-7)
-            configuration.integer(name="cv1_pulse_bit", range=bitcount_range, default=1),
-            configuration.integer(name="cv2_pulse_bit", range=bitcount_range, default=2),
-            configuration.integer(name="cv3_pulse_bit", range=bitcount_range, default=4),
+            configuration.integer(name="CV1_PULSE_BIT", range=bitcount_range, default=1),
+            configuration.integer(name="CV2_PULSE_BIT", range=bitcount_range, default=2),
+            configuration.integer(name="CV3_PULSE_BIT", range=bitcount_range, default=4),
         ]
 
     def main(self):

--- a/software/contrib/turing_machine.py
+++ b/software/contrib/turing_machine.py
@@ -1,5 +1,5 @@
 """
- A script meant to recreate the Music Thing Modular Turning Machine Random Sequencer as faithfully
+ A script meant to recreate the Music Thing Modular Turning Machine Random Sequencer as faithfully 
  as possible on the EuroPi hardware using bit shift operations to mimic the analog shift register.
 
 din - clock
@@ -15,7 +15,7 @@ cv4 - pulse cv1 & cv2
 cv5 - pulse cv2 & cv3
 cv6 - sequence out
 
-If you'd like to use different bits for the pulse outputs you can update the `CVX_PULSE_BIT`
+If you'd like to use different bits for the pulse outputs you can update the `CVX_PULSE_BIT` 
 constants below.
 
 The length, scale, and bit pattern are saved whenever the knob 2 state is changed, or when the user

--- a/software/contrib/turing_machine.py
+++ b/software/contrib/turing_machine.py
@@ -1,5 +1,5 @@
 """
- A script meant to recreate the Music Thing Modular Turning Machine Random Sequencer as faithfully 
+ A script meant to recreate the Music Thing Modular Turning Machine Random Sequencer as faithfully
  as possible on the EuroPi hardware using bit shift operations to mimic the analog shift register.
 
 din - clock
@@ -15,7 +15,7 @@ cv4 - pulse cv1 & cv2
 cv5 - pulse cv2 & cv3
 cv6 - sequence out
 
-If you'd like to use different bits for the pulse outputs you can update the `CVX_PULSE_BIT` 
+If you'd like to use different bits for the pulse outputs you can update the `CVX_PULSE_BIT`
 constants below.
 
 The length, scale, and bit pattern are saved whenever the knob 2 state is changed, or when the user
@@ -210,7 +210,7 @@ class EuroPiTuringMachine(EuroPiScript):
         self.tm = TuringMachine(
             bit_count=bit_count,
             max_output_voltage=max_output_voltage,
-            clear_on_write=self.config["write_value"] == 0,
+            clear_on_write=self.config.WRITE_VALUE == 0,
             length=initial_length,
             scale=MAX_OUTPUT_VOLTAGE * initial_scale_percent,
         )
@@ -232,9 +232,9 @@ class EuroPiTuringMachine(EuroPiScript):
             .build()
         )
 
-        self.cv1_pulse_bit = self.config["cv1_pulse_bit"]
-        self.cv2_pulse_bit = self.config["cv2_pulse_bit"]
-        self.cv3_pulse_bit = self.config["cv3_pulse_bit"]
+        self.cv1_pulse_bit = self.config.CV1_PULSE_BIT
+        self.cv2_pulse_bit = self.config.CV2_PULSE_BIT
+        self.cv3_pulse_bit = self.config.CV3_PULSE_BIT
 
         @din.handler
         def clock():

--- a/software/contrib/turing_machine.py
+++ b/software/contrib/turing_machine.py
@@ -210,7 +210,7 @@ class EuroPiTuringMachine(EuroPiScript):
         self.tm = TuringMachine(
             bit_count=bit_count,
             max_output_voltage=max_output_voltage,
-            clear_on_write=self.config["write_value"] == 0,
+            clear_on_write=self.config.WRITE_VALUE == 0,
             length=initial_length,
             scale=MAX_OUTPUT_VOLTAGE * initial_scale_percent,
         )
@@ -232,9 +232,9 @@ class EuroPiTuringMachine(EuroPiScript):
             .build()
         )
 
-        self.cv1_pulse_bit = self.config["cv1_pulse_bit"]
-        self.cv2_pulse_bit = self.config["cv2_pulse_bit"]
-        self.cv3_pulse_bit = self.config["cv3_pulse_bit"]
+        self.cv1_pulse_bit = self.config.CV1_PULSE_BIT
+        self.cv2_pulse_bit = self.config.CV2_PULSE_BIT
+        self.cv3_pulse_bit = self.config.CV3_PULSE_BIT
 
         @din.handler
         def clock():

--- a/software/firmware/configuration.py
+++ b/software/firmware/configuration.py
@@ -267,14 +267,4 @@ class ConfigSettings:
             except ValueError:
                 return False
         elif type(that) is ConfigSettings:
-            # Make sure every key self exists and is equal to the equivalent in that
-            for k in self.__dict__.keys():
-                if not k in that.__dict__ or self.__dict__[k] != that.__dict__[k]:
-                    return False
-
-            # Make sure every key in that exists and is equal to its equivalent in self
-            for k in that.__dict__.keys():
-                if not k in self.__dict__ or self.__dict__[k] != that.__dict__[k]:
-                    return False
-
-            return True
+            return self.__dict__ == that.__dict__

--- a/software/firmware/configuration.py
+++ b/software/firmware/configuration.py
@@ -212,7 +212,7 @@ class ConfigFile:
         delete_file(ConfigFile.config_filename(cls))
 
 
-class ConfigSettings:
+class ConfigSettings(dict):
     """Collects the configuration settings into an object with attributes instead of a dict with keys
 
     Dict keys are converted to upper-case strings with underscores
@@ -223,9 +223,11 @@ class ConfigSettings:
 
         @param d  The raw dict loaded from the configuration file
         """
+        super().__init__()
         self.__dict__ = {}
 
         for k in d.keys():
+            self[k] = d[k]
             cname = k.upper().strip().replace(" ", "_").replace("-", "_")
             if cname[0].isdigit():
                 cname = f"_{cname}"

--- a/software/firmware/configuration.py
+++ b/software/firmware/configuration.py
@@ -213,8 +213,6 @@ class ConfigFile:
 
 class ConfigSettings:
     """Collects the configuration settings into an object with attributes instead of a dict with keys
-
-    Dict keys are converted to upper-case strings with underscores
     """
 
     def __init__(self, d):
@@ -225,33 +223,31 @@ class ConfigSettings:
         self.__dict__ = {}  # required for getattr & setattr
 
         for k in d.keys():
-            cname = self.to_attr_name(k)
-            setattr(self, cname, d[k])
+            self.validate_key(k)
+            setattr(self, k, d[k])
 
-    def to_attr_name(self, key):
-        """Converts a dict key string to its equivalent attribute name
+    def validate_key(self, key):
+        """Ensures that a `dict` key is a valid attribute name
 
-        @param key  The string to convert
-        @return     The same string, converted to upper-case, preserving underscores
+        @param key  The string to check
+        @return     True if the key is valid. Otherwise an exception is raised
 
         @exception  ValueError if the key contains invalid characters; only letters, numbers, hyphens, and underscores
                     are permitted. They key cannot be length 0, nor can it begin with a number
         """
         key = key.strip()
-        s = ""
         for ch in key:
-            if ch.isalpha() or ch.isdigit() or ch == "_":
-                s += ch.upper()
-            else:
+            if not (ch.isalpha() or ch.isdigit() or ch == "_"):
                 raise ValueError(
                     f"Invalid attribute name: {key}. Keys cannot contain the character {ch}"
                 )
 
-        if len(s) == 0:
+        if len(key) == 0:
             raise ValueError("Invalid attribute name: key cannot be empty")
-        elif s[0].isdigit():
+        elif key[0].isdigit():
             raise ValueError("Invalid attribute name: key cannot start with a number")
-        return s
+
+        return True
 
     def __eq__(self, that):
         """Allows comparing the config object directly to either another config object or a dict

--- a/software/firmware/configuration.py
+++ b/software/firmware/configuration.py
@@ -223,7 +223,7 @@ class ConfigSettings:
 
         @param d  The raw dict loaded from the configuration file
         """
-        self.__dict__ = {}     # required for getattr & setattr
+        self.__dict__ = {}  # required for getattr & setattr
 
         for k in d.keys():
             cname = self.to_attr_name(k)

--- a/software/firmware/configuration.py
+++ b/software/firmware/configuration.py
@@ -244,7 +244,9 @@ class ConfigSettings:
             if ch.isalpha() or ch.isdigit() or ch == "_":
                 s += ch.upper()
             else:
-                raise ValueError(f"Invalid attribute name: {key}. Keys cannot contain the character {ch}")
+                raise ValueError(
+                    f"Invalid attribute name: {key}. Keys cannot contain the character {ch}"
+                )
 
         if len(s) == 0:
             raise ValueError("Invalid attribute name: key cannot be empty")

--- a/software/firmware/configuration.py
+++ b/software/firmware/configuration.py
@@ -240,7 +240,7 @@ class ConfigSettings:
                     If the string starts with a number, a leading 'K_' is added
         """
         key = key.strip()
-        s = ''
+        s = ""
         for ch in key:
             if ch.isalpha() or ch.isdigit():
                 s += ch.upper()

--- a/software/firmware/configuration.py
+++ b/software/firmware/configuration.py
@@ -223,7 +223,7 @@ class ConfigSettings:
 
         @param d  The raw dict loaded from the configuration file
         """
-        self.__dict__ = {}
+        self.__dict__ = {}     # required for getattr & setattr
 
         for k in d.keys():
             cname = self.to_attr_name(k)

--- a/software/firmware/configuration.py
+++ b/software/firmware/configuration.py
@@ -212,21 +212,20 @@ class ConfigFile:
         delete_file(ConfigFile.config_filename(cls))
 
 
-class ConfigSettings(dict):
-    """A dict wrapper that presents its contents as attributes
+class ConfigSettings:
+    """Collects the configuration settings into an object with attributes instead of a dict with keys
+
+    Dict keys are converted to upper-case strings with underscores
     """
 
     def __init__(self, d):
         """Constructor
 
-        @param d  A dict to copy into this instance
+        @param d  The raw dict loaded from the configuration file
         """
-        super().__init__()
         self.__dict__ = {}
 
         for k in d.keys():
-            self[k] = d[k]
-
             cname = k.upper().strip().replace(' ', '_').replace('-', '_')
             if cname[0].isdigit():
                 cname = f"_{cname}"

--- a/software/firmware/configuration.py
+++ b/software/firmware/configuration.py
@@ -251,3 +251,29 @@ class ConfigSettings:
         elif s[0].isdigit():
             raise ValueError("Invalid attribute name: key cannot start with a number")
         return s
+
+    def __eq__(self, that):
+        """Allows comparing the config object directly to either another config object or a dict
+
+        @param that  The object we're comparing to, either a dict or another ConfigSettings object
+
+        @return True if the two objects are equivalent, otherwise False
+        """
+        if type(that) is dict:
+            try:
+                that = ConfigSettings(that)
+                return self == that
+            except ValueError:
+                return False
+        elif type(that) is ConfigSettings:
+            # Make sure every key self exists and is equal to the equivalent in that
+            for k in self.__dict__.keys():
+                if not k in that.__dict__ or self.__dict__[k] != that.__dict__[k]:
+                    return False
+
+            # Make sure every key in that exists and is equal to its equivalent in self
+            for k in that.__dict__.keys():
+                if not k in self.__dict__ or self.__dict__[k] != that.__dict__[k]:
+                    return False
+
+            return True

--- a/software/firmware/configuration.py
+++ b/software/firmware/configuration.py
@@ -227,9 +227,6 @@ class ConfigSettings:
 
         for k in d.keys():
             cname = self.to_attr_name(k)
-            if cname[0].isdigit():
-                cname = f"_{cname}"
-
             setattr(self, cname, d[k])
 
     def to_attr_name(self, key):
@@ -249,19 +246,3 @@ class ConfigSettings:
         if len(s) > 0 and s[0].isdigit():
             s = f"K_{s}"
         return s
-
-    def __eq__(self, d):
-        """Compare this object's contents with a dict
-
-        Dict keys are converted to attribute names and checked.  This is used by the tests to verify
-        that the class is working correctly.
-
-        @param d  The dictionary to compare to
-        @return   True if this instance's attributes are a superset of the dict's keys
-                  i.e. every key is an attribute, but not every attribute must be a key
-        """
-        for k in d.keys():
-            k_attr = self.to_attr_name(k)
-            if getattr(self, k_attr) != d[k]:
-                return False
-        return True

--- a/software/firmware/configuration.py
+++ b/software/firmware/configuration.py
@@ -226,7 +226,7 @@ class ConfigSettings:
         self.__dict__ = {}
 
         for k in d.keys():
-            cname = k.upper().strip().replace(' ', '_').replace('-', '_')
+            cname = k.upper().strip().replace(" ", "_").replace("-", "_")
             if cname[0].isdigit():
                 cname = f"_{cname}"
 

--- a/software/firmware/configuration.py
+++ b/software/firmware/configuration.py
@@ -195,7 +195,6 @@ class ConfigFile:
         if len(config_spec):
             saved_config = load_json_file(ConfigFile.config_filename(cls))
             config = config_spec.default_config()
-
             validation = config_spec.validate(saved_config)
 
             if not validation.is_valid:

--- a/software/firmware/configuration.py
+++ b/software/firmware/configuration.py
@@ -212,8 +212,7 @@ class ConfigFile:
 
 
 class ConfigSettings:
-    """Collects the configuration settings into an object with attributes instead of a dict with keys
-    """
+    """Collects the configuration settings into an object with attributes instead of a dict with keys"""
 
     def __init__(self, d):
         """Constructor

--- a/software/firmware/configuration.py
+++ b/software/firmware/configuration.py
@@ -166,8 +166,8 @@ class ConfigFile:
 
     @staticmethod
     def config_filename(cls):
-        """Returns the filename for teh config file for the given class."""
-        return f"config/config_{cls.__qualname__}.json"
+        """Returns the filename for the config file for the given class."""
+        return f"config/{cls.__qualname__}.json"
 
     @staticmethod
     def save_config(cls, data: dict):
@@ -233,16 +233,21 @@ class ConfigSettings:
         """Converts a dict key string to its equivalent attribute name
 
         @param key  The string to convert
-        @return     The same string, converted to upper-case with non-alphanumeric characters replaced with '_'
-                    If the string starts with a number, a leading 'K_' is added
+        @return     The same string, converted to upper-case, preserving underscores
+
+        @exception  ValueError if the key contains invalid characters; only letters, numbers, hyphens, and underscores
+                    are permitted. They key cannot be length 0, nor can it begin with a number
         """
         key = key.strip()
         s = ""
         for ch in key:
-            if ch.isalpha() or ch.isdigit():
+            if ch.isalpha() or ch.isdigit() or ch == "_":
                 s += ch.upper()
             else:
-                s += "_"
-        if len(s) > 0 and s[0].isdigit():
-            s = f"K_{s}"
+                raise ValueError(f"Invalid attribute name: {key}. Keys cannot contain the character {ch}")
+
+        if len(s) == 0:
+            raise ValueError("Invalid attribute name: key cannot be empty")
+        elif s[0].isdigit():
+            raise ValueError("Invalid attribute name: key cannot start with a number")
         return s

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -63,11 +63,11 @@ experimental_config = load_experimental_config()
 
 
 # OLED component display dimensions.
-OLED_WIDTH = europi_config["display_width"]
-OLED_HEIGHT = europi_config["display_height"]
-I2C_SDA = europi_config["display_sda"]
-I2C_SCL = europi_config["display_scl"]
-I2C_CHANNEL = europi_config["display_channel"]
+OLED_WIDTH = europi_config.DISPLAY_WIDTH
+OLED_HEIGHT = europi_config.DISPLAY_HEIGHT
+I2C_SDA = europi_config.DISPLAY_SDA
+I2C_SCL = europi_config.DISPLAY_SCL
+I2C_CHANNEL = europi_config.DISPLAY_CHANNEL
 I2C_FREQUENCY = 400000
 
 # Standard max int consts.
@@ -75,12 +75,12 @@ MAX_UINT16 = 65535
 
 # Analogue voltage read range.
 MIN_INPUT_VOLTAGE = 0
-MAX_INPUT_VOLTAGE = europi_config["max_input_voltage"]
+MAX_INPUT_VOLTAGE = europi_config.MAX_INPUT_VOLTAGE
 DEFAULT_SAMPLES = 32
 
 # Output voltage range
 MIN_OUTPUT_VOLTAGE = 0
-MAX_OUTPUT_VOLTAGE = europi_config["max_output_voltage"]
+MAX_OUTPUT_VOLTAGE = europi_config.MAX_OUTPUT_VOLTAGE
 
 # PWM Frequency
 PWM_FREQ = 100_000
@@ -518,7 +518,7 @@ class Display(SSD1306_I2C):
                     "EuroPi Hardware Error:\nMake sure the OLED display is connected correctly"
                 )
         super().__init__(self.width, self.height, i2c)
-        self.rotate(europi_config["rotate_display"])
+        self.rotate(europi_config.ROTATE_DISPLAY)
 
     def rotate(self, rotate):
         """Flip the screen from its default orientation
@@ -578,7 +578,7 @@ class Output:
         self._duty = 0
         self.MIN_VOLTAGE = min_voltage
         self.MAX_VOLTAGE = max_voltage
-        self.gate_voltage = clamp(europi_config["gate_voltage"], self.MIN_VOLTAGE, self.MAX_VOLTAGE)
+        self.gate_voltage = clamp(europi_config.GATE_VOLTAGE, self.MIN_VOLTAGE, self.MAX_VOLTAGE)
 
         self._gradients = []
         for index, value in enumerate(OUTPUT_CALIBRATION_VALUES[:-1]):
@@ -641,7 +641,7 @@ cvs = [cv1, cv2, cv3, cv4, cv5, cv6]
 usb_connected = DigitalReader(PIN_USB_CONNECTED, 0)
 
 # Overclock the Pico for improved performance.
-freq(europi_config["cpu_freq"])
+freq(europi_config.CPU_FREQ)
 
 # Reset the module state upon import.
 reset_state()

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -29,6 +29,7 @@ from ssd1306 import SSD1306_I2C
 
 from version import __version__
 
+from configuration import ConfigSettings
 from framebuf import FrameBuffer, MONO_HLSB
 from europi_config import load_europi_config
 from experimental.experimental_config import load_experimental_config
@@ -58,8 +59,10 @@ except ImportError:
 
 
 # Initialize EuroPi global singleton instance variables.
-europi_config = load_europi_config()
-experimental_config = load_experimental_config()
+__europi_config_json = load_europi_config()
+__experimental_config_json = load_experimental_config()
+europi_config = ConfigSettings(__europi_config_json)
+experimental_config = ConfigSettings(__experimental_config_json)
 
 
 # OLED component display dimensions.

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -58,11 +58,9 @@ except ImportError:
     ]
 
 
-# Initialize EuroPi global singleton instance variables.
-__europi_config_json = load_europi_config()
-__experimental_config_json = load_experimental_config()
-europi_config = ConfigSettings(__europi_config_json)
-experimental_config = ConfigSettings(__experimental_config_json)
+# Initialize EuroPi global singleton instance variables
+europi_config = load_europi_config()
+experimental_config = load_experimental_config()
 
 
 # OLED component display dimensions.

--- a/software/firmware/europi_config.py
+++ b/software/firmware/europi_config.py
@@ -10,12 +10,12 @@ OVERCLOCKED_CPU_FREQ = 250_000_000
 class EuroPiConfig:
     """This class provides EuroPi's global config points.
 
-    To override the default values, create /config/config_EuroPiConfig.json on the Raspberry Pi Pico
+    To override the default values, create /config/EuroPiConfig.json on the Raspberry Pi Pico
     and populate it with a JSON object. e.g. if your build has the oled mounted upside-down compared
-    to normal, the contents of /config/config_EuroPiConfig.json should look like this:
+    to normal, the contents of /config/EuroPiConfig.json should look like this:
 
     {
-        "rotate_display": true
+        "ROTATE_DISPLAY": true
     }
     """
 
@@ -25,68 +25,68 @@ class EuroPiConfig:
         return [
             # EuroPi revision -- this is currently unused, but reserved for future expansion
             configuration.choice(
-                name="europi_model",
+                name="EUROPI_MODEL",
                 choices = ["europi"],
                 default="europi"
             ),
 
             # CPU & board settings
             configuration.choice(
-                name="pico_model",
+                name="PICO_MODEL",
                 choices=["pico", "pico w"],
                 default="pico"
             ),
             configuration.choice(
-                name="cpu_freq",
+                name="CPU_FREQ",
                 choices=[PICO_DEFAULT_CPU_FREQ, OVERCLOCKED_CPU_FREQ],
                 default=OVERCLOCKED_CPU_FREQ,
             ),
 
             # Display settings
             configuration.boolean(
-                name="rotate_display",
+                name="ROTATE_DISPLAY",
                 default=False
             ),
             configuration.integer(
-                name="display_width",
+                name="DISPLAY_WIDTH",
                 range=range(8, 1024),
                 default=128
             ),
             configuration.integer(
-                name="display_height",
+                name="DISPLAY_HEIGHT",
                 range=range(8, 1024),
                 default=32
             ),
             configuration.choice(
-                name="display_sda",
+                name="DISPLAY_SDA",
                 choices=[0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 26],
                 default=0,
             ),
             configuration.choice(
-                name="display_scl",
+                name="DISPLAY_SCL",
                 choices=[1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 27],
                 default=1,
             ),
             configuration.integer(
-                name="display_channel",
+                name="DISPLAY_CHANNEL",
                 range=range(0, 2),
                 default=0
             ),
 
             # Synthesizer family settings
             configuration.integer(
-                name="max_output_voltage",
+                name="MAX_OUTPUT_VOLTAGE",
                 range=range(1, 11),
                 default=10
             ),
             configuration.integer(
-                name="max_input_voltage",
+                name="MAX_INPUT_VOLTAGE",
                 range=range(1, 13),
                 default=12
             ),
             configuration.integer(
-                name="gate_voltage",
-                range=range(1, 13),
+                name="GATE_VOLTAGE",
+                range=range(1, 11),
                 default=5
             ),
         ]

--- a/software/firmware/europi_config.py
+++ b/software/firmware/europi_config.py
@@ -6,12 +6,6 @@ from configuration import ConfigFile, ConfigSpec
 PICO_DEFAULT_CPU_FREQ = 125_000_000
 OVERCLOCKED_CPU_FREQ = 250_000_000
 
-# Moog/Eurorack standard is 1.0 volts per octave
-MOOG_VOLTS_PER_OCTAVE = 1.0
-
-# Buchla standard is 1.2 volts per octave (0.1 volts per semitone)
-BUCHLA_VOLTS_PER_OCTAVE = 1.2
-
 
 class EuroPiConfig:
     """This class provides EuroPi's global config points.

--- a/software/firmware/europi_script.py
+++ b/software/firmware/europi_script.py
@@ -118,24 +118,16 @@ class EuroPiScript:
             return [configuration.choice(name="language", choices=["english", "french"], default="english")]
 
     Our main method could then use the value of this configuration to display its greeting in the
-    configured language::
+    configured language:
 
         def main(self):
-            if self.config.LANGUAGE == "french":
+            if self.config["language"] == "french":
                 oled.centre_text("Bonjour le monde")
             else:
                 oled.centre_text("Hello world")
 
     Configuration files are validated, so scripts do not need to worry about invalid values. Validation
     failures raise exceptions with messages that will help the user correct their configurations.
-
-    The config object's attributes have names equivalent to the config_point's names, converted to upper-case,
-    with non-alphanumeric characters replaced with the underscore '_' character.  Names that start with numbers
-    have 'K_' added to the start of their names. e.g.:
-
-        - "language" -> .LANGUAGE
-        - "max_frequency" -> .MAX_FREQUENCY
-        - "2pi" -> .K_2PI
 
     Users can create and edit configuration files in order to change a script's configuration. The
     files should be uploaded to the pico in the `/config` directory. To assist in generating initial

--- a/software/firmware/europi_script.py
+++ b/software/firmware/europi_script.py
@@ -121,13 +121,10 @@ class EuroPiScript:
     configured language::
 
         def main(self):
-            if self.config.LANGUAGE == "french":
+            if self.config["language"] == "french":
                 oled.centre_text("Bonjour le monde")
             else:
                 oled.centre_text("Hello world")
-
-    Note that the configuration object's properties share the `name` field of the config_point, but converted to
-    upper case to appear as a constant.
 
     Configuration files are validated, so scripts do not need to worry about invalid values. Validation
     failures raise exceptions with messages that will help the user correct their configurations.
@@ -135,6 +132,14 @@ class EuroPiScript:
     Users can create and edit configuration files in order to change a script's configuration. The
     files should be uploaded to the pico in the `/config` directory. To assist in generating initial
     versions of these files, see `/scripts/generate_default_configs.py`.
+
+    Note that config points can also be accessed as named constants using the same name, converted to upper case:
+
+        def main(self):
+            if self.config.LANGUAGE == "french":
+                oled.centre_text("Bonjour le monde")
+            else:
+                oled.centre_text("Hello world")
     """
 
     def __init__(self):

--- a/software/firmware/europi_script.py
+++ b/software/firmware/europi_script.py
@@ -121,10 +121,13 @@ class EuroPiScript:
     configured language::
 
         def main(self):
-            if self.config["language"] == "french":
+            if self.config.LANGUAGE == "french":
                 oled.centre_text("Bonjour le monde")
             else:
                 oled.centre_text("Hello world")
+
+    Note that the configuration object's properties share the `name` field of the config_point, but converted to
+    upper case to appear as a constant.
 
     Configuration files are validated, so scripts do not need to worry about invalid values. Validation
     failures raise exceptions with messages that will help the user correct their configurations.

--- a/software/firmware/europi_script.py
+++ b/software/firmware/europi_script.py
@@ -121,7 +121,7 @@ class EuroPiScript:
     configured language::
 
         def main(self):
-            if self.config["language"] == "french":
+            if self.config.LANGUAGE == "french":
                 oled.centre_text("Bonjour le monde")
             else:
                 oled.centre_text("Hello world")
@@ -129,17 +129,17 @@ class EuroPiScript:
     Configuration files are validated, so scripts do not need to worry about invalid values. Validation
     failures raise exceptions with messages that will help the user correct their configurations.
 
+    The config object's attributes have names equivalent to the config_point's names, converted to upper-case,
+    with non-alphanumeric characters replaced with the underscore '_' character.  Names that start with numbers
+    have 'K_' added to the start of their names. e.g.:
+
+        - "language" -> .LANGUAGE
+        - "max_frequency" -> .MAX_FREQUENCY
+        - "2pi" -> .K_2PI
+
     Users can create and edit configuration files in order to change a script's configuration. The
     files should be uploaded to the pico in the `/config` directory. To assist in generating initial
     versions of these files, see `/scripts/generate_default_configs.py`.
-
-    Note that config points can also be accessed as named constants using the same name, converted to upper case:
-
-        def main(self):
-            if self.config.LANGUAGE == "french":
-                oled.centre_text("Bonjour le monde")
-            else:
-                oled.centre_text("Hello world")
     """
 
     def __init__(self):

--- a/software/firmware/europi_script.py
+++ b/software/firmware/europi_script.py
@@ -121,7 +121,7 @@ class EuroPiScript:
     configured language:
 
         def main(self):
-            if self.config["language"] == "french":
+            if self.config.LANGUAGE == "french":
                 oled.centre_text("Bonjour le monde")
             else:
                 oled.centre_text("Hello world")

--- a/software/firmware/experimental/experimental_config.py
+++ b/software/firmware/experimental/experimental_config.py
@@ -22,7 +22,7 @@ class ExperimentalConfig:
     quantization, it should look like this:
 
     {
-        "volts_per_octave": 1.2
+        "VOLTS_PER_OCTAVE": 1.2
     }
     """
 
@@ -34,7 +34,7 @@ class ExperimentalConfig:
             # Normally this is intended for Eurorack compatibility, but being open-source someone may
             # want to use it in an ecosystem that uses different specs
             configuration.choice(
-                name="volts_per_octave",
+                name="VOLTS_PER_OCTAVE",
                 choices=[MOOG_VOLTS_PER_OCTAVE, BUCHLA_VOLTS_PER_OCTAVE],
                 default=MOOG_VOLTS_PER_OCTAVE,
             ),

--- a/software/firmware/experimental/quantizer.py
+++ b/software/firmware/experimental/quantizer.py
@@ -7,7 +7,7 @@
 from europi import experimental_config, MAX_OUTPUT_VOLTAGE
 
 ## 1.0V/O is the Eurorack/Moog standard, but Buchla uses 1.2V/O
-VOLTS_PER_OCTAVE = experimental_config["volts_per_octave"]
+VOLTS_PER_OCTAVE = experimental_config.VOLTS_PER_OCTAVE
 
 ## Standard western music scale has 12 semitones per octave
 SEMITONES_PER_OCTAVE = 12
@@ -104,7 +104,7 @@ class Quantizer:
         #  to MAX_OUTPUT_VOLTAGE
         highest_volts = volts
         highest_note = nearest_on_scale
-        while volts > MAX_OUTPUT_VOLTAGE:
+        while volts > europi_config.MAX_OUTPUT_VOLTAGE:
             highest_volts -= VOLTS_PER_SEMITONE
             highest_note = (highest_note - 1) % len(self.notes)
             if self.notes[highest_note]:

--- a/software/firmware/experimental/quantizer.py
+++ b/software/firmware/experimental/quantizer.py
@@ -104,7 +104,7 @@ class Quantizer:
         #  to MAX_OUTPUT_VOLTAGE
         highest_volts = volts
         highest_note = nearest_on_scale
-        while volts > europi_config.MAX_OUTPUT_VOLTAGE:
+        while volts > MAX_OUTPUT_VOLTAGE:
             highest_volts -= VOLTS_PER_SEMITONE
             highest_note = (highest_note - 1) % len(self.notes)
             if self.notes[highest_note]:

--- a/software/tests/test_configuration.py
+++ b/software/tests/test_configuration.py
@@ -104,7 +104,7 @@ def test_helper_int():
 
 
 def test_config_file_name(class_with_config):
-    assert ConfigFile.config_filename(class_with_config) == "config/config_AClassWithConfig.json"
+    assert ConfigFile.config_filename(class_with_config) == "config/AClassWithConfig.json"
 
 
 def test_load_config_no_config(class_with_config):

--- a/software/tests/test_europi_script.py
+++ b/software/tests/test_europi_script.py
@@ -78,4 +78,4 @@ def test_load_config_defaults(script_for_testing_with_config):
 
 
 def test_load_europi_config(script_for_testing_with_config):
-    assert script_for_testing_with_config.europi_config["pico_model"] == "pico"
+    assert script_for_testing_with_config.europi_config.PICO_MODEL == "pico"

--- a/software/tests/test_europi_script.py
+++ b/software/tests/test_europi_script.py
@@ -78,4 +78,4 @@ def test_load_config_defaults(script_for_testing_with_config):
 
 
 def test_load_europi_config(script_for_testing_with_config):
-    assert script_for_testing_with_config.europi_config.PICO_MODEL == "pico"
+    assert script_for_testing_with_config.europi_config["pico_model"] == "pico"


### PR DESCRIPTION
Proposal based on Discord suggestions.  Instead of using a raw `dict` for the static configuration settings, create a wrapper object that creates named-constant-like attributes with the same values as the underlying keys. This exposes the configuration settings with the `dir` function, and should help make it clear that values in `experimental_config` and `europi_config` are to be treated as constants in `contrib` scripts (and elsewhere).

Marked as a draft since this is just a proposal at this stage, and it seemed easiest to create a full MR to show what I meant, rather than code snippets.