### PR TITLE
Handle syntax errors when reading JSON files

### DIFF
--- a/software/firmware/file_utils.py
+++ b/software/firmware/file_utils.py
@@ -32,6 +32,9 @@ def load_json_file(filename, mode="r") -> dict:
     try:
         with open(filename, mode) as file:
             return json.load(file)
+    except ValueError as e:
+        print(f"Unable to parse JSON data from {filename}: {e}")
+        return {}
     except OSError as e:
         print(f"Unable to read JSON data from {filename}: {e}")
         return {}


### PR DESCRIPTION
The recently-merged JSON updates don't properly handle syntax errors. This fix will return an empty `dict` if the file is malformed or isn't valid JSON syntax.