### PR TITLE
Add the git attributes to hopefully resolve EOL issues on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,9 @@
 *.sh text eol=lf
 *.bash text eol=lf
 
+# Windows-specific files need crlf endings
+*.bat text eol=crlf
+
 # Image files should be binary
 *.png binary
 *.jpg binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Python, markdown files can use user-preferred line endings
+*.py text=auto
+*.md text=auto
+
+# Linux-specific files need lf endings
+*.sh text eol=lf
+*.bash text eol=lf
+
+# Image files should be binary
+*.png binary
+*.jpg binary


### PR DESCRIPTION
Force Linux shell scripts to keep `\n` line endings, force Windows batch files to use `\r\n` line endings. Allow user-preferred endings for Python & Markdown files.