### PR TITLE
Make the missing-file warning less alarming when loading JSON data

### DIFF
--- a/software/firmware/file_utils.py
+++ b/software/firmware/file_utils.py
@@ -1,3 +1,4 @@
+import errno
 import os
 import json
 
@@ -36,7 +37,10 @@ def load_json_file(filename, mode="r") -> dict:
         print(f"Unable to parse JSON data from {filename}: {e}")
         return {}
     except OSError as e:
-        print(f"Unable to read JSON data from {filename}: {e}")
+        if e.errno == errno.ENOENT:
+            print(f"/{filename} does not exist. Using default settings")
+        else:
+            print(f"Unable to open {filename}: {e}")
         return {}
 
 


### PR DESCRIPTION
Currently if the JSON configuration file is missing for any of `europi_config`, `experimental_config`, or any individual script that uses the `configuration.ConfigPoint` implementation, the user will see an error message like this:
```
Unable to read JSON data from config/EuroPiConfig.json: [Errno 2] ENOENT
Unable to read JSON data from config/ExperimentalConfig.json: [Errno 2] ENOENT
```

This can cause confusion for users, since it looks like it's an error they need to correct, when in fact they're just opting not to define a customization file to override the default settings.  This MR handles `errno.ENOENT` ("no entity") so instead the user will see
```
/config/EuroPiConfig.json does not exist. Using default settings
/config/ExperimentalConfig.json does not exist. Using default settings
```

I considered just swallowing that error and not printing anything, but I think it's important to show that the file is failing to load just in case the user is trying to override something and e.g. accidentally put the file in the wrong directory or has an invalid capitalization inside the filename.

All other errors are handled as they are now, as those probably _are_ bugs that should be addressed.