### PR TITLE
Add Slopes script

### DIFF
--- a/software/contrib/README.md
+++ b/software/contrib/README.md
@@ -206,6 +206,12 @@ Random CV, optionally quantized, voltages based on controllable normal distribut
 <i>Author: [chrisib](https://github.com/chrisib)</i>
 <br><i>Labels: random, quantizer</i>
 
+### Sigma \[ [documentation](/software/contrib/slopes.md) | [script](/software/contrib/slopes.py) \]
+CV analyzer that produces gates & CV outputs based on the slope of the incoming signal
+
+<i>Author: [chrisib](https://github.com/chrisib)</i>
+<br><i>Labels: gates, CV</i>
+
 ### Smooth Random Voltages \[ [script](/software/contrib/smooth_random_voltages.py) \]
 Random CV with adjustable slew rate, inspired by: https://youtu.be/tupkx3q7Dyw.
 

--- a/software/contrib/menu.py
+++ b/software/contrib/menu.py
@@ -55,6 +55,7 @@ EUROPI_SCRIPTS = OrderedDict([
     ["Scope",             "contrib.scope.Scope"],
     ["Seq. Switch",       "contrib.sequential_switch.SequentialSwitch"],
     ["Sigma",             "contrib.sigma.Sigma"],
+    ["Slopes",            "contrib.slopes.Slopes"],
     ["Smooth Rnd Volts",  "contrib.smooth_random_voltages.SmoothRandomVoltages"],
     ["StrangeAttractor",  "contrib.strange_attractor.StrangeAttractor"],
     ["Traffic",           "contrib.traffic.Traffic"],

--- a/software/contrib/slopes.md
+++ b/software/contrib/slopes.md
@@ -1,0 +1,27 @@
+# Slopes
+
+Slopes is a CV processor that analyzes an incoming signal and generates outputs based on the shape of that input.
+
+## Inputs & Outputs
+
+- `ain`: The analogue signal to process. Due to technical limitations this signal should ideally be an LFO, smooth
+  random voltage, or envelope. Audio-rate signals can be patched in, but will likely not be analyzed correctly due
+  to processing latency.
+- `k1`: Noise filter. Increasing `k1` will make the signal processing less sensitive, but will also reduce random
+  noise.
+- `k2`: CV output attenuator. At maximum, `cv4`-`6` will output `0-10V`. At 50% `cv4`-`6` will output `0-5V`. At 0%
+  `cv4`-`6` will produce no output
+
+- `cv1`: A gate signal that is high when `ain` is rising and low when `ain` is falling
+- `cv2`: A gate signal that is high when `ain` is falling and low when `ain` is rising
+- `cv3`: A gate signal that is high when `ain` is flat (i.e. holding the same voltage across samples)
+- `cv4`: A CV signal representing the positive slope of `ain`; the faster `ain` is rising, the stronger the CV signal
+- `cv5`: A CV signal representing the negative slope of `ain`; the faster `ain` is falling, the stronger the CV signal
+- `cv6`: A CV signal representing the overall maginude of the slope, ignoring the direction (i.e. the sum of `cv4` and `cv5`)
+
+Unused:
+- `din`
+- `b1`
+- `b2`
+
+The display is not used by `Slopes` and will remain off at all times.

--- a/software/contrib/slopes.py
+++ b/software/contrib/slopes.py
@@ -48,7 +48,7 @@ class Slopes(EuroPiScript):
             n_bins = round(denoise_percent * (self.MAX_BINS - self.MIN_BINS) + self.MIN_BINS)
             n_samples = round(denoise_percent * (self.MAX_SAMPLES - self.MIN_SAMPLES) + self.MIN_SAMPLES)
             deadzone = self.DEAD_ZONE * denoise_percent
-            output_attenuation_percent = self.output_attenuator.percent()
+            output_attenuation_percent = self.output_attenuator.percent() * 2
 
             # calculate the previous sample based on our current noise filter size
             prev_volts = self.denoise(n_bins)

--- a/software/contrib/slopes.py
+++ b/software/contrib/slopes.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""
+Generates CV and gate signals based on the slope of an incoming analogue signal
+"""
+
+from europi import *
+from europi_script import EuroPiScript
+
+from experimental.math_extras import median
+
+class Slopes(EuroPiScript):
+    noise_attenuator = k1
+    output_attenuator = k2
+
+    ain_rising_gate = cv1
+    ain_falling_gate = cv2
+    ain_steady_gate = cv3
+    ain_pos_slope_cv = cv4
+    ain_neg_slope_cv = cv5
+    ain_slope_magnitude_cv = cv6
+
+    MIN_BINS = 1
+    MAX_BINS = 12
+
+    MIN_SAMPLES = 32
+    MAX_SAMPLES = 512
+
+    MAX_SLOPE = europi_config.MAX_INPUT_VOLTAGE / 10.0
+
+    DEAD_ZONE = 0.01
+
+    def __init__(self):
+        super().__init__()
+
+        # bins used for median smoothing of the raw AIN data
+        self.bins = [0] * self.MAX_BINS
+
+    def denoise(self, window_size):
+        return median(self.bins[len(self.bins) - window_size - 1:])
+
+    def main(self):
+        turn_off_all_cvs()
+        oled.fill(0)
+        oled.show()
+
+        while True:
+            denoise_percent = self.noise_attenuator.percent()
+            n_bins = round(denoise_percent * (self.MAX_BINS - self.MIN_BINS) + self.MIN_BINS)
+            n_samples = round(denoise_percent * (self.MAX_SAMPLES - self.MIN_SAMPLES) + self.MIN_SAMPLES)
+            deadzone = self.DEAD_ZONE * denoise_percent
+            output_attenuation_percent = self.output_attenuator.percent()
+
+            # calculate the previous sample based on our current noise filter size
+            prev_volts = self.denoise(n_bins)
+
+            # grab the new sample and add it to the end of the list
+            self.bins.pop(0)
+            self.bins.append(ain.read_voltage(samples=n_samples))
+            curr_volts = self.denoise(n_bins)
+
+            # calculate the change in volts
+            d_volts = curr_volts - prev_volts
+            slope = d_volts / self.MAX_SLOPE
+            if slope > 1:
+                slope = 1.0
+            elif slope < -1.0:
+                slope = -1.0
+
+            # Set the outputs
+            if d_volts > deadzone:
+                # ain rising
+                self.ain_rising_gate.on()
+                self.ain_falling_gate.off()
+                self.ain_steady_gate.off()
+
+                self.ain_pos_slope_cv.voltage(slope * output_attenuation_percent * europi_config.MAX_OUTPUT_VOLTAGE)
+                self.ain_neg_slope_cv.off()
+                self.ain_slope_magnitude_cv.voltage(slope * output_attenuation_percent * europi_config.MAX_OUTPUT_VOLTAGE)
+            elif d_volts < -deadzone:
+                # ain falling
+                self.ain_rising_gate.off()
+                self.ain_falling_gate.on()
+                self.ain_steady_gate.off()
+
+                self.ain_pos_slope_cv.off()
+                self.ain_neg_slope_cv.voltage(-slope * output_attenuation_percent * europi_config.MAX_OUTPUT_VOLTAGE)
+                self.ain_slope_magnitude_cv.voltage(-slope * output_attenuation_percent * europi_config.MAX_OUTPUT_VOLTAGE)
+            else:
+                # ain steady
+                self.ain_rising_gate.off()
+                self.ain_falling_gate.off()
+                self.ain_steady_gate.on()
+
+                self.ain_pos_slope_cv.off()
+                self.ain_neg_slope_cv.off()
+                self.ain_slope_magnitude_cv.off()
+
+if __name__ == "__main__":
+    Slopes().main()


### PR DESCRIPTION
Adds a new script that generates gates & CV signals based on the slope of an incoming LFO, envelope, or other signal.

Connect an analogue signal to `ain`. `cv1`-`3` output gates depending on whether the slope of the incoming signal is positive, negative, or steady.  `cv4`-`6` output CV signals based on the steepness of the slope (e.g. a faster LFO will change faster, producing steeper slopes, resulting in stronger output CV signals). For best results `ain` should have a varying slope (e.g. triangle or sine); a sawtooth wave will result in pretty boring outputs as the slope is consistently the same.

`k1` acts as a de-noise adjustment. Increasing it will result in smoother outputs, but may make the script less responsive to rapid changes in slope.

`k2` acts as an output attenuator for `cv4`-`6`.