### PR TITLE
Add Sigma script

### DIFF
--- a/software/contrib/README.md
+++ b/software/contrib/README.md
@@ -194,6 +194,12 @@ A 2-6 output sequential switch.  The analogue input is mirrored to one of the ou
 <i>Author: [chrisib](https://github.com/chrisib)</i>
 <br><i>Labels: random, sequential switch</i>
 
+### Sigma \[ [documentation](/software/contrib/sigma.md) | [script](/software/contrib/sigma.py) \]
+Random CV, optionally quantized, voltages based on controllable normal distributions. Inspired by Magnetic Freak's Gaussian module.
+
+<i>Author: [chrisib](https://github.com/chrisib)</i>
+<br><i>Labels: random, quantizer</i>
+
 ### Smooth Random Voltages \[ [script](/software/contrib/smooth_random_voltages.py) \]
 Random CV with adjustable slew rate, inspired by: https://youtu.be/tupkx3q7Dyw.
 

--- a/software/contrib/arp.py
+++ b/software/contrib/arp.py
@@ -9,6 +9,7 @@ from europi import *
 from europi_script import EuroPiScript
 
 from experimental.quantizer import CommonScales, SEMITONE_LABELS, VOLTS_PER_OCTAVE, VOLTS_PER_SEMITONE, SEMITONES_PER_OCTAVE
+from experimental.random_extras import shuffle
 
 import random
 
@@ -16,18 +17,6 @@ MODE_ASCENDING = 0
 MODE_DESCENDING = 1
 MODE_RANDOM = 2
 
-def shuffle(l):
-    """Shuffle a list randomly
-
-    Replacement for random.shuffle, which doesn't exist in micropython
-
-    @param l  The list to shuffle
-    """
-    for i in range(len(l)):
-        n = random.randint(i, len(l)-1)
-        tmp = l[i]
-        l[i] = l[n]
-        l[n] = tmp
 
 class Arpeggio:
     def __init__(self, scale, mode):

--- a/software/contrib/menu.py
+++ b/software/contrib/menu.py
@@ -53,6 +53,7 @@ EUROPI_SCRIPTS = OrderedDict([
     ["RadioScanner",      "contrib.radio_scanner.RadioScanner"],
     ["Scope",             "contrib.scope.Scope"],
     ["Seq. Switch",       "contrib.sequential_switch.SequentialSwitch"],
+    ["Sigma",             "contrib.sigma.Sigma"],
     ["Smooth Rnd Volts",  "contrib.smooth_random_voltages.SmoothRandomVoltages"],
     ["StrangeAttractor",  "contrib.strange_attractor.StrangeAttractor"],
     ["Traffic",           "contrib.traffic.Traffic"],

--- a/software/contrib/sigma.md
+++ b/software/contrib/sigma.md
@@ -1,0 +1,75 @@
+# Sigma -- Gaussian CV Generator
+
+This script is inspired by [Magnetic Freak's](https://magnetic-freak.com/) Gaussian module.
+Please see the [user manual](https://magnetic-freak.com/wp-content/uploads/2022/08/Gaussian_Eurorack_UserGuide.pdf)
+for details on the original module and a deeper dive into the mathematics used in this script.
+
+## Gaussian Distributions
+
+The Gaussian or Normal distribution is a bell-shaped curve often used in statistics. Unlike rolling a d20 in
+Dungeons and Dragons, where there is an equal chance of the roll being 1, 2, 3, ..., 19, or 20, a normal distribution
+is more likely to produce numbers in the middle of its range and less likely to produce numbers at the extremes. The
+way in which this probability changes is determined by the standard deviation of the curve, written using the
+Greek letter Sigma in statistics.
+
+## Inputs & Outputs
+
+Inputs:
+- `din`: an external clock signal to trigger sampling. The pulse width of this signal controls the output
+  pulse width
+- `ain`: CV control over spread
+- `b1`: manual trigger input (used instead of or in addition to `din`)
+- `b2`: cycles through the binning modes (see below)
+- `k1`: spread control
+- `k2`: mean control
+
+`cv1`-`6` output 0-10V CV signals whose value is determined by the normal distribution & binning.
+- `cv1`
+- `cv2`
+- `cv3`
+- `cv4`
+- `cv5`
+- `cv6`
+
+## Distrubution Control
+
+`k1` and `k2` control the mean and standard deviation of the normal distribution at the heart of this script.
+
+...
+
+## Spread Control
+
+By default all six output channels update simultaneously. By applying positive voltage to `ain` the outputs can be
+desynchronized, updating at random intervals. `cv1` will always trigger in-time with the clock on `din`, but `cv2`-`5`
+will trigger at normally-distributed intervals after `cv1`.
+
+## Binning and Quantize modes
+
+The CV outputs on can be configured to either oscillate between fixed voltage levels, output
+quantized 1V/Octave pitch levels, or a continuous smooth voltage.
+
+In Bin mode the output voltage will oscillate between values chosen from the levels below:
+
+| # Bins | CV Output Levels                                    | Delta (V) |
+|--------|-----------------------------------------------------|-----------|
+|    2   | 0V, 10V                                             | 10V       |
+|    3   | 0V, 5V, 10V                                         | 5V        |
+|    6   | 0V, 2V, 4V, 6V, 8V, 10V                             | 2V        |
+|    7   | 0V, 1.7V, 3.4V, 5V, 6.6V, 8.3V, 10V                 | 1.7V      |
+|    9   | 0V, 1.25V, 2.5V, 3.75V, 5V, 6.25V, 7.5V, 8.75V, 10V | 1.25V     |
+
+To use the outputs as gate triggers, use `Bin 2` mode; this will output 10V triggers. If your module requires
+lower trigger voltage, use an external attenuator.
+
+In Quantize mode, the output voltage will be quantized to 1V/Octave scales with the following resolution:
+
+| Quantize Mode | Delta (V) |
+|---------------|-----------|
+| Tone          | 0.16667   |
+| Semitone      | 0.08333   |
+| Quartertone   | 0.41667   |
+| Continuous    | inf`*`    |
+
+Output will be in the range 0-10V
+
+`*` Not actually infinte, but as high-resolution as the DAC chips will allow

--- a/software/contrib/sigma.md
+++ b/software/contrib/sigma.md
@@ -17,7 +17,8 @@ Greek letter Sigma in statistics.
 Inputs:
 - `din`: an external clock signal to trigger sampling. The pulse width of this signal controls the output
   pulse width
-- `ain`: assignable CV control (see below)
+- `ain`: assignable CV control (can be disabled, or assigned to control `mean`, `standard deviation`, `jitter` or
+  `bin mode`)
 - `b1`: shift button; hold to change `k1` and `k2` modes
 - `b2`: cycles through `ain` routing
 - `k1`: mean control / shift: jitter control

--- a/software/contrib/sigma.md
+++ b/software/contrib/sigma.md
@@ -25,7 +25,9 @@ Inputs:
 
 `k1` or `k2` will act as an attenuator for the assigned control (mean/spread/jitter/binning).
 
-`cv1`-`6` output 0-10V CV signals whose value is determined by the normal distribution & binning.
+Outputs are divided into 3 pairs: `cv1 & cv 4`, `cv2 & cv 5`, and `cv3 & cv 6`.  `cv1-3` output gate signals
+with a duration equivalent to the duty cycle of the incoming clock on `din`.  `cv4-6` output random control
+voltages according to the spread & mean controls and the binning mode.
 
 ## Distrubution Control
 
@@ -37,11 +39,11 @@ averate output close to 5V.
 Increasing `k2` will increase the standard deviation of the outputs.  At the lowest setting the outputs will be
 effectively locked to the mean set by `k1`.  As `k2` increases the spread of output voltages increases.
 
-## Spread Control
+## Jitter Control
 
 By default all six output channels update simultaneously. By applying positive voltage to `ain` the outputs can be
-desynchronized, updating at random intervals. `cv1` will always trigger in-time with the clock on `din`, but `cv2`-`5`
-will trigger at normally-distributed intervals after `cv1`.
+desynchronized, updating at random intervals. `cv1 & 4` will always trigger in-time with the clock on `din`,
+but the other pairs will trigger at normally-distributed intervals after `cv1`.
 
 ## Binning and Quantize modes
 

--- a/software/contrib/sigma.md
+++ b/software/contrib/sigma.md
@@ -17,7 +17,7 @@ Greek letter Sigma in statistics.
 Inputs:
 - `din`: an external clock signal to trigger sampling. The pulse width of this signal controls the output
   pulse width
-- `ain`: assignable CV control
+- `ain`: assignable CV control (see below)
 - `b1`: shift button; hold to change `k1` and `k2` modes
 - `b2`: cycles through `ain` routing
 - `k1`: mean control / shift: jitter control

--- a/software/contrib/sigma.md
+++ b/software/contrib/sigma.md
@@ -26,18 +26,16 @@ Inputs:
 `k1` or `k2` will act as an attenuator for the assigned control (mean/spread/jitter/binning).
 
 `cv1`-`6` output 0-10V CV signals whose value is determined by the normal distribution & binning.
-- `cv1`
-- `cv2`
-- `cv3`
-- `cv4`
-- `cv5`
-- `cv6`
 
 ## Distrubution Control
 
-`k1` and `k2` control the mean and standard deviation of the normal distribution at the heart of this script.
+The following description assumes the binning mode is set to `continuous`.
 
-...
+Changing `k1` will move the average output voltage of the outputs.  Keeping the knob near-vertical will keep the
+averate output close to 5V.
+
+Increasing `k2` will increase the standard deviation of the outputs.  At the lowest setting the outputs will be
+effectively locked to the mean set by `k1`.  As `k2` increases the spread of output voltages increases.
 
 ## Spread Control
 

--- a/software/contrib/sigma.md
+++ b/software/contrib/sigma.md
@@ -17,11 +17,13 @@ Greek letter Sigma in statistics.
 Inputs:
 - `din`: an external clock signal to trigger sampling. The pulse width of this signal controls the output
   pulse width
-- `ain`: CV control over spread
-- `b1`: manual trigger input (used instead of or in addition to `din`)
-- `b2`: cycles through the binning modes (see below)
-- `k1`: spread control
-- `k2`: mean control
+- `ain`: assignable CV control
+- `b1`: shift button; hold to change `k1` and `k2` modes
+- `b2`: cycles through `ain` routing
+- `k1`: mean control / shift: jitter control
+- `k2`: spread control / shift: binning/quantizer mode select
+
+`k1` or `k2` will act as an attenuator for the assigned control (mean/spread/jitter/binning).
 
 `cv1`-`6` output 0-10V CV signals whose value is determined by the normal distribution & binning.
 - `cv1`

--- a/software/contrib/sigma.md
+++ b/software/contrib/sigma.md
@@ -60,9 +60,6 @@ In Bin mode the output voltage will oscillate between values chosen from the lev
 |    7   | 0V, 1.7V, 3.4V, 5V, 6.6V, 8.3V, 10V                 | 1.7V      |
 |    9   | 0V, 1.25V, 2.5V, 3.75V, 5V, 6.25V, 7.5V, 8.75V, 10V | 1.25V     |
 
-To use the outputs as gate triggers, use `Bin 2` mode; this will output 10V triggers. If your module requires
-lower trigger voltage, use an external attenuator.
-
 In Quantize mode, the output voltage will be quantized to 1V/Octave scales with the following resolution:
 
 | Quantize Mode | Delta (V) |

--- a/software/contrib/sigma.py
+++ b/software/contrib/sigma.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+"""Gaussian-based, clocked, quantized CV generator
+
+Inspired by Magnetic Freak's Gaussian module.
+
+@author  Chris Iverach-Brereton
+@year    2024
+"""
+
+from experimental.random_extras import normal

--- a/software/contrib/sigma.py
+++ b/software/contrib/sigma.py
@@ -7,4 +7,106 @@ Inspired by Magnetic Freak's Gaussian module.
 @year    2024
 """
 
+from europi import *
+from europi_script import EuroPiScript
+
 from experimental.random_extras import normal
+
+def bisect_left(a, x, lo=0, hi=None, *, key=None):
+    """Return the index where to insert item x in list a, assuming a is sorted.
+
+    The return value i is such that all e in a[:i] have e < x, and all e in
+    a[i:] have e >= x.  So if x already appears in the list, a.insert(i, x) will
+    insert just before the leftmost x already there.
+
+    Optional args lo (default 0) and hi (default len(a)) bound the
+    slice of a to be searched.
+
+    A custom key function can be supplied to customize the sort order.
+
+    Copied from https://github.com/python/cpython/blob/3.12/Lib/bisect.py
+    """
+
+    if lo < 0:
+        raise ValueError('lo must be non-negative')
+    if hi is None:
+        hi = len(a)
+    # Note, the comparison uses "<" to match the
+    # __lt__() logic in list.sort() and in heapq.
+    if key is None:
+        while lo < hi:
+            mid = (lo + hi) // 2
+            if a[mid] < x:
+                lo = mid + 1
+            else:
+                hi = mid
+    else:
+        while lo < hi:
+            mid = (lo + hi) // 2
+            if key(a[mid]) < x:
+                lo = mid + 1
+            else:
+                hi = mid
+    return lo
+
+
+class VoltageBin:
+    """Quantizes a random voltage to the closest bin"""
+    def __init__(self, name, bins):
+        """Create a new set of bins
+
+        @param name  The human-readable display name for this set of bins
+        @param bins  A list of voltages we are allowed to output
+        """
+        self.name = name
+        self.bins = [float(b) for b in bins]
+        self.bins.sort()
+
+    def __str__(self):
+        return self.name
+
+    def closest(self, v):
+        """Quantize an input voltage to the closest bin. If two bins are equally close, choose the lower one.
+
+        Our internal bins are sorted, so we can do a binary search for that sweet, sweet O(log(n)) efficiency
+
+        @param v  A voltage in the range 0-10 to quantize
+        @return   The closest voltage bin to @v
+        """
+        i = bisect_left(self.bins, v)
+        if i == 0:
+            return self.bins[0]
+        if i == len(self.bins):
+            return self.bins[-1]
+        prev = self.bins[i - 1]
+        next = self.bins[i + 1]
+        if abs(v - next) < abs(v - prev):
+            return next
+        else:
+            return prev
+
+
+class Sigma(EuroPiScript):
+    """The main class for this script
+
+    Handles all I/O, renders the UI
+    """
+
+    ## Voltage bins for bin mode
+    voltage_bins = [
+        VoltageBin("Bin 2", [0, 10]),
+        VoltageBin("Bin 3", [0, 5, 10]),
+        VoltageBin("Bin 6", [0, 2, 4, 6, 8, 10]),
+        VoltageBin("Bin 7", [0, 1.7, 3.4, 5, 6.6, 8.3, 10]),
+        VoltageBin("Bin 9", [0, 1.25, 2.5, 3.75, 5, 6.25, 7.5, 8.75, 10])
+    ]
+
+    def __init__(self):
+        super().__init__()
+
+    def main(self):
+        while True:
+            pass
+
+if __name__ == "__main__":
+    Sigma().main()

--- a/software/contrib/sigma.py
+++ b/software/contrib/sigma.py
@@ -13,47 +13,10 @@ from europi_script import EuroPiScript
 import configuration
 import time
 
+from experimental.bisect import bisect_left
 from experimental.knobs import *
 from experimental.random_extras import normal
 from experimental.screensaver import Screensaver
-
-
-def bisect_left(a, x, lo=0, hi=None, *, key=None):
-    """Return the index where to insert item x in list a, assuming a is sorted.
-
-    The return value i is such that all e in a[:i] have e < x, and all e in
-    a[i:] have e >= x.  So if x already appears in the list, a.insert(i, x) will
-    insert just before the leftmost x already there.
-
-    Optional args lo (default 0) and hi (default len(a)) bound the
-    slice of a to be searched.
-
-    A custom key function can be supplied to customize the sort order.
-
-    Copied from https://github.com/python/cpython/blob/3.12/Lib/bisect.py
-    """
-
-    if lo < 0:
-        raise ValueError('lo must be non-negative')
-    if hi is None:
-        hi = len(a)
-    # Note, the comparison uses "<" to match the
-    # __lt__() logic in list.sort() and in heapq.
-    if key is None:
-        while lo < hi:
-            mid = (lo + hi) // 2
-            if a[mid] < x:
-                lo = mid + 1
-            else:
-                hi = mid
-    else:
-        while lo < hi:
-            mid = (lo + hi) // 2
-            if key(a[mid]) < x:
-                lo = mid + 1
-            else:
-                hi = mid
-    return lo
 
 
 class OutputBin:

--- a/software/contrib/sigma.py
+++ b/software/contrib/sigma.py
@@ -142,7 +142,7 @@ class Sigma(EuroPiScript):
     AIN_ROUTE_STDEV = 2
     AIN_ROUTE_JITTER = 3
     AIN_ROUTE_BIN = 4
-    N_AIN_ROUNTES = 5
+    N_AIN_ROUTES = 5
 
     AIN_ROUTE_NAMES = [
         "None",
@@ -241,7 +241,7 @@ class Sigma(EuroPiScript):
 
         @b2.handler
         def on_b2_rise():
-            self.ain_route = (self.ain_route + 1) % self.N_AIN_ROUNTES
+            self.ain_route = (self.ain_route + 1) % self.N_AIN_ROUTES
             self.config_dirty = True
             self.last_interaction_at = time.ticks_ms()
 

--- a/software/firmware/experimental/bisect.py
+++ b/software/firmware/experimental/bisect.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""
+A replacement for the standard bisect Python library
+
+Currently only supports a subset of the full module
+"""
+
+def bisect_left(a, x, lo=0, hi=None, *, key=None):
+    """Return the index where to insert item x in list a, assuming a is sorted.
+
+    The return value i is such that all e in a[:i] have e < x, and all e in
+    a[i:] have e >= x.  So if x already appears in the list, a.insert(i, x) will
+    insert just before the leftmost x already there.
+
+    Optional args lo (default 0) and hi (default len(a)) bound the
+    slice of a to be searched.
+
+    A custom key function can be supplied to customize the sort order.
+
+    Copied from https://github.com/python/cpython/blob/3.12/Lib/bisect.py
+    """
+
+    if lo < 0:
+        raise ValueError('lo must be non-negative')
+    if hi is None:
+        hi = len(a)
+    # Note, the comparison uses "<" to match the
+    # __lt__() logic in list.sort() and in heapq.
+    if key is None:
+        while lo < hi:
+            mid = (lo + hi) // 2
+            if a[mid] < x:
+                lo = mid + 1
+            else:
+                hi = mid
+    else:
+        while lo < hi:
+            mid = (lo + hi) // 2
+            if key(a[mid]) < x:
+                lo = mid + 1
+            else:
+                hi = mid
+    return lo

--- a/software/firmware/experimental/bisect.py
+++ b/software/firmware/experimental/bisect.py
@@ -1,9 +1,83 @@
 #!/usr/bin/env python3
 """
-A replacement for the standard bisect Python library
+Functions for searching, splitting, and inserting into a sorted list
 
-Currently only supports a subset of the full module
+Copied from https://github.com/python/cpython/blob/3.12/Lib/bisect.py with some modifications
+noted in-line with `# EDIT`
 """
+
+
+def insort_right(a, x, lo=0, hi=None, *, key=None):
+    """Insert item x in list a, and keep it sorted assuming a is sorted.
+
+    If x is already in a, insert it to the right of the rightmost x.
+
+    Optional args lo (default 0) and hi (default len(a)) bound the
+    slice of a to be searched.
+
+    A custom key function can be supplied to customize the sort order.
+    """
+    if key is None:
+        lo = bisect_right(a, x, lo, hi)
+    else:
+        lo = bisect_right(a, key(x), lo, hi, key=key)
+    a.insert(lo, x)
+
+
+def bisect_right(a, x, lo=0, hi=None, *, key=None):
+    """Return the index where to insert item x in list a, assuming a is sorted.
+
+    The return value i is such that all e in a[:i] have e <= x, and all e in
+    a[i:] have e > x.  So if x already appears in the list, a.insert(i, x) will
+    insert just after the rightmost x already there.
+
+    Optional args lo (default 0) and hi (default len(a)) bound the
+    slice of a to be searched.
+
+    A custom key function can be supplied to customize the sort order.
+    """
+
+    if lo < 0:
+        # EDIT
+        #raise ValueError('lo must be non-negative')
+        lo = 0
+    if hi is None:
+        hi = len(a)
+    # Note, the comparison uses "<" to match the
+    # __lt__() logic in list.sort() and in heapq.
+    if key is None:
+        while lo < hi:
+            mid = (lo + hi) // 2
+            if x < a[mid]:
+                hi = mid
+            else:
+                lo = mid + 1
+    else:
+        while lo < hi:
+            mid = (lo + hi) // 2
+            if x < key(a[mid]):
+                hi = mid
+            else:
+                lo = mid + 1
+    return lo
+
+
+def insort_left(a, x, lo=0, hi=None, *, key=None):
+    """Insert item x in list a, and keep it sorted assuming a is sorted.
+
+    If x is already in a, insert it to the left of the leftmost x.
+
+    Optional args lo (default 0) and hi (default len(a)) bound the
+    slice of a to be searched.
+
+    A custom key function can be supplied to customize the sort order.
+    """
+
+    if key is None:
+        lo = bisect_left(a, x, lo, hi)
+    else:
+        lo = bisect_left(a, key(x), lo, hi, key=key)
+    a.insert(lo, x)
 
 
 def bisect_left(a, x, lo=0, hi=None, *, key=None):
@@ -17,13 +91,10 @@ def bisect_left(a, x, lo=0, hi=None, *, key=None):
     slice of a to be searched.
 
     A custom key function can be supplied to customize the sort order.
-
-    Copied from https://github.com/python/cpython/blob/3.12/Lib/bisect.py with some modifications
-    noted below
     """
 
     if lo < 0:
-        # EDIT: force lo to be non-zero to avoid raising a potentially unhandled exception
+        # EDIT
         # raise ValueError('lo must be non-negative')
         lo = 0
     if hi is None:
@@ -45,3 +116,8 @@ def bisect_left(a, x, lo=0, hi=None, *, key=None):
             else:
                 hi = mid
     return lo
+
+
+# Create aliases
+bisect = bisect_right
+insort = insort_right

--- a/software/firmware/experimental/bisect.py
+++ b/software/firmware/experimental/bisect.py
@@ -5,6 +5,7 @@ A replacement for the standard bisect Python library
 Currently only supports a subset of the full module
 """
 
+
 def bisect_left(a, x, lo=0, hi=None, *, key=None):
     """Return the index where to insert item x in list a, assuming a is sorted.
 

--- a/software/firmware/experimental/bisect.py
+++ b/software/firmware/experimental/bisect.py
@@ -17,11 +17,14 @@ def bisect_left(a, x, lo=0, hi=None, *, key=None):
 
     A custom key function can be supplied to customize the sort order.
 
-    Copied from https://github.com/python/cpython/blob/3.12/Lib/bisect.py
+    Copied from https://github.com/python/cpython/blob/3.12/Lib/bisect.py with some modifications
+    noted below
     """
 
     if lo < 0:
-        raise ValueError('lo must be non-negative')
+        # EDIT: force lo to be non-zero to avoid raising a potentially unhandled exception
+        # raise ValueError('lo must be non-negative')
+        lo = 0
     if hi is None:
         hi = len(a)
     # Note, the comparison uses "<" to match the

--- a/software/firmware/experimental/bisect.py
+++ b/software/firmware/experimental/bisect.py
@@ -39,7 +39,7 @@ def bisect_right(a, x, lo=0, hi=None, *, key=None):
 
     if lo < 0:
         # EDIT
-        #raise ValueError('lo must be non-negative')
+        # raise ValueError('lo must be non-negative')
         lo = 0
     if hi is None:
         hi = len(a)

--- a/software/firmware/experimental/random_extras.py
+++ b/software/firmware/experimental/random_extras.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""
+Additional random functions that are part of standard Python3's random module
+but are omitted from MicroPython's implementation
+
+Specifically _not_ called "random.py" to prevent clobbering the standard random import
+in other experimental libraries
+"""
+
+from math import log, sqrt
+import random
+
+
+def normal(mean=0.0, stdev=1.0):
+    """
+    Generate a random number with a normal distribution
+
+    Uses the Marsaglia-Tsang algorithm, which isn't a perfectly normal
+    distribution, but is likely close enough for EuroPi applications
+
+    @param mean   The desired mean for the distribution
+    @param stdev  The standard deviation of the distribution
+
+    @return A floating-point number chosen from a normal distribution with the
+            given mean and standard deviation
+    """
+    x = 0.0
+    y = 0.0
+    z = 0.0
+    while True:
+        x = random.random() * 2.0 - 1.0
+        y = random.random() * 2.0 - 1.0
+        z = x ** 2 + y ** 2
+
+        if 0 < z and z <= 1.0:
+            break
+
+    q = sqrt(-2.0 * log(z) / z)
+    return mean + stdev * x * q
+
+
+def shuffle(l):
+    """
+    Re-order the elements of a list in-situ
+
+    @param l  The list to shuffle
+    """
+    for i in range(len(l)):
+        n = random.randint(i, len(l)-1)
+        tmp = l[i]
+        l[i] = l[n]
+        l[n] = tmp

--- a/software/firmware/experimental/random_extras.py
+++ b/software/firmware/experimental/random_extras.py
@@ -30,7 +30,7 @@ def normal(mean=0.0, stdev=1.0):
     while True:
         x = random.random() * 2.0 - 1.0
         y = random.random() * 2.0 - 1.0
-        z = x ** 2 + y ** 2
+        z = x**2 + y**2
 
         if 0 < z and z <= 1.0:
             break
@@ -46,7 +46,7 @@ def shuffle(l):
     @param l  The list to shuffle
     """
     for i in range(len(l)):
-        n = random.randint(i, len(l)-1)
+        n = random.randint(i, len(l) - 1)
         tmp = l[i]
         l[i] = l[n]
         l[n] = tmp


### PR DESCRIPTION
This adds a new random CV/Gate generator based on gaussian distributions rather than the even distributions used by most other scripts.

Outputs are paired in Gate (CV1-3) + Random Voltage (CV4-6) pairs.  Voltage outputs can optionally be continuous, binned, or quantized to tone/semitone/quartertone (at 1V/octave) resolution.

This script is inspired by Magnetic Freak's Gaussian module (see https://magnetic-freak.com/ for details on that module).

Firmware changes include adding a new `experimental.random_extras` module to store useful random-related functions that are part of standard Python3, but are omitted from MicroPython.