### PR TITLE
Update Pam's Workout to use `_thread` library to unlock both cores

### DIFF
--- a/software/contrib/pams.py
+++ b/software/contrib/pams.py
@@ -1509,6 +1509,9 @@ class PamsWorkout(EuroPiScript):
             ssoled.blit(imgFB, OLED_WIDTH - STATUS_IMG_WIDTH, 0)
             ssoled.show()
 
+            # Keep a small delay between frames
+            time.sleep(0.01)
+
     def voltage_thread(self):
         """The main thread; handles all CV I/O. The main clock timer runs on this thread on core 0
 

--- a/software/contrib/pams.py
+++ b/software/contrib/pams.py
@@ -310,9 +310,9 @@ class DigitalInputMonitor:
         self.b1_high = b1_state
         self.b2_high = b2_state
 
-        if b1_state:
+        if self.b1_rising:
             self.b1_last_pressed = time.ticks_ms()
-        if b2_state:
+        if self.b2_rising:
             self.b2_last_pressed = time.ticks_ms()
 
 
@@ -1505,6 +1505,8 @@ class PamsWorkout(EuroPiScript):
 
     def ui_thread(self):
         """The main GUI thread; runs on core 1 as a secondary thread
+
+        Handles reading the digital inputs (din + buttons) & rendering the GUI
         """
         while True:
             now = time.ticks_ms()
@@ -1540,6 +1542,8 @@ class PamsWorkout(EuroPiScript):
 
     def voltage_thread(self):
         """The main thread; handles all CV I/O. The main clock timer runs on this thread on core 0
+
+        Handles most of the math-heavy work via the main clock's tick & runs garbage collection periodically
         """
         GC_INTERVAL_MS = 250
         last_gc_at = time.ticks_ms()

--- a/software/contrib/pams.py
+++ b/software/contrib/pams.py
@@ -1562,7 +1562,7 @@ class PamsWorkout(EuroPiScript):
     def main(self):
         self.load()
 
-        core_1_thread = _thread.start_new_thread(self.ui_thread(), ())
+        core_1_thread = _thread.start_new_thread(self.ui_thread, ())
         self.voltage_thread()
 
 

--- a/software/contrib/pams.py
+++ b/software/contrib/pams.py
@@ -485,7 +485,7 @@ class MasterClock:
     MIN_BPM = 1
 
     ## The absolute fastest the clock can go
-    MAX_BPM = 240
+    MAX_BPM = 300
 
     def __init__(self, bpm):
         """Create the main clock to run at a given bpm
@@ -1497,8 +1497,6 @@ class PamsWorkout(EuroPiScript):
         Handles drawing the GUI to the screen
         """
         while True:
-            now = time.ticks_ms()
-
             ssoled.fill(0)
             with self.menu_lock:
                 self.main_menu.draw()
@@ -1509,7 +1507,6 @@ class PamsWorkout(EuroPiScript):
             else:
                 imgFB = FrameBuffer(STATUS_IMG_PAUSE, STATUS_IMG_WIDTH, STATUS_IMG_HEIGHT, MONO_HLSB)
             ssoled.blit(imgFB, OLED_WIDTH - STATUS_IMG_WIDTH, 0)
-
             ssoled.show()
 
     def voltage_thread(self):

--- a/software/contrib/pams.py
+++ b/software/contrib/pams.py
@@ -274,7 +274,7 @@ PERCENT_RANGE = list(range(101))
 class DigitalInputMonitor:
     """Helper class to work around the fact that _thread doesn't play nicely with ISRs
 
-    Used by the UI thread to check the state of the buttons + din and indicate if rising/falling
+    Used by the main thread to check the state of the buttons + din and indicate if rising/falling
     edges are detected
     """
     def __init__(self):

--- a/software/contrib/pams.py
+++ b/software/contrib/pams.py
@@ -1296,7 +1296,7 @@ class PamsMenu:
 
     def draw(self):
         if not self.visible_item.is_editable():
-            self.visible_item = k2_bank.current.choice(self.get_active_items(), samples=1024)
+            self.visible_item = k2_bank.current.choice(self.get_active_items(), samples=2048)
 
         self.visible_item.draw()
 

--- a/software/firmware/experimental/knobs.py
+++ b/software/firmware/experimental/knobs.py
@@ -334,3 +334,23 @@ class KnobBank:
     @staticmethod
     def builder(knob: Knob) -> Builder:
         return KnobBank.Builder(knob)
+
+
+class BufferedKnob(Knob):
+    """A knob whose value remains fixed until .update(...) is called
+
+    This allows multiple uses of .percent(), .choice(...), etc... without forcing a re-read of
+    the ADC value
+
+    :param knob:  The knob to wrap
+    """
+
+    def __init__(self, knob):
+        super().__init__(knob.pin_id)
+        self.value = 0
+
+    def _sample_adc(self, samples=None):
+        return self.value
+
+    def update(self, samples=None):
+        self.value = super()._sample_adc(samples)

--- a/software/firmware/experimental/screensaver.py
+++ b/software/firmware/experimental/screensaver.py
@@ -121,7 +121,10 @@ class OledWithScreensaver:
         else:
             self.show_blank = False
             self.show_screensaver = False
-            oled.show()
+            try:
+                oled.show()
+            except OSError:
+                pass
 
     # The following are just wrappers for the functions in the Display class to allow 1:1 access
     # See europi.Display for documentation details


### PR DESCRIPTION
Move the GUI rendering to the second core using `_thread`.  This should (hopefully) allow higher clock speeds and/or higher PPQN settings for smoother analogue outputs (e.g. outputting a sine or triangle wave should be smoother and less stepped than the current implementation).

## Implementation Notes

From previous testing (see discussion on Discord from around 18 February 2024) it looks like using interrupt handlers doesn't work well with `_thread`, so the rising/falling edge handlers for `din`, `b1`, and `b2` have been moved into a new `DigitalInputMonitor` class with the button/input states polled in the main thread.

The GUI rendering is moved to a second thread that runs on the second core, with all of the digital + analogue CV I/O handled in the main thread. The main `Timer` object also runs on the main core.

## Testing Status

This is still being tested on my end; once it's ready to merge I'll remove the `draft` tag. However, I'd really appreciate it if other users could give it a try and report any bugs they find.

The biggest issue I've run into so far is noise when scrolling through the menu with `K2`. If I turn the knob all the way to the left, the menu will sometimes flicker between `BPM` and `CV1 Mod`. I'm not sure if I just have a noisy knob on my module, or if this is a larger software bug, so more testing is greatly appreciated!