### PR TITLE
Add Volts script

### DIFF
--- a/software/contrib/README.md
+++ b/software/contrib/README.md
@@ -231,6 +231,16 @@ as faithfully as possible on the EuroPi hardware.
 <i>Author: [mjaskula](https://github.com/mjaskula)</i>
 <br><i>Labels: sequencer, random, triggers</i>
 
+### Volts \[ [documentation](/software/contrib/volts.md) | [script](/software/contrib/volts.py) \]
+Generates static voltages on CV1-6. Useful for when you need a reliable, fixed voltage source as an input. Some useful applications include:
+- transposing a sequencer
+- shifting a bipolar LFO or VCO to be unipolar
+- sending a fixed voltage to a VCA to amplify a signal to a fixed level
+- calibrating other modules
+
+<i>Author: [chrisib](http://github.com/chrisib)</i>
+<br><i>Labels: cv, voltages, non-interactive</i>
+
 ---
 
 <details>

--- a/software/contrib/menu.py
+++ b/software/contrib/menu.py
@@ -58,6 +58,7 @@ EUROPI_SCRIPTS = OrderedDict([
     ["StrangeAttractor",  "contrib.strange_attractor.StrangeAttractor"],
     ["Traffic",           "contrib.traffic.Traffic"],
     ["Turing Machine",    "contrib.turing_machine.EuroPiTuringMachine"],
+    ["Volts",             "contrib.volts.OffsetVoltages"],
 
     ["_Calibrate",        "calibrate.Calibrate"],              # this one should always be second to last!
     ["_BootloaderMode",   "bootloader_mode.BootloaderMode"]    # this one should always be last!

--- a/software/contrib/volts.md
+++ b/software/contrib/volts.md
@@ -1,0 +1,28 @@
+# Volts
+
+This script is non-interactive and simply generates 6 fixed voltages:
+
+- `cv1`: 0.5V
+- `cv2`: 1.0V
+- `cv3`: 2.0V
+- `cv4`: 2.5V
+- `cv5`: 5.0V
+- `cv6`: 10.0V
+
+These can be used to apply fixed offsets for e.g. transposing a sequencer up a number of octaves, shifting a bipolar
+LFO so it is positive, sending a contant voltage to a VCA to amplify a signal, or calibrating other modules.
+
+## Changing the voltages
+
+The offset voltages can be changed by creating/editing `config/OffsetVoltages.json`:
+```json
+{
+    "CV1": 0.5,
+    "CV2": 1.0,
+    "CV3": 2.0,
+    "CV4": 2.5,
+    "CV5": 5.0,
+    "CV6": 10.0,
+}
+```
+Simply set each cv to the desired voltage, save the file, and reset the module.

--- a/software/contrib/volts.py
+++ b/software/contrib/volts.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Generates fixed voltages
+
+Voltages can be configured via an optional JSON file
+"""
+
+
+from europi import *
+from europi_script import EuroPiScript
+
+import configuration
+
+
+class OffsetVoltages(EuroPiScript):
+    def __init__(self):
+        super().__init__()
+
+    @classmethod
+    def config_points(cls):
+        """Return the static configuration options for this class
+        """
+        return [
+            configuration.floatingPoint(name="CV1", minimum=0.0, maximum=europi_config.MAX_OUTPUT_VOLTAGE, default=0.5),
+            configuration.floatingPoint(name="CV2", minimum=0.0, maximum=europi_config.MAX_OUTPUT_VOLTAGE, default=1.0),
+            configuration.floatingPoint(name="CV3", minimum=0.0, maximum=europi_config.MAX_OUTPUT_VOLTAGE, default=2.0),
+            configuration.floatingPoint(name="CV4", minimum=0.0, maximum=europi_config.MAX_OUTPUT_VOLTAGE, default=2.5),
+            configuration.floatingPoint(name="CV5", minimum=0.0, maximum=europi_config.MAX_OUTPUT_VOLTAGE, default=5.0),
+            configuration.floatingPoint(name="CV6", minimum=0.0, maximum=europi_config.MAX_OUTPUT_VOLTAGE, default=10.0),
+        ]
+
+    def main(self):
+        oled.fill(0)
+        oled.show()
+
+        cv1.voltage(self.config.CV1)
+        cv2.voltage(self.config.CV2)
+        cv3.voltage(self.config.CV3)
+        cv4.voltage(self.config.CV4)
+        cv5.voltage(self.config.CV5)
+        cv6.voltage(self.config.CV6)
+
+        while True:
+            pass


### PR DESCRIPTION
Adds a _super_ basic script that simply generates user-configurable offset voltages.  It's wholly non-interactive and exists only to be a reliable, fixed voltage source for other modules.

Configuration must be done via the configuration JSON file.