### PR TITLE
Remove JSON <--> String conversions when reading/writing files

### DIFF
--- a/software/firmware/bootloader.py
+++ b/software/firmware/bootloader.py
@@ -141,7 +141,8 @@ class BootloaderMenu(EuroPiScript):
         return launch_class
 
     def main(self):
-        script_class_name = self.load_state_str()
+        saved_state = self.load_state_json()
+        script_class_name = saved_state.get("last_launched", None)
         script_class = None
 
         if script_class_name:
@@ -149,7 +150,7 @@ class BootloaderMenu(EuroPiScript):
 
         if not script_class:
             script_class = self.run_menu()
-            self.save_state_str(f"{script_class.__module__}.{script_class.__name__}")
+            self.save_state_json({"last_launched": f"{script_class.__module__}.{script_class.__name__}"})
             machine.reset()
         else:
             # setup the exit handlers, and execute the selection

--- a/software/firmware/bootloader.py
+++ b/software/firmware/bootloader.py
@@ -150,7 +150,9 @@ class BootloaderMenu(EuroPiScript):
 
         if not script_class:
             script_class = self.run_menu()
-            self.save_state_json({"last_launched": f"{script_class.__module__}.{script_class.__name__}"})
+            self.save_state_json(
+                {"last_launched": f"{script_class.__module__}.{script_class.__name__}"}
+            )
             machine.reset()
         else:
             # setup the exit handlers, and execute the selection

--- a/software/firmware/configuration.py
+++ b/software/firmware/configuration.py
@@ -10,7 +10,7 @@ of the valid values that it may have. There are several different types of COnfi
 
 import os
 import json
-from file_utils import load_file, delete_file, load_json_data
+from file_utils import load_file, delete_file, load_json_file
 from collections import namedtuple
 
 Validation = namedtuple("Validation", "is_valid message")
@@ -192,20 +192,16 @@ class ConfigFile:
         """If this class has config points, this method validates and returns the config dictionary
         as saved in this class's config file, else, returns an empty dict."""
         if len(config_spec):
-            data = load_file(ConfigFile.config_filename(cls))
-            config = config_spec.default_config()
-            if not data:
-                return config
-            else:
-                saved_config = load_json_data(data)
-                validation = config_spec.validate(saved_config)
+            saved_config = load_json_file(ConfigFile.config_filename(cls))
+            default_config = config_spec.default_config()
+            validation = config_spec.validate(saved_config)
 
-                if not validation.is_valid:
-                    raise ValueError(validation.message)
+            if not validation.is_valid:
+                raise ValueError(validation.message)
 
-                config.update(saved_config)
+            default_config.update(saved_config)
 
-                return config
+            return default_config
         else:
             return {}
 

--- a/software/firmware/configuration.py
+++ b/software/firmware/configuration.py
@@ -193,15 +193,15 @@ class ConfigFile:
         as saved in this class's config file, else, returns an empty dict."""
         if len(config_spec):
             saved_config = load_json_file(ConfigFile.config_filename(cls))
-            default_config = config_spec.default_config()
+            config = config_spec.default_config()
             validation = config_spec.validate(saved_config)
 
             if not validation.is_valid:
                 raise ValueError(validation.message)
 
-            default_config.update(saved_config)
+            config.update(saved_config)
 
-            return default_config
+            return config
         else:
             return {}
 

--- a/software/firmware/europi_script.py
+++ b/software/firmware/europi_script.py
@@ -170,20 +170,7 @@ class EuroPiScript:
         appropriate save method, such as `save_state_json(state)`. See the
         class documentation for a full example.
         """
-        pass
-
-    def save_state_str(self, state: str):
-        """Take state in persistence format as a string and write to disk.
-
-        .. note::
-            Be mindful of how often `save_state_str()` is called because
-            writing to disk too often can slow down the performance of your
-            script. Only call save state when state has changed and consider
-            adding a time since last save check to reduce save frequency.
-        """
-        with open(self._state_filename, "w") as file:
-            file.write(state)
-            self._last_saved = ticks_ms()
+        self.save_state_json({})
 
     def save_state_bytes(self, state: bytes):
         """Take state in persistence format as bytes and write to disk.
@@ -210,14 +197,6 @@ class EuroPiScript:
         with open(self._state_filename, "w") as file:
             json.dump(state, file)
             self._last_saved = ticks_ms()
-
-    def load_state_str(self) -> str:
-        """Check disk for saved state, if it exists, return the raw state value as a string.
-
-        Check for a previously saved state. If it exists, return state as a
-        string. If no state is found, an empty string will be returned.
-        """
-        return load_file(self._state_filename, "r")
 
     def load_state_bytes(self) -> bytes:
         """Check disk for saved state, if it exists, return the raw state value as bytes.

--- a/software/firmware/file_utils.py
+++ b/software/firmware/file_utils.py
@@ -3,25 +3,37 @@ import json
 
 
 def load_file(filename, mode: str = "r") -> any:
+    """Load a file and return its contents
+
+    @param filename  The name of the file to load
+    @param mode      The mode to open the file in. Should be "r" for text files or "rb" for binary files
+
+    @return  The file's contents, either as a string or bytes, depending on mode.
+    """
     try:
         with open(filename, mode) as file:
             return file.read()
     except OSError as e:
-        return ""
+        print(f"Unable to read {filename}: {e}")
+        if "b" in mode:
+            return b""
+        else:
+            return ""
 
 
-def load_json_data(json_str):
-    """Load previously saved json data as a dict.
+def load_json_file(filename, mode="r") -> dict:
+    """Load a file and return its contents
 
-    Check for a previously saved data. If it exists, return data as a
-    dict. If no data is found, an empty dictionary will be returned.
+    @param filename  The name of the file to load
+    @param mode      The mode to open the file in. Should be "r" except in very unique circumstances
+
+    @return  The file's contents as a dict
     """
-    if json_str == "":
-        return {}
     try:
-        return json.loads(json_str)
-    except ValueError as e:
-        print(f"Unable to decode {json_str}: {e}")
+        with open(filename, mode) as file:
+            return json.load(file)
+    except OSError as e:
+        print(f"Unable to read JSON data from {filename}: {e}")
         return {}
 
 

--- a/software/tests/test_europi_script.py
+++ b/software/tests/test_europi_script.py
@@ -35,8 +35,8 @@ def script_for_testing_with_config():
 
 
 def test_save_state(script_for_testing):
-    script_for_testing.save_state_str("test state")
-    assert script_for_testing.load_state_str() == "test state"
+    script_for_testing.save_state_json({"spam": "eggs"})
+    assert script_for_testing.load_state_json() == {"spam": "eggs"}
 
 
 def test_state_file_name(script_for_testing):

--- a/software/tests/test_europi_script.py
+++ b/software/tests/test_europi_script.py
@@ -35,8 +35,8 @@ def script_for_testing_with_config():
 
 
 def test_save_state(script_for_testing):
-    script_for_testing._save_state("test state")
-    assert script_for_testing._load_state() == "test state"
+    script_for_testing.save_state_str("test state")
+    assert script_for_testing.load_state_str() == "test state"
 
 
 def test_state_file_name(script_for_testing):


### PR DESCRIPTION
Two main changes:

1) Refactor JSON file I/O to operate on file objects directly instead of loading data into a string in RAM and operating on that
2) When reading non-JSON files, return `bytes` instead of `str` if the mode is binary & there's an error opening the file