### PR TITLE
Prevent ConfigPoints from crashing if the maximum voltages are lower-than-default

### DIFF
--- a/software/contrib/bezier.py
+++ b/software/contrib/bezier.py
@@ -405,14 +405,52 @@ class Bezier(EuroPiScript):
     def config_points(cls):
         """Return the static configuration options for this class
         """
+        def restrict_input_voltage(v):
+            if v > europi_config.MAX_INPUT_VOLTAGE:
+                return europi_config.MAX_INPUT_VOLTAGE
+            return v
+
         return [
-            configuration.floatingPoint(name="MAX_INPUT_VOLTAGE", minimum=0.0, maximum=europi_config.MAX_INPUT_VOLTAGE, default=10.0),
-            configuration.floatingPoint(name="MIN_VOLTAGE", minimum=0.0, maximum=europi_config.MAX_OUTPUT_VOLTAGE, default=0.0),
-            configuration.floatingPoint(name="MAX_VOLTAGE", minimum=0.0, maximum=europi_config.MAX_OUTPUT_VOLTAGE, default=europi_config.MAX_OUTPUT_VOLTAGE),
-            configuration.floatingPoint(name="MIN_FREQUENCY", minimum=0.001, maximum=10.0, default=0.01),
-            configuration.floatingPoint(name="MAX_FREQUENCY", minimum=0.001, maximum=10.0, default=1.0),
-            configuration.choice(name="AIN_MODE", choices=["frequency", "curve"], default="frequency"),
-            configuration.choice(name="LOGIC_MODE", choices=["and", "or", "xor", "nand", "nor", "xnor"], default="xor")
+            configuration.floatingPoint(
+                name="MAX_INPUT_VOLTAGE",
+                minimum=0.0,
+                maximum=europi_config.MAX_INPUT_VOLTAGE,
+                default=restrict_input_voltage(10.0)
+            ),
+            configuration.floatingPoint(
+                name="MIN_VOLTAGE",
+                minimum=0.0,
+                maximum=europi_config.MAX_OUTPUT_VOLTAGE,
+                default=0.0
+            ),
+            configuration.floatingPoint(
+                name="MAX_VOLTAGE",
+                minimum=0.0,
+                maximum=europi_config.MAX_OUTPUT_VOLTAGE,
+                default=europi_config.MAX_OUTPUT_VOLTAGE
+            ),
+            configuration.floatingPoint(
+                name="MIN_FREQUENCY",
+                minimum=0.001,
+                maximum=10.0,
+                default=0.01
+            ),
+            configuration.floatingPoint(
+                name="MAX_FREQUENCY",
+                minimum=0.001,
+                maximum=10.0,
+                default=1.0
+            ),
+            configuration.choice(
+                name="AIN_MODE",
+                choices=["frequency", "curve"],
+                default="frequency"
+            ),
+            configuration.choice(
+                name="LOGIC_MODE",
+                choices=["and", "or", "xor", "nand", "nor", "xnor"],
+                default="xor"
+            )
         ]
 
     def save(self):

--- a/software/contrib/volts.py
+++ b/software/contrib/volts.py
@@ -15,17 +15,55 @@ class OffsetVoltages(EuroPiScript):
     def __init__(self):
         super().__init__()
 
+
     @classmethod
     def config_points(cls):
         """Return the static configuration options for this class
         """
+        def restrict_voltage(v):
+            """If the max output voltage has been lowered, disable the too-high output
+            """
+            if v > europi_config.MAX_OUTPUT_VOLTAGE:
+                return 0.0
+            return v
+
         return [
-            configuration.floatingPoint(name="CV1", minimum=0.0, maximum=europi_config.MAX_OUTPUT_VOLTAGE, default=0.5),
-            configuration.floatingPoint(name="CV2", minimum=0.0, maximum=europi_config.MAX_OUTPUT_VOLTAGE, default=1.0),
-            configuration.floatingPoint(name="CV3", minimum=0.0, maximum=europi_config.MAX_OUTPUT_VOLTAGE, default=2.0),
-            configuration.floatingPoint(name="CV4", minimum=0.0, maximum=europi_config.MAX_OUTPUT_VOLTAGE, default=2.5),
-            configuration.floatingPoint(name="CV5", minimum=0.0, maximum=europi_config.MAX_OUTPUT_VOLTAGE, default=5.0),
-            configuration.floatingPoint(name="CV6", minimum=0.0, maximum=europi_config.MAX_OUTPUT_VOLTAGE, default=10.0),
+            configuration.floatingPoint(
+                name="CV1",
+                minimum=0.0,
+                maximum=europi_config.MAX_OUTPUT_VOLTAGE,
+                default=restrict_voltage(0.5)
+            ),
+            configuration.floatingPoint(
+                name="CV2",
+                minimum=0.0,
+                maximum=europi_config.MAX_OUTPUT_VOLTAGE,
+                default=restrict_voltage(1.0)
+            ),
+            configuration.floatingPoint(
+                name="CV3",
+                minimum=0.0,
+                maximum=europi_config.MAX_OUTPUT_VOLTAGE,
+                default=restrict_voltage(2.0)
+            ),
+            configuration.floatingPoint(
+                name="CV4",
+                minimum=0.0,
+                maximum=europi_config.MAX_OUTPUT_VOLTAGE,
+                default=restrict_voltage(2.5)
+            ),
+            configuration.floatingPoint(
+                name="CV5",
+                minimum=0.0,
+                maximum=europi_config.MAX_OUTPUT_VOLTAGE,
+                default=restrict_voltage(5.0)
+            ),
+            configuration.floatingPoint(
+                name="CV6",
+                minimum=0.0,
+                maximum=europi_config.MAX_OUTPUT_VOLTAGE,
+                default=restrict_voltage(10.0)
+            ),
         ]
 
     def main(self):


### PR DESCRIPTION
Fix a possible crash with the ConfigPoints if the global maximum output voltage has been lowered. Any channels whose default voltages are greater than the specified maximum will now be zero instead