### PR TITLE
Fix a crash in `Scope`

### DIFF
--- a/software/contrib/scope.py
+++ b/software/contrib/scope.py
@@ -1,3 +1,4 @@
+import math
 from time import sleep
 
 from europi_script import EuroPiScript
@@ -74,7 +75,7 @@ class Scope(EuroPiScript):
 
     @staticmethod
     def read_max_disp_voltage():
-        return k2.read_position(MAX_INPUT_VOLTAGE) + 1
+        return k2.read_position(math.ceil(MAX_INPUT_VOLTAGE)) + 1
 
     @staticmethod
     def calc_y_pos(max_disp_voltage, a_voltage):


### PR DESCRIPTION
Fix a crash in Scope where the max input voltage was being incorrectly treated as an integer

User report from Discord:
> [...] scope crashes now (all other modules look ok) [...] Here's a sample crash log:
```
624: range expects an int value, got: 12.0
Traceback (most recent call last):
  File "bootloader.py", line 170, in main
  File "contrib/scope.py", line 92, in main
  File "contrib/scope.py", line 77, in read_max_disp_voltage
  File "europi.py", line 346, in read_position
  File "europi.py", line 216, in range
ValueError: range expects an int value, got: 12.0
```