### PR TITLE
Add `apt-get update` line to `compile_to_uf2` workflow

### DIFF
--- a/.github/workflows/compile_to_uf2.yml
+++ b/.github/workflows/compile_to_uf2.yml
@@ -23,6 +23,7 @@ jobs:
           path: micropython
 
       - name: install os deps
+        run: sudo apt-get update
         run: sudo apt-get install -y cmake gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential
 
       - name: prepare micropython build

--- a/.github/workflows/compile_to_uf2.yml
+++ b/.github/workflows/compile_to_uf2.yml
@@ -23,8 +23,7 @@ jobs:
           path: micropython
 
       - name: install os deps
-        run: sudo apt-get update
-        run: sudo apt-get install -y cmake gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential
+        run: sudo apt-get update; sudo apt-get install -y cmake gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential
 
       - name: prepare micropython build
         working-directory: micropython


### PR DESCRIPTION
The UF2 compile workflow failed on the last release with error:
```
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Fetched 443 MB in 6s (72.7 MB/s)
Error: Process completed with exit code 100.
```

Add `apt-get update` line to workflow to try and fix this