### PR TITLE
launch first menu item

### DIFF
--- a/software/firmware/ui.py
+++ b/software/firmware/ui.py
@@ -22,8 +22,7 @@ class Menu:
 
         # init handlers
         def select():
-            if self.selected != 0:  # ignore the '-- MENU --' item
-                self.select_func(self.items[self.selected + 1])
+            self.select_func(self.items[self.selected + 1])
 
         for b in choice_buttons:
             b.handler_falling(select)


### PR DESCRIPTION
The check for the '-- MENU --' item is no longer necessary. It prevented the first menu item (bernoulli gates) from being selected.