### PR TITLE
Expose the second I2C channel to make it easier to work with

### DIFF
--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -66,10 +66,10 @@ experimental_config = load_experimental_config()
 # OLED component display dimensions.
 OLED_WIDTH = europi_config.DISPLAY_WIDTH
 OLED_HEIGHT = europi_config.DISPLAY_HEIGHT
-I2C_SDA = europi_config.DISPLAY_SDA
-I2C_SCL = europi_config.DISPLAY_SCL
-I2C_CHANNEL = europi_config.DISPLAY_CHANNEL
-I2C_FREQUENCY = 400000
+OLED_I2C_SDA = europi_config.DISPLAY_SDA
+OLED_I2C_SCL = europi_config.DISPLAY_SCL
+OLED_I2C_CHANNEL = europi_config.DISPLAY_CHANNEL
+OLED_I2C_FREQUENCY = europi_config.DISPLAY_FREQUENCY
 
 # Standard max int consts.
 MAX_UINT16 = 65535
@@ -502,12 +502,12 @@ class Display(SSD1306_I2C):
 
     def __init__(
         self,
-        sda=I2C_SDA,
-        scl=I2C_SCL,
+        sda=OLED_I2C_SDA,
+        scl=OLED_I2C_SCL,
         width=OLED_WIDTH,
         height=OLED_HEIGHT,
-        channel=I2C_CHANNEL,
-        freq=I2C_FREQUENCY,
+        channel=OLED_I2C_CHANNEL,
+        freq=OLED_I2C_FREQUENCY,
     ):
         i2c = I2C(channel, sda=Pin(sda), scl=Pin(scl), freq=freq)
         self.width = width
@@ -638,6 +638,15 @@ cv4 = Output(PIN_CV4)
 cv5 = Output(PIN_CV5)
 cv6 = Output(PIN_CV6)
 cvs = [cv1, cv2, cv3, cv4, cv5, cv6]
+
+# External I2C
+external_i2c = I2C(
+    europi_config.EXTERNAL_CHANNEL,
+    sda=Pin(europi_config.EXTERNAL_SDA),
+    scl=Pin(europi_config.EXTERNAL_SCL),
+    freq=europi_config.EXTERNAL_FREQUENCY,
+    timeout=europi_config.EXTERNAL_I2C_TIMEOUT
+)
 
 usb_connected = DigitalReader(PIN_USB_CONNECTED, 0)
 

--- a/software/firmware/europi_config.py
+++ b/software/firmware/europi_config.py
@@ -69,11 +69,45 @@ class EuroPiConfig:
                 choices=[1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 27],
                 default=1,
             ),
-            configuration.integer(
+            configuration.choice(
                 name="DISPLAY_CHANNEL",
-                minimum=0,
-                maximum=1,
+                choices=[0, 1],
                 default=0
+            ),
+            configuration.integer(
+                name="DISPLAY_FREQUENCY",
+                minimum=0,
+                maximum=1000000,
+                default=400000
+            ),
+
+            # External I2C connection (header between Pico & power connector)
+            configuration.choice(
+                name="EXTERNAL_I2C_SDA",
+                choices=[0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 26],
+                default=2,
+            ),
+            configuration.choice(
+                name="EXTERNAL_I2C_SCL",
+                choices=[1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 27],
+                default=3,
+            ),
+            configuration.choice(
+                name="EXTERNAL_I2C_CHANNEL",
+                choices=[0, 1],
+                default=1
+            ),
+            configuration.integer(
+                name="EXTERNAL_I2C_FREQUENCY",
+                minimum=0,
+                maximum=1000000,  # 1M max
+                default=100000    # 100k default
+            ),
+            configuration.integer(
+                name="EXTERNAL_I2C_TIMEOUT",
+                minimum=0,
+                maximum=100000,
+                default=50000
             ),
 
             # I/O voltage settings

--- a/software/interesting_things.md
+++ b/software/interesting_things.md
@@ -18,3 +18,41 @@ while True:
 ```
 
 This code proves the speed of the Pico to the extent that if you send audio to the analogue input, you can hear a very bitcrushed but recognisable version of it at CV output 1.
+
+
+## Connecting I2C devices
+EuroPi has 1 I2C channel available for connecting external devices. The header pins for this connection are located
+between the Pico and the module's power connector.
+
+To use an external I2C device, you will need to connect it to the ground, 3.3V supply, SDA, and SCL pins of the I2C
+header. You must also specify the frequency of the I2C channel by creating or modifying `config/EuroPiConfig.json`
+on the module:
+```json
+{
+    "EXTERNAL_I2C_FREQUENCY": 400000
+}
+```
+Specify the desired frequency with the `EXTERNAL_I2C_FREQUENCY` key in the JSON object. The default frequency is
+`100000` (100k). Rates of up to 1M can be specified, but nothing faster than 400k has been officially tested.
+(The OLED display connected to the other I2C channel uses a frequency of 400k).
+
+By default the I2C channel uses a timeout of 50000 microseconds. To change this, set the `EXTERNAL_I2C_TIMEOUT`
+parameter in `config/EuroPiConfig.json`:
+```json
+{
+    "EXTERNAL_I2C_TIMEOUT": 100000
+}
+```
+The timeout value specificed is in microseconds.
+
+To use the external I2C connection in your programs, use
+```python
+from europi import external_i2c
+
+external_i2c.writeto(...)
+external_i2c.readfrom(...)
+# etc...
+```
+
+The `external_i2c` object is an instance of `machine.I2C`, so refer to [the official documentation](https://docs.micropython.org/en/latest/library/machine.I2C.html)
+for more information on using I2C.


### PR DESCRIPTION
Instantiate the external I2C interface to make programming with it easier, add europi_config parameters to set the necessary frequency & timeout of the external I2C channel. Add documentation to `interesting_things`.