### PR TITLE
upgrade to micropython 1.22.2

### DIFF
--- a/.github/workflows/compile_to_uf2.yml
+++ b/.github/workflows/compile_to_uf2.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: micropython/micropython
-          ref: v1.20.0
+          ref: v1.22.2
           path: micropython
 
       - name: install os deps

--- a/.github/workflows/compile_to_uf2.yml
+++ b/.github/workflows/compile_to_uf2.yml
@@ -66,7 +66,7 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 
       - name: rename firmware file with version info
-        run: cp micropython/ports/rp2/build-PICO/firmware.uf2 europi-v${{ steps.release-asset-version.outputs.VERSION }}.uf2
+        run: cp micropython/ports/rp2/build-RPI_PICO/firmware.uf2 europi-v${{ steps.release-asset-version.outputs.VERSION }}.uf2
 
       - name: create github release
         uses: "marvinpinto/action-automatic-releases@v1.2.1"

--- a/software/programming_instructions.md
+++ b/software/programming_instructions.md
@@ -34,7 +34,7 @@ To start with, you'll need to download the [Thonny IDE](https://thonny.org/). Th
 ![Thonny](https://i.imgur.com/UX4uQDO.jpg)
 
 ### Installing the firmware
-1. Download the [most recent firmware](https://micropython.org/download/rp2-pico/) from the MicroPython website. The latest supported version is `1.20.0`.
+1. Download the [most recent firmware](https://micropython.org/download/rp2-pico/) from the MicroPython website. The latest supported version is `1.22.2`.
 2. Holding down the white button labeled 'BOOTSEL' on the Raspberry Pi Pico, connect the module to your computer via the USB cable.
 
     ![_DSC2400](https://user-images.githubusercontent.com/79809962/148647201-52b0d279-fc1e-4615-9e65-e51543605e15.jpg)

--- a/software/uf2_build/copy_and_compile.sh
+++ b/software/uf2_build/copy_and_compile.sh
@@ -13,4 +13,4 @@ cd micropython/ports/rp2
 make
 
 echo "Copying firmware file to /europi/software/uf2_build/europi-dev.uf2"
-cp build-PICO/firmware.uf2 /europi/software/uf2_build/europi-dev.uf2
+cp build-RPI_PICO/firmware.uf2 /europi/software/uf2_build/europi-dev.uf2


### PR DESCRIPTION
This PR upgrades the supported micropython to 1.22.2. Release notes are [here](https://github.com/micropython/micropython/releases).

I've tested the following:

- Installation of 1.22.2, followed by europi packages via thonny
- launching every script from menu
- diagnostics

Untested:

- generation of the custom europi uf2
- detailed testing of any contrib scripts