### PR TITLE
Add `DISPLAY_CONTRAST` to `europi_config`, refactor `Display` class

### DIFF
--- a/software/CONFIGURATION.md
+++ b/software/CONFIGURATION.md
@@ -46,6 +46,7 @@ Display options:
 - `DISPLAY_SDA` is the I²C SDA pin used for the display. Only SDA capable pins can be selected. Default: `0`
 - `DISPLAY_SCL` is the I²C SCL pin used for the display. Only SCL capable pins can be selected. Default: `1`
 - `DISPLAY_CHANNEL` is the I²C channel used for the display, either 0 or 1. Default: `0`
+- `DISPLAY_CONTRAST` is a value indicating the display contrast. Higher numbers give higher contrast. `0` to `255`. Default: `255`
 
 External I²C options:
 - `EXTERNAL_I2C_SDA` is the I²C SDA pin used for the external I²C interface. Only SDA capable pis can be selected. Default: `2`
@@ -130,33 +131,7 @@ True
 ```
 
 `europi.py` contains objects called `europi_config` and `experimental_config` which implement the core & experimental
-customizations described in the sections above. Below is a detailed summary of the contents of these objects:
-
-```python
->>> from europi import europi_config
->>> dir(europi_config)
-[
-  '__class__',
-  '__init__',
-  '__module__',
-  '__qualname__',
-  '__dict__',
-  'to_attr_name',
-  'CPU_FREQ',
-  'DISPLAY_CHANNEL',
-  'DISPLAY_HEIGHT',
-  'DISPLAY_SCL',
-  'DISPLAY_SDA',
-  'DISPLAY_WIDTH',
-  'EUROPI_MODEL',
-  'GATE_VOLTAGE',
-  'MAX_INPUT_VOLTAGE',
-  'MAX_OUTPUT_VOLTAGE',
-  'MENU_AFTER_POWER_ON',
-  'PICO_MODEL',
-  'ROTATE_DISPLAY'
-]
-```
+customizations described in the sections above.
 
 When you import `europi` into your project you can access the `europi_config` object like this:
 ```python

--- a/software/contrib/bit_garden.py
+++ b/software/contrib/bit_garden.py
@@ -3,7 +3,6 @@ try:
     from software.firmware import europi_config
     from software.firmware.europi import CHAR_HEIGHT, CHAR_WIDTH, OLED_WIDTH
     from software.firmware.europi import ain, din, k1, k2, oled, b1, b2, cvs
-    from software.firmware.europi_display import DummyDisplay, NoDisplayConnectedException
     from software.firmware.europi_script import EuroPiScript
     from software.firmware.experimental.a_to_d import AnalogReaderDigitalWrapper
     from software.firmware.experimental.custom_font import CustomFontDisplay
@@ -12,7 +11,6 @@ try:
 except ImportError:
     # Device import path
     from europi import *
-    from europi_display import DummyDisplay, NoDisplayConnectedException
     from europi_script import EuroPiScript
     from experimental.a_to_d import AnalogReaderDigitalWrapper
     from experimental.custom_font import CustomFontDisplay
@@ -28,11 +26,7 @@ MAX_STEPS = 32
 LONG_PRESS_MS = 500
 
 # Use the Custom Font wrapper for oled display.
-try:
-    oled = CustomFontDisplay()
-except NoDisplayConnectedException as e:
-    print(e)
-    oled = DummyDisplay(OLED_WIDTH, OLED_HEIGHT)
+oled = CustomFontDisplay()
 
 
 class TriggerMode:

--- a/software/contrib/bit_garden.py
+++ b/software/contrib/bit_garden.py
@@ -3,6 +3,7 @@ try:
     from software.firmware import europi_config
     from software.firmware.europi import CHAR_HEIGHT, CHAR_WIDTH, OLED_WIDTH
     from software.firmware.europi import ain, din, k1, k2, oled, b1, b2, cvs
+    from software.firmware.europi_display import DummyDisplay, NoDisplayConnectedException
     from software.firmware.europi_script import EuroPiScript
     from software.firmware.experimental.a_to_d import AnalogReaderDigitalWrapper
     from software.firmware.experimental.custom_font import CustomFontDisplay
@@ -11,6 +12,7 @@ try:
 except ImportError:
     # Device import path
     from europi import *
+    from europi_display import DummyDisplay, NoDisplayConnectedException
     from europi_script import EuroPiScript
     from experimental.a_to_d import AnalogReaderDigitalWrapper
     from experimental.custom_font import CustomFontDisplay
@@ -26,7 +28,11 @@ MAX_STEPS = 32
 LONG_PRESS_MS = 500
 
 # Use the Custom Font wrapper for oled display.
-oled = CustomFontDisplay()
+try:
+    oled = CustomFontDisplay()
+except NoDisplayConnectedException as e:
+    print(e)
+    oled = DummyDisplay(OLED_WIDTH, OLED_HEIGHT)
 
 
 class TriggerMode:
@@ -171,7 +177,7 @@ class BitGarden(EuroPiScript):
     def digital_falling(self):
         """Tell the SeedPacket the digital input has gone low for Trigger mode."""
         self.packet.trigger_off()
-    
+
     def digital2_rising(self):
         self.packet.new_seed()
         self._update_display = True
@@ -364,7 +370,7 @@ class BitGarden(EuroPiScript):
         charh = ubuntumono20.height()
         oled.text(f"{self._temp_seed:04X}", start, top, font=ubuntumono20)
         oled.hline(start + (self._seed_index * charw), top+charh, charw, 1)
-    
+
     def display_edit_probability(self):
         """Display each output probability as a vertical filled bar with edit indicator."""
         top = 0

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -32,7 +32,7 @@ from configuration import ConfigSettings
 from framebuf import FrameBuffer, MONO_HLSB
 
 from europi_config import load_europi_config, CPU_FREQS
-from europi_display import Display, DummyDisplay, NoDisplayConnectedException
+from europi_display import Display, DummyDisplay
 
 from experimental.experimental_config import load_experimental_config
 

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -608,7 +608,7 @@ k2 = Knob(PIN_K2)
 b1 = Button(PIN_B1)
 b2 = Button(PIN_B2)
 
-try:
+if not TEST_ENV:
     oled = Display(
         width=europi_config.DISPLAY_WIDTH,
         height=europi_config.DISPLAY_HEIGHT,
@@ -619,8 +619,8 @@ try:
         contrast=europi_config.DISPLAY_CONTRAST,
         rotate=europi_config.ROTATE_DISPLAY,
     )
-except NoDisplayConnectedException as e:
-    print(e)
+else:
+    print("No display hardware detected; falling back to DummyDisplay")
     oled = DummyDisplay(
         width=europi_config.DISPLAY_WIDTH,
         height=europi_config.DISPLAY_HEIGHT,

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -609,16 +609,23 @@ b1 = Button(PIN_B1)
 b2 = Button(PIN_B2)
 
 if not TEST_ENV:
-    oled = Display(
-        width=europi_config.DISPLAY_WIDTH,
-        height=europi_config.DISPLAY_HEIGHT,
-        sda=europi_config.DISPLAY_SDA,
-        scl=europi_config.DISPLAY_SCL,
-        channel=europi_config.DISPLAY_CHANNEL,
-        freq=europi_config.DISPLAY_FREQUENCY,
-        contrast=europi_config.DISPLAY_CONTRAST,
-        rotate=europi_config.ROTATE_DISPLAY,
-    )
+    try:
+        oled = Display(
+            width=europi_config.DISPLAY_WIDTH,
+            height=europi_config.DISPLAY_HEIGHT,
+            sda=europi_config.DISPLAY_SDA,
+            scl=europi_config.DISPLAY_SCL,
+            channel=europi_config.DISPLAY_CHANNEL,
+            freq=europi_config.DISPLAY_FREQUENCY,
+            contrast=europi_config.DISPLAY_CONTRAST,
+            rotate=europi_config.ROTATE_DISPLAY,
+        )
+    except Exception as err:
+        print(f"Failed to initialize display: {err}. Is the hardware connected properly?")
+        oled = DummyDisplay(
+            width=europi_config.DISPLAY_WIDTH,
+            height=europi_config.DISPLAY_HEIGHT,
+        )
 else:
     print("No display hardware detected; falling back to DummyDisplay")
     oled = DummyDisplay(

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -621,7 +621,10 @@ try:
     )
 except NoDisplayConnectedException as e:
     print(e)
-    oled = DummyDisplay()
+    oled = DummyDisplay(
+        width=europi_config.DISPLAY_WIDTH,
+        height=europi_config.DISPLAY_HEIGHT,
+    )
 
 
 cv1 = Output(PIN_CV1)

--- a/software/firmware/europi_config.py
+++ b/software/firmware/europi_config.py
@@ -130,6 +130,12 @@ class EuroPiConfig:
                 default=0,
             ),
             configuration.integer(
+                name="DISPLAY_CONTRAST",
+                minimum=0,
+                maximum=255,
+                default=255
+            ),
+            configuration.integer(
                 name="DISPLAY_FREQUENCY",
                 minimum=0,
                 maximum=1000000,

--- a/software/firmware/europi_display.py
+++ b/software/firmware/europi_display.py
@@ -11,6 +11,7 @@ class NoDisplayConnectedException(Exception):
     """
     An exception raised by the Display constructor if no display hardware is connected
     """
+
     def __init__(self):
         super().__init__(
             "EuroPi Hardware Error:\nMake sure the OLED display is connected correctly"

--- a/software/firmware/europi_display.py
+++ b/software/firmware/europi_display.py
@@ -7,17 +7,6 @@ import ssd1306
 from ssd1306 import SSD1306_I2C
 
 
-class NoDisplayConnectedException(Exception):
-    """
-    An exception raised by the Display constructor if no display hardware is connected
-    """
-
-    def __init__(self):
-        super().__init__(
-            "EuroPi Hardware Error:\nMake sure the OLED display is connected correctly"
-        )
-
-
 class Display(SSD1306_I2C):
     """
     A class for drawing graphics and text to the OLED.
@@ -50,9 +39,6 @@ class Display(SSD1306_I2C):
         i2c = I2C(channel, sda=Pin(sda), scl=Pin(scl), freq=freq)
         self.width = width
         self.height = height
-
-        if len(i2c.scan()) == 0:
-            raise NoDisplayConnectedException()
         super().__init__(self.width, self.height, i2c)
         self.rotate(rotate)
         self.contrast(contrast)

--- a/software/firmware/europi_display.py
+++ b/software/firmware/europi_display.py
@@ -34,6 +34,7 @@ class Display(SSD1306_I2C):
     """
 
     def __init__(
+        # fmt: off
         self,
         width,
         height,
@@ -43,6 +44,7 @@ class Display(SSD1306_I2C):
         freq,
         contrast,
         rotate
+        # fmt: on
     ):
         i2c = I2C(channel, sda=Pin(sda), scl=Pin(scl), freq=freq)
         self.width = width
@@ -100,6 +102,7 @@ class DummyDisplay:
 
     Useful e.g when debugging a breadboard version of the module without a display connected
     """
+
     def __init__(self, width, height):
         self.width = width
         self.height = height

--- a/software/firmware/europi_display.py
+++ b/software/firmware/europi_display.py
@@ -1,0 +1,150 @@
+"""
+Classes and definitions for interacting with the OLED display
+"""
+
+from machine import I2C, Pin
+import ssd1306
+from ssd1306 import SSD1306_I2C
+
+
+class NoDisplayConnectedException(Exception):
+    """
+    An exception raised by the Display constructor if no display hardware is connected
+    """
+    def __init__(self):
+        super().__init__(
+            "EuroPi Hardware Error:\nMake sure the OLED display is connected correctly"
+        )
+
+
+class Display(SSD1306_I2C):
+    """
+    A class for drawing graphics and text to the OLED.
+
+    The OLED Display works by collecting all the applied commands and only
+    updates the physical display when ``oled.show()`` is called. This allows
+    you to perform more complicated graphics without slowing your program, or
+    to perform the calculations for other functions, but only update the
+    display every few steps to prevent lag.
+
+    To clear the display, simply fill the display with the colour black by using ``oled.fill(0)``
+
+    More explanations and tips about the the display can be found in the oled_tips file
+    `oled_tips.md <https://github.com/Allen-Synthesis/EuroPi/blob/main/software/oled_tips.md>`_
+    """
+
+    def __init__(
+        self,
+        width,
+        height,
+        sda,
+        scl,
+        channel,
+        freq,
+        contrast,
+        rotate
+    ):
+        i2c = I2C(channel, sda=Pin(sda), scl=Pin(scl), freq=freq)
+        self.width = width
+        self.height = height
+
+        if len(i2c.scan()) == 0:
+            raise NoDisplayConnectedException()
+        super().__init__(self.width, self.height, i2c)
+        self.rotate(rotate)
+        self.contrast(contrast)
+
+    def rotate(self, rotate):
+        """Flip the screen from its default orientation
+
+        @param rotate  True or False, indicating whether we want to flip the screen from its default orientation
+        """
+        # From a hardware perspective, the default screen orientation of the display _is_ rotated
+        # But logically we treat this as right-way-up.
+        if rotate:
+            rotate = 0
+        else:
+            rotate = 1
+        self.write_cmd(ssd1306.SET_COM_OUT_DIR | ((rotate & 1) << 3))
+        self.write_cmd(ssd1306.SET_SEG_REMAP | (rotate & 1))
+
+    def centre_text(self, text, clear_first=True, auto_show=True):
+        """Display one or more lines of text centred both horizontally and vertically.
+
+        @param text  The text to display
+        @param clear_first  If true, the screen buffer is cleared before rendering the text
+        @param auto_show  If true, oled.show() is called after rendering the text. If false, you must call oled.show() yourself
+        """
+        if clear_first:
+            self.fill(0)
+        # Default font is 8x8 pixel monospaced font which can be split to a
+        # maximum of 4 lines on a 128x32 display, but the maximum_lines variable
+        # is rounded down for readability
+        lines = str(text).split("\n")
+        maximum_lines = round(self.height / CHAR_HEIGHT)
+        if len(lines) > maximum_lines:
+            raise Exception("Provided text exceeds available space on oled display.")
+        padding_top = (self.height - (len(lines) * (CHAR_HEIGHT + 1))) / 2
+        for index, content in enumerate(lines):
+            x_offset = int((self.width - ((len(content) + 1) * (CHAR_WIDTH - 1))) / 2) - 1
+            y_offset = int((index * (CHAR_HEIGHT + 1)) + padding_top) - 1
+            self.text(content, x_offset, y_offset)
+
+        if auto_show:
+            self.show()
+
+
+class DummyDisplay:
+    """
+    An alternative to Display that provides software compatibility, but no hardware interface
+
+    Useful e.g when debugging a breadboard version of the module without a display connected
+    """
+    def __init__(self, width, height):
+        self.width = width
+        self.height = height
+
+    def rotate(self, rotate):
+        pass
+
+    def centre_text(self, text, clear_first=True, auto_show=True):
+        pass
+
+    def show(self):
+        pass
+
+    def fill(self, color):
+        pass
+
+    def text(self, string, x, y, color=1):
+        pass
+
+    def line(self, x1, y1, x2, y2, color=1):
+        pass
+
+    def hline(self, x, y, length, color=1):
+        pass
+
+    def vline(self, x, y, length, color=1):
+        pass
+
+    def rect(self, x, y, width, height, color=1):
+        pass
+
+    def fill_rect(self, x, y, width, height, color=1):
+        pass
+
+    def blit(self, buffer, x, y):
+        pass
+
+    def scroll(self, x, y):
+        pass
+
+    def invert(self, color=1):
+        pass
+
+    def contrast(self, contrast):
+        pass
+
+    def pixel(self, x, y, color=1):
+        pass

--- a/software/firmware/europi_display.py
+++ b/software/firmware/europi_display.py
@@ -6,6 +6,10 @@ from machine import I2C, Pin
 import ssd1306
 from ssd1306 import SSD1306_I2C
 
+# Default font is 8x8 pixel monospaced font.
+CHAR_WIDTH = 8
+CHAR_HEIGHT = 8
+
 
 class Display(SSD1306_I2C):
     """

--- a/software/firmware/europi_display.py
+++ b/software/firmware/europi_display.py
@@ -128,6 +128,9 @@ class DummyDisplay:
     def fill_rect(self, x, y, width, height, color=1):
         pass
 
+    def ellipse(self, x, y, xr, yr, colour=1, fill=False):
+        pass
+
     def blit(self, buffer, x, y):
         pass
 

--- a/software/firmware/experimental/custom_font.py
+++ b/software/firmware/experimental/custom_font.py
@@ -5,16 +5,11 @@ from machine import Pin
 from ssd1306 import SSD1306_I2C
 
 from europi import (
-    OLED_WIDTH,
-    OLED_I2C_FREQUENCY,
-    OLED_HEIGHT,
-    OLED_I2C_SDA,
-    OLED_I2C_SCL,
-    OLED_I2C_CHANNEL,
+    europi_config,
     TEST_ENV,
     CHAR_HEIGHT,
 )
-from europi import Display as BasicDisplay
+from europi_display import Display as BasicDisplay
 
 
 # TODO: add a method to select the font to use by default
@@ -79,7 +74,16 @@ class CustomFontDisplay(BasicDisplay):
     def __init__(self, default_font=None):  # by default will use the monospaced 8x8 font
         self.writers = {}  # re-usable large font writer instances
         self.default_font = default_font
-        super().__init__(OLED_I2C_SDA, OLED_I2C_SCL, channel=OLED_I2C_CHANNEL)
+        super().__init__(
+            width=europi_config.DISPLAY_WIDTH,
+            height=europi_config.DISPLAY_HEIGHT,
+            sda=europi_config.DISPLAY_SDA,
+            scl=europi_config.DISPLAY_SCL,
+            channel=europi_config.DISPLAY_CHANNEL,
+            freq=europi_config.DISPLAY_FREQUENCY,
+            contrast=europi_config.DISPLAY_CONTRAST,
+            rotate=europi_config.ROTATE_DISPLAY,
+        )
 
     def _writer(self, font):
         """Returns the large font writer for the specified font."""


### PR DESCRIPTION
As-per a user suggestion on Discord, add `DISPLAY_CONTRAST` to europi_config to tune the brightness of the display.  Documentation seems inconsistent, as some Arduino docs for the `SSD1306_I2C` I've read indicate contrast is the percentage 0-100, while the Micropython docs use `0` and `255` in their example (https://docs.micropython.org/en/latest/esp8266/tutorial/ssd1306.html.  I've opted for the Micropython range, though truth be told I don't see anything changing below about 8.

I've also relocated the `Display` class to a new `europi_display` module, and added a new `DummyDisplay` class & custom exception that gets raised if the display hardware is not detected.  I've been doing some software debugging with an extra Pico in a breadboard, but don't have a display connected. Having `europi` crash with an unhandled exception because the display hardware is missing doesn't feel great IMO, so instead the error gets printed for debugging, and we instantiate a software-compatible `DummyDisplay`. This lets the software function, and should (in theory) make things easier for a possible EuroPi Lite that doesn't have a display at all.

This eliminates some extra logic inside the `Display` class where functions behave differently if `TEST_ENV` is True or False.