### PR TITLE
add missing import to envelope_generator

### DIFF
--- a/software/contrib/envelope_generator.py
+++ b/software/contrib/envelope_generator.py
@@ -1,5 +1,5 @@
 from time import sleep
-from europi import oled, din, cv1, cv2, cv3, k1, k2, b1, b2, ain, OLED_WIDTH, OLED_HEIGHT
+from europi import oled, din, cv1, cv2, cv3, k1, k2, b1, b2, ain, OLED_WIDTH, OLED_HEIGHT, europi_config
 from europi_script import EuroPiScript
 
 from time import sleep_ms, ticks_ms, ticks_diff


### PR DESCRIPTION
The envelope generator crashes on launch. Adding this missing import fixes it.