### PR TITLE
Reduce latency in Clock Modifer script

### DIFF
--- a/software/contrib/clock_mod.md
+++ b/software/contrib/clock_mod.md
@@ -18,8 +18,8 @@ are not adjustable and are fixed to approximately a 50% duty cycle (some roundin
 | `cv1-6`       | Multiplied/divided clock signals                                  |
 
 The outputs will begin firing automatically when clock signals are received on `din`, and will stop if the input
-signals are stopped for 1s or longer.  Upon stopping all output channels will reset.  (NOTE: this means the signal
-coming into `din` cannot be 1Hz or slower!)
+signals are stopped for 5s or longer.  Upon stopping all output channels will reset.  (NOTE: this means the signal
+coming into `din` cannot be 0.2Hz or slower!)
 
 Applying a signal of at least 0.8V to `ain` will reset all output channels.
 

--- a/software/contrib/clock_mod.py
+++ b/software/contrib/clock_mod.py
@@ -67,12 +67,7 @@ class ClockOutput:
 
         if elapsed_us > hi_lo_duration_us:
             self.last_state_change_at = us
-            if self.is_high:
-                self.is_high = False
-
-            else:
-                self.is_high = True
-                self.output_port.on()
+            self.is_high = not self.is_high
 
     def set_output_voltage(self):
         """Set the output voltage either high or low.

--- a/software/contrib/clock_mod.py
+++ b/software/contrib/clock_mod.py
@@ -317,6 +317,7 @@ class ClockModifier(EuroPiScript):
                 self.ui_dirty = False
                 last_render_at = time.ticks_us()
             elif time.ticks_diff(now, last_render_at) > screensaver.ACTIVATE_TIMEOUT_US:
+                last_render_at = time.ticks_add(now, -screensaver.ACTIVATE_TIMEOUT_US)
                 screensaver.draw()
 
             for i in range(len(mods)):

--- a/software/contrib/clock_mod.py
+++ b/software/contrib/clock_mod.py
@@ -9,6 +9,7 @@ from europi import *
 from europi_script import EuroPiScript
 from experimental.a_to_d import AnalogReaderDigitalWrapper
 from experimental.knobs import KnobBank
+from experimental.screensaver import Screensaver
 from math import floor
 
 
@@ -248,6 +249,9 @@ class ClockModifier(EuroPiScript):
     def main(self):
         """The main loop
         """
+        screensaver = Screensaver()
+        last_render_at = time.ticks_us()
+
         knob_choices = list(self.clock_modifiers.keys())
 
         prev_mods = [
@@ -311,9 +315,17 @@ class ClockModifier(EuroPiScript):
                     f"{self.channel_markers[0]} 1:{ljust(mods[0], 3)} 4:{ljust(mods[3], 3)}\n{self.channel_markers[1]} 2:{ljust(mods[1], 3)} 5:{ljust(mods[4], 3)}\n{self.channel_markers[2]} 3:{ljust(mods[2], 3)} 6:{ljust(mods[5], 3)}"
                 )
                 self.ui_dirty = False
+                last_render_at = time.ticks_us()
+            elif time.ticks_diff(now, last_render_at) > screensaver.ACTIVATE_TIMEOUT_US:
+                screensaver.draw()
+            elif time.ticks_diff(now, last_render_at) > screensaver.BLANK_TIMEOUT_US:
+                screensaver.draw_blank()
 
             for i in range(len(mods)):
                 prev_mods[i] = mods[i]
+
+
+
 
 if __name__=="__main__":
     ClockModifier().main()

--- a/software/contrib/clock_mod.py
+++ b/software/contrib/clock_mod.py
@@ -34,6 +34,11 @@ def ljust(s, length):
 class ClockOutput:
     """A control class that handles a single output
     """
+    ## The smallest common multiple of the allowed clock divisions (2, 3, 4, 5, 6, 8, 12)
+    #
+    #  Used to reset the input gate counter to avoid integer overflows/performance degredation with large values
+    MAX_GATE_COUNT = 120
+
     def __init__(self, output_port, modifier):
         """Constructor
 
@@ -60,7 +65,10 @@ class ClockOutput:
         if self.last_external_clock_at != ticks_us:
             self.last_interval_us = time.ticks_diff(ticks_us, self.last_external_clock_at)
             self.last_external_clock_at = ticks_us
+
             self.input_gate_counter += 1
+            if self.input_gate_counter >= self.MAX_GATE_COUNT:
+                self.input_gate_counter = 0
 
     def calculate_state(self, ticks_us):
         """Calculate whether this output should be high or low based on the current time

--- a/software/contrib/clock_mod.py
+++ b/software/contrib/clock_mod.py
@@ -316,15 +316,13 @@ class ClockModifier(EuroPiScript):
                 )
                 self.ui_dirty = False
                 last_render_at = time.ticks_us()
-            elif time.ticks_diff(now, last_render_at) > screensaver.ACTIVATE_TIMEOUT_US:
-                screensaver.draw()
             elif time.ticks_diff(now, last_render_at) > screensaver.BLANK_TIMEOUT_US:
                 screensaver.draw_blank()
+            elif time.ticks_diff(now, last_render_at) > screensaver.ACTIVATE_TIMEOUT_US:
+                screensaver.draw()
 
             for i in range(len(mods)):
                 prev_mods[i] = mods[i]
-
-
 
 
 if __name__=="__main__":

--- a/software/contrib/clock_mod.py
+++ b/software/contrib/clock_mod.py
@@ -26,6 +26,7 @@ def ljust(s, length):
     n_spaces = max(0, length - len(s))
     return s + ' '*n_spaces
 
+
 class ClockOutput:
     """A control class that handles a single output
     """
@@ -53,20 +54,20 @@ class ClockOutput:
             self.last_interval_us = time.ticks_diff(ticks_us, self.last_external_clock_at)
             self.last_external_clock_at = ticks_us
 
-    def calculate_state(self, us):
+    def calculate_state(self, ticks_us):
         """Calculate whether this output should be high or low based on the current time
 
         Must be called before calling set_output_voltage
 
-        @param us  The current time in us; passed as a parameter to synchronize multiple channels
+        @param ticks_us  The current time in microseconds; passed as a parameter to synchronize multiple channels
         """
         gate_duration_us = self.last_interval_us / self.modifier
         hi_lo_duration_us = gate_duration_us / 2
 
-        elapsed_us = time.ticks_diff(us, self.last_state_change_at)
+        elapsed_us = time.ticks_diff(ticks_us, self.last_state_change_at)
 
         if elapsed_us > hi_lo_duration_us:
-            self.last_state_change_at = us
+            self.last_state_change_at = ticks_us
             self.is_high = not self.is_high
 
     def set_output_voltage(self):
@@ -85,6 +86,7 @@ class ClockOutput:
         self.is_high = False
         self.output_port.off()
         self.last_state_change_at = time.ticks_us()
+
 
 class ClockModifier(EuroPiScript):
     """The main script class; multiplies and divides incoming clock signals

--- a/software/contrib/clock_mod.py
+++ b/software/contrib/clock_mod.py
@@ -316,8 +316,6 @@ class ClockModifier(EuroPiScript):
                 )
                 self.ui_dirty = False
                 last_render_at = time.ticks_us()
-            elif time.ticks_diff(now, last_render_at) > screensaver.BLANK_TIMEOUT_US:
-                screensaver.draw_blank()
             elif time.ticks_diff(now, last_render_at) > screensaver.ACTIVATE_TIMEOUT_US:
                 screensaver.draw()
 

--- a/software/firmware/experimental/screensaver.py
+++ b/software/firmware/experimental/screensaver.py
@@ -51,7 +51,8 @@ class Screensaver:
         LOGO_UPDATE_INTERVAL = 2000
 
         now = utime.ticks_ms()
-        if force or time.ticks_diff(now, self.last_logo_reposition_at) > LOGO_UPDATE_INTERVAL:
+        elapsed_ms = time.ticks_diff(now, self.last_logo_reposition_at)
+        if force or abs(elapsed_ms) >= LOGO_UPDATE_INTERVAL:
             self.last_logo_reposition_at = now
             x = random.randint(0, OLED_WIDTH - self.LOGO_WIDTH)
             y = random.randint(0, OLED_HEIGHT - self.LOGO_HEIGHT)

--- a/software/firmware/experimental/screensaver.py
+++ b/software/firmware/experimental/screensaver.py
@@ -30,9 +30,11 @@ class Screensaver:
 
     ## Standard duration before we activate the screensaver
     ACTIVATE_TIMEOUT_MS = 1000 * 60 * 5
+    ACTIVATE_TIMEOUT_US = ACTIVATE_TIMEOUT_MS * 1000
 
     ## Standard duration before we blank the screen
     BLANK_TIMEOUT_MS = 1000 * 60 * 20
+    BLANK_TIMEOUT_US = BLANK_TIMEOUT_MS * 1000
 
     def __init__(self):
         self.last_logo_reposition_at = 0


### PR DESCRIPTION
Improvements:
- Use microseconds for calculating the timing instead of milliseconds.
- Keep track of when the GUI needs re-rendering instead of always redrawing to reduce latency