### PR TITLE
Improve numerical `ConfigPoint` implementations

### DIFF
--- a/software/contrib/turing_machine.py
+++ b/software/contrib/turing_machine.py
@@ -294,14 +294,15 @@ class EuroPiTuringMachine(EuroPiScript):
 
     @classmethod
     def config_points(cls):
-        bitcount_range = range(1, min(DEFAULT_BIT_COUNT, 8))
+        range_min = 0
+        range_max = min(DEFAULT_BIT_COUNT, 8) - 1
 
         return [
             configuration.choice(name="WRITE_VALUE", choices=[0, 1], default=0),
             # simulate the actual bits available in the pulses expander (1-7)
-            configuration.integer(name="CV1_PULSE_BIT", range=bitcount_range, default=1),
-            configuration.integer(name="CV2_PULSE_BIT", range=bitcount_range, default=2),
-            configuration.integer(name="CV3_PULSE_BIT", range=bitcount_range, default=4),
+            configuration.integer(name="CV1_PULSE_BIT", minimum=range_min, maximum=range_max, default=1),
+            configuration.integer(name="CV2_PULSE_BIT", minimum=range_min, maximum=range_max, default=2),
+            configuration.integer(name="CV3_PULSE_BIT", minimum=range_min, maximum=range_max, default=4),
         ]
 
     def main(self):

--- a/software/firmware/configuration.py
+++ b/software/firmware/configuration.py
@@ -73,15 +73,9 @@ class FloatConfigPoint(ConfigPoint):
             if value >= self.minimum and value <= self.maximum:
                 return VALID
             else:
-                return Validation(
-                    is_valid=False,
-                    message=f"Value {value} is out of range"
-                )
+                return Validation(is_valid=False, message=f"Value {value} is out of range")
         else:
-            return Validation(
-                is_valid=False,
-                message=f"Value {value} is not a number"
-            )
+            return Validation(is_valid=False, message=f"Value {value} is not a number")
 
 
 class IntegerConfigPoint(ConfigPoint):
@@ -109,15 +103,9 @@ class IntegerConfigPoint(ConfigPoint):
             if value >= self.minimum and value <= self.maximum:
                 return VALID
             else:
-                return Validation(
-                    is_valid=False,
-                    message=f"Value {value} is out of range"
-                )
+                return Validation(is_valid=False, message=f"Value {value} is out of range")
         else:
-            return Validation(
-                is_valid=False,
-                message=f"Value {value} is not a number"
-            )
+            return Validation(is_valid=False, message=f"Value {value} is not a number")
 
 
 class ChoiceConfigPoint(ConfigPoint):
@@ -163,6 +151,7 @@ def boolean(name: str, default: bool) -> BooleanConfigPoint:
     :param default: The default value
     """
     return BooleanConfigPoint(name=name, default=default)
+
 
 def choice(name: str, choices: "List", default) -> ChoiceConfigPoint:
     """A helper function to simplify the creation of ChoiceConfigPoints. Requires selection from a

--- a/software/firmware/configuration.py
+++ b/software/firmware/configuration.py
@@ -83,15 +83,15 @@ class IntegerConfigPoint(ConfigPoint):
     must lie within the specified range
 
     :param name: The name of this `ConfigPoint`, will be used by scripts to lookup the configured value.
-    :param range: The range of valid integers. Note that only the maximum and minimum values are considered;
-                  step values within the range are discarded.
+    :param minimum: The minimum allowed value
+    :param maximum: The maximum allowed value
     :param default: The default value
     """
 
-    def __init__(self, name: str, range: range, default: int):
+    def __init__(self, name: str, minimum: int, maximum: int, default: int):
         super().__init__(name=name, type=int, default=default)
-        self.minimum = range[0]
-        self.maximum = range[-1]
+        self.minimum = minimum
+        self.maximum = maximum
 
         if default < self.minimum or default > self.maximum:
             raise Exception(f"Default {default} is out of range")
@@ -106,7 +106,7 @@ class IntegerConfigPoint(ConfigPoint):
             else:
                 return Validation(is_valid=False, message=f"Value {value} is out of range")
         else:
-            return Validation(is_valid=False, message=f"Value {value} is not a number")
+            return Validation(is_valid=False, message=f"Value {value} is not an integer")
 
 
 class ChoiceConfigPoint(ConfigPoint):
@@ -176,15 +176,16 @@ def floatingPoint(name: str, minimum: float, maximum: float, default: float) -> 
     return FloatConfigPoint(name=name, minimum=minimum, maximum=maximum, default=default)
 
 
-def integer(name: str, range: range, default: int) -> IntegerConfigPoint:
+def integer(name: str, minimum: int, maximum: int, default: int) -> IntegerConfigPoint:
     """A helper function to simplify the creation of IntegerConfigPoints. Requires selection from a
     range of integers. The default value must exist in the given range.
 
     :param name: The name of this `ConfigPoint`, will be used by scripts to lookup the configured value.
-    :param range: The range of valid integers
+    :param minimum: The minimum allowed value
+    :param maximum: The maximum allowed value
     :param default: The default value
     """
-    return IntegerConfigPoint(name=name, range=range, default=default)
+    return IntegerConfigPoint(name=name, minimum=minimum, maximum=maximum, default=default)
 
 
 class ConfigSpec:

--- a/software/firmware/configuration.py
+++ b/software/firmware/configuration.py
@@ -83,7 +83,8 @@ class IntegerConfigPoint(ConfigPoint):
     must lie within the specified range
 
     :param name: The name of this `ConfigPoint`, will be used by scripts to lookup the configured value.
-    :param range: The range of valid integers
+    :param range: The range of valid integers. Note that only the maximum and minimum values are considered;
+                  step values within the range are discarded.
     :param default: The default value
     """
 

--- a/software/firmware/europi_config.py
+++ b/software/firmware/europi_config.py
@@ -74,20 +74,23 @@ class EuroPiConfig:
             ),
 
             # I/O voltage settings
-            configuration.integer(
+            configuration.floatingPoint(
                 name="MAX_OUTPUT_VOLTAGE",
-                range=range(1, 11),
-                default=10
+                minimum=1.0,
+                maximum=10.0,
+                default=10.0
             ),
-            configuration.integer(
+            configuration.floatingPoint(
                 name="MAX_INPUT_VOLTAGE",
-                range=range(1, 13),
-                default=12
+                minimum=1.0,
+                maximum=12.0,
+                default=12.0
             ),
-            configuration.integer(
+            configuration.floatingPoint(
                 name="GATE_VOLTAGE",
-                range=range(1, 11),
-                default=5
+                minimum=1.0,
+                maximum=10.0,
+                default=5.0
             ),
 
             # Menu settings

--- a/software/firmware/europi_config.py
+++ b/software/firmware/europi_config.py
@@ -49,12 +49,14 @@ class EuroPiConfig:
             ),
             configuration.integer(
                 name="DISPLAY_WIDTH",
-                range=range(8, 1024),
+                minimum=8,
+                maximum=1024,
                 default=128
             ),
             configuration.integer(
                 name="DISPLAY_HEIGHT",
-                range=range(8, 1024),
+                minimum=8,
+                maximum=1024,
                 default=32
             ),
             configuration.choice(
@@ -69,7 +71,8 @@ class EuroPiConfig:
             ),
             configuration.integer(
                 name="DISPLAY_CHANNEL",
-                range=range(0, 2),
+                minimum=0,
+                maximum=1,
                 default=0
             ),
 

--- a/software/tests/test_configuration.py
+++ b/software/tests/test_configuration.py
@@ -93,7 +93,6 @@ def test_helper_int():
     assert config_points.default_config() == {"a": 2, "b": 0}
     assert config_points.points["a"].type == int
     assert config_points.points["b"].type == int
-    assert config_points.points["c"].type == int
     assert config_points.points["a"].minimum == 0
     assert config_points.points["a"].maximum == 4
     assert config_points.points["b"].minimum == -5

--- a/software/tests/test_configuration.py
+++ b/software/tests/test_configuration.py
@@ -86,18 +86,18 @@ def test_helper_int():
         [
             config.integer(name="a", range=range(5), default=2),
             config.integer(name="b", range=range(-5, 6), default=0),
-            config.integer(name="c", range=range(-5, 6, 2), default=1),
         ]
     )
 
     assert len(config_points) == 3
     assert config_points.default_config() == {"a": 2, "b": 0, "c": 1}
-    assert config_points.points["a"].type == "choice"
-    assert config_points.points["b"].type == "choice"
-    assert config_points.points["c"].type == "choice"
-    assert config_points.points["a"].choices == [0, 1, 2, 3, 4]
-    assert config_points.points["b"].choices == [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5]
-    assert config_points.points["c"].choices == [-5, -3, -1, 1, 3, 5]
+    assert config_points.points["a"].type == int
+    assert config_points.points["b"].type == int
+    assert config_points.points["c"].type == int
+    assert config_points.points["a"].minimum == 0
+    assert config_points.points["a"].maximum == 4
+    assert config_points.points["b"].minimum == -5
+    assert config_points.points["b"].maximum == 5
 
 
 # ConfigFile

--- a/software/tests/test_configuration.py
+++ b/software/tests/test_configuration.py
@@ -19,7 +19,7 @@ def simple_config_spec():
     return ConfigSpec(
         [
             config.choice(name="a", choices=[1, 2, 3], default=2),
-            config.integer(name="b", range=range(5), default=3),
+            config.integer(name="b", minimum=0, maximum=4, default=3),
         ]
     )
 
@@ -84,8 +84,8 @@ def test_helper_choice():
 def test_helper_int():
     config_points = ConfigSpec(
         [
-            config.integer(name="a", range=range(5), default=2),
-            config.integer(name="b", range=range(-5, 6), default=0),
+            config.integer(name="a", minimum=0, maximum=4, default=2),
+            config.integer(name="b", minimum=-5, maximum=5, default=0),
         ]
     )
 

--- a/software/tests/test_configuration.py
+++ b/software/tests/test_configuration.py
@@ -89,8 +89,8 @@ def test_helper_int():
         ]
     )
 
-    assert len(config_points) == 3
-    assert config_points.default_config() == {"a": 2, "b": 0, "c": 1}
+    assert len(config_points) == 2
+    assert config_points.default_config() == {"a": 2, "b": 0}
     assert config_points.points["a"].type == int
     assert config_points.points["b"].type == int
     assert config_points.points["c"].type == int


### PR DESCRIPTION
Currently if an `IntegerConfigPoint` has a very wide range, the entire range is saved as a list in RAM, which could have negative impacts on scripts.  Instead of inheriting from the `ChoiceConfigPoint` instead we inherit directly from `ConfigPoint` and save the maximum & minimum values of the range and check that the value is within the correct bounds.

This also lets us add the new `FloatConfigPoint` class, which works the same way but with floating point values instead of integers.

`europi_config` is modified to use the new floating point config points for the master input & output voltages, to allow more precision (e.g. if someone really needs to restrict the output voltage to e.g. `2.5` volts, they now can).

External interfaces for the `IntegerConfigPoint` and the `configuration.integer(...)` helper function remain unchanged.