### PR TITLE
Use buttons as logic inputs

### DIFF
--- a/software/contrib/logic.md
+++ b/software/contrib/logic.md
@@ -3,10 +3,12 @@
 This program implements six digital logic operations, with each
 operation's result sent to a different output jack.
 
-- `ain`: the first boolean input; any signal above 0.8V is treated
+- `din`: the first boolean input. Holding down `b1` is equivalent to
+  applying voltage to `din`.
+- `ain`: the second boolean input; any signal above 0.8V is treated
   as ON, anything below that is OFF. (Note: this is the same voltage
-  threshold used on the digital input.)
-- `din`: the second boolean input
+  threshold used on the digital input.) Holding `b2` is equivalent to
+  applying voltage to `ain`.
 - `cv1`: `ain` AND `din`
 - `cv2`: `ain` OR `din`
 - `cv3`: `ain` XOR `din`
@@ -39,3 +41,9 @@ The screen will go to sleep after 20 minutes of inactivity. Pressing
 either button will wake the screen up.
 
 The knobs are not used in this program.
+
+## Note on button interaction
+
+Holding both buttons for a few seconds will send the reboot signal to the module,
+forcing the module to return to the main menu.  For this reason it is recommended to
+use only one button at a time when using the logic module performatively.

--- a/software/contrib/logic.py
+++ b/software/contrib/logic.py
@@ -26,9 +26,8 @@ class Logic(EuroPiScript):
     def __init__(self):
         super().__init__()
 
-        # keep track of the last time the user interacted with the module
-        # if we're idle for too long, start the screensaver
-        self.last_interaction_time = time.ticks_ms()
+        self.b1_high = False
+        self.b2_high = False
 
     @classmethod
     def display_name(cls):
@@ -44,16 +43,26 @@ class Logic(EuroPiScript):
         @b1.handler
         def on_b1_press():
             ssoled.notify_user_interaction()
+            self.b1_high = 1
 
         @b2.handler
         def on_b2_press():
             ssoled.notify_user_interaction()
+            self.b2_high = 1
+
+        @b1.handler_falling
+        def on_b1_release():
+            self.b1_high = 0
+
+        @b2.handler_falling
+        def on_b2_release():
+            self.b2_high = 0
 
         while True:
 
             # read both inputs as 0/1
-            x = din.value()
-            y = 1 if ain.read_voltage() > AIN_VOLTAGE_CUTOFF else 0
+            x = (din.value() or self.b1_high) | self.b1_high
+            y = (1 if ain.read_voltage() > AIN_VOLTAGE_CUTOFF else 0) | self.b2_high
 
             x_and_y = x & y
             x_or_y = x | y

--- a/software/contrib/logic.py
+++ b/software/contrib/logic.py
@@ -26,9 +26,6 @@ class Logic(EuroPiScript):
     def __init__(self):
         super().__init__()
 
-        self.b1_high = 0
-        self.b2_high = 0
-
     @classmethod
     def display_name(cls):
         return "Logic"
@@ -43,26 +40,16 @@ class Logic(EuroPiScript):
         @b1.handler
         def on_b1_press():
             ssoled.notify_user_interaction()
-            self.b1_high = 1
 
         @b2.handler
         def on_b2_press():
             ssoled.notify_user_interaction()
-            self.b2_high = 1
-
-        @b1.handler_falling
-        def on_b1_release():
-            self.b1_high = 0
-
-        @b2.handler_falling
-        def on_b2_release():
-            self.b2_high = 0
 
         while True:
 
             # read both inputs as 0/1
-            x = din.value() | self.b1_high
-            y = (1 if ain.read_voltage() > AIN_VOLTAGE_CUTOFF else 0) | self.b2_high
+            x = din.value() | b1.value()
+            y = (1 if ain.read_voltage() > AIN_VOLTAGE_CUTOFF else 0) | b2.value()
 
             x_and_y = x & y
             x_or_y = x | y

--- a/software/contrib/logic.py
+++ b/software/contrib/logic.py
@@ -61,7 +61,7 @@ class Logic(EuroPiScript):
         while True:
 
             # read both inputs as 0/1
-            x = (din.value() or self.b1_high) | self.b1_high
+            x = din.value() | self.b1_high
             y = (1 if ain.read_voltage() > AIN_VOLTAGE_CUTOFF else 0) | self.b2_high
 
             x_and_y = x & y

--- a/software/contrib/logic.py
+++ b/software/contrib/logic.py
@@ -26,8 +26,8 @@ class Logic(EuroPiScript):
     def __init__(self):
         super().__init__()
 
-        self.b1_high = False
-        self.b2_high = False
+        self.b1_high = 0
+        self.b2_high = 0
 
     @classmethod
     def display_name(cls):


### PR DESCRIPTION
Previously the buttons just cancelled the screensaver. Now they're actually usable as logic inputs to augment/replace the input jacks.

`l1 = (din | b1)`, `l2 - (ain | b2)` Outputs are `l1 {and|or|xor|nand|nor|xnor} l2`