### PR TITLE
Reduce the default input voltage limit to 10V instead of 12V

### DIFF
--- a/software/CONFIGURATION.md
+++ b/software/CONFIGURATION.md
@@ -20,9 +20,9 @@ default configuration:
     "EXTERNAL_I2C_CHANNEL": 1,
     "EXTERNAL_I2C_FREQUENCY": 100000,
     "EXTERNAL_I2C_TIMEOUT": 50000,
-    "MAX_OUTPUT_VOLTAGE": 10,
-    "MAX_INPUT_VOLTAGE": 12,
-    "GATE_VOLTAGE": 5,
+    "MAX_OUTPUT_VOLTAGE": 10.0,
+    "MAX_INPUT_VOLTAGE": 10.0,
+    "GATE_VOLTAGE": 5.0,
     "MENU_AFTER_POWER_ON": false
 }
 ```
@@ -51,7 +51,7 @@ I/O voltage options:
 - `MAX_OUTPUT_VOLTAGE` is an integer in the range `[0, 10]` indicating the maximum voltage CV output can generate. Default: `10`
   The hardware is capable of 10V maximum
 - `MAX_INPUT_VOLTAGE` is an integer in the range `[0, 12]` indicating the maximum allowed voltage into the `ain` jack.
-  The hardware is capable of 12V maximum. Default: `12`
+  The hardware is capable of 12V maximum. Default: `10`
 - `GATE_VOLTAGE` is an integer in the range `[0, 10]` indicating the voltage that an output will produce when `cvx.on()`
   is called. This value must not be higher than `MAX_OUTPUT_VOLTAGE`. Default: `5`
 

--- a/software/contrib/scope.py
+++ b/software/contrib/scope.py
@@ -49,7 +49,7 @@ class Scope(EuroPiScript):
 
     knob1 - samples per screen refresh. This effectively lets you 'zoom in' on the x-axis. Start at the lowest setting, 1 sample.
     knob2 - y voltage scale (only affects analog wave). This effectively lets you 'zoom in' on the low voltages. Start at
-    the highest setting, 12v.
+    the highest setting, 10v.
 
     button1 - toggle digital wave display
     button2 - toggle analog wave display

--- a/software/firmware/europi_config.py
+++ b/software/firmware/europi_config.py
@@ -121,7 +121,7 @@ class EuroPiConfig:
                 name="MAX_INPUT_VOLTAGE",
                 minimum=1.0,
                 maximum=12.0,
-                default=12.0
+                default=10.0
             ),
             configuration.floatingPoint(
                 name="GATE_VOLTAGE",


### PR DESCRIPTION
# Motivation

EuroPi's output voltage is limited to 10V, but the input accepts up to 12V. This limits compatibility between multiple EuroPi modules, as the output of one can never sweep the full input range of the other. This also limits the ability to self-patch a single EuroPi module.

We still support 12V inputs via `EuroPiConfig` if desired, but I don't believe 12V input should be the default.