### PR TITLE
Add sustain gate, end-of-rise, end-of-fall triggers to Envelope Generator

### DIFF
--- a/software/contrib/envelope_generator.md
+++ b/software/contrib/envelope_generator.md
@@ -21,3 +21,10 @@ Inputs and Outputs:
 - **cv 4:** a gate that is high whenever the envelope is in a sustain state
 - **cv 5:** a 10ms end-of-rise trigger
 - **cv 6:** a 10ms end-of-fall trigger
+
+The 10ms end-of-rise trigger will fire every time the envelope transitions from the rising to either the
+falling or sustain states. This can occur as a result of the incoming gate signal dropping low while a slow rise
+is still being processed.
+
+The 10ms end-of-fall trigger will only fire if the full duration of the fall portion is reached; if the envelope
+is re-triggered before the fall completes, this trigger will _not_ fire.

--- a/software/contrib/envelope_generator.md
+++ b/software/contrib/envelope_generator.md
@@ -18,3 +18,6 @@ Inputs and Outputs:
 - **cv 1:** a copy of the digital input
 - **cv 2:** the generated envelope
 - **cv 3:** the inversion of the generated envelope
+- **cv 4:** a gate that is high whenever the envelope is in a sustain state
+- **cv 5:** a 10ms end-of-rise trigger
+- **cv 6:** a 10ms end-of-fall trigger

--- a/software/contrib/envelope_generator.py
+++ b/software/contrib/envelope_generator.py
@@ -31,8 +31,9 @@ class EnvelopeGenerator(EuroPiScript):
         self.looping_mode = state.get("looping_mode", LOOPING_MODE_ONCE)
 
         #Milliscond tick of of the most recent end-of-rise and end-of-fall
-        self.last_rise_end_at = 0
-        self.last_fall_end_at = 0
+        #initialized to be 2x trigger duration in the past on startup to prevent roll-over issues
+        self.last_rise_end_at = time.ticks_add(time.ticks_ms(), -2*TRIGGER_DURATION_MS)
+        self.last_fall_end_at = self.last_rise_end_at
 
         self.max_output_voltage = europi_config.MAX_OUTPUT_VOLTAGE
 


### PR DESCRIPTION
Add additional outputs to the envelope generator:

- cv4: sustain gate: high whenever the e.g. is in its internal "sustain" state -- this is both the S state of the ASR & when the voltage is held low between non-looping envelopes
- cv5: a 10ms end-of-rise trigger (fires whenever the state changes from rising to either falling or sustain, possibly as the result of the incoming gate going low while the rise state is still ongoing)
- cv6: 10ms end-of-fall trigger (fires ONLY when the end of the fall phase is reached; if the envelope is re-triggered before the fall ends, this trigger is skipped)

Minor code cleanup, replacing magic numbers with named constants.