### PR TITLE
Fix screensaver timer to be less reliant on exact timing

### DIFF
--- a/software/firmware/experimental/screensaver.py
+++ b/software/firmware/experimental/screensaver.py
@@ -34,6 +34,9 @@ class Screensaver:
     ## Standard duration before we blank the screen
     BLANK_TIMEOUT_MS = 1000 * 60 * 20
 
+    def __init__(self):
+        self.last_logo_reposition_at = 0
+
     def draw(self, force=False):
         """Draw the logo to a random position on the screen
 
@@ -45,8 +48,9 @@ class Screensaver:
         """
         LOGO_UPDATE_INTERVAL = 2000
 
-        ms = utime.ticks_ms()
-        if force or ms % LOGO_UPDATE_INTERVAL == 0:
+        now = utime.ticks_ms()
+        if force or time.ticks_diff(now, self.last_logo_reposition_at) > LOGO_UPDATE_INTERVAL:
+            self.last_logo_reposition_at = now
             x = random.randint(0, OLED_WIDTH - self.LOGO_WIDTH)
             y = random.randint(0, OLED_HEIGHT - self.LOGO_HEIGHT)
 


### PR DESCRIPTION
Don't rely on modular arithmetic for the screensaver; just check the elapsed time from the last reposition