### PR TITLE
Add Itty Bitty script

### DIFF
--- a/software/contrib/README.md
+++ b/software/contrib/README.md
@@ -104,6 +104,13 @@ The division of the master clock that each LFO runs at, as well as each of their
 <i>Author: [roryjamesallen](https://github.com/roryjamesallen)</i>
 <br><i>Labels: LFO</i>
 
+### Itty Bitty \[ [documentation](/software/contrib/itty_bitty.md) | [script](/software/contrib/itty_bitty.py) \]
+
+Dual-channel 8-bit trigger+gate+cv sequencer based on the binary representation of an 8-bit number.
+
+<i>Author: [chrisib](https://github.com/chrisib)</i>
+<br><i>Labels: sequencer, gate, trigger, cv</i>
+
 ### Kompari \[ [documentation](/software/contrib/kompari.md) | [script](/software/contrib/kompari.py) \]
 
 Compares `AIN` to `K1` and `K2`, outputting 5V digital signals on `CV1`-`CV5`, and an analogue output signal based on

--- a/software/contrib/itty_bitty.md
+++ b/software/contrib/itty_bitty.md
@@ -38,12 +38,22 @@ The numbers 0-255 can be represented in binary in 8 bits:
 Let `0 <= n <= 255` be the value the user selects with the knob. Every time we receive a clock signal we rotate
 the bits 1 place to the left, giving us `n'`:
 ```
-00000001 -> 00000010 -> 00000100 -> 00001000 -> 00010000 -> 00100000 -> 01000000 -> 10000000 -> 00000001
+...
+00000001
+00000010
+00000100
+00001000
+00010000
+00100000
+01000000
+10000000
+00000001
+...
 ```
 
 The "current bit` is the least-significant bit.
 
-The trigger output will emit a trgger signal if the current 1s bit is 1, and no trigger if the current bit is 0. The
+The trigger output will emit a trigger signal if the current 1s bit is 1, and no trigger if the current bit is 0. The
 duration of the trigger is the same as the incoming clock signal (or the duration of the button press).
 
 The gate output will go high if the current bit is 1, and will go low if the current bit is 0.

--- a/software/contrib/itty_bitty.md
+++ b/software/contrib/itty_bitty.md
@@ -1,0 +1,51 @@
+# Itty Bitty
+
+A gate & CV sequencer that uses the binary representation of an 8-bit integer to determine the of/off pattern.
+
+The module has 2 channels, A and B.  Channel A is controlled by `K1` and outputs on `CV1-3`.  Channel B is controlled
+by `K2` and outputs on `CV4-6`.
+
+Inspired by an [Instagram post by Schreibmaschine](https://www.instagram.com/p/DDaZklkgzbr) describing an idea for a
+new module.
+
+## Ins & Outs
+
+- `DIN`: an input clock/gate/trigger signal used to advance the sequences
+- `AIN`: not used
+- `K1`: determines the value of sequence A: 0-255
+- `K2`: determines the value of sequence B: 0-255
+- `B1`: manually advance sequence A
+- `B2`: manually advance sequence B
+- `CV1`: trigger output of sequence A
+- `CV2`: gate output of sequence A
+- `CV3`: CV output of sequence A
+- `CV4`: trigger output of sequence B
+- `CV5`: gate output of sequence B
+- `CV6`: CV output of sequence B
+
+## How the sequence works
+
+The numbers 0-255 can be represented in binary in 8 bits:
+- `0`: `00000000`
+- `1`: `00000001`
+- `2`: `00000010`
+- `3`: `00000011`
+- ...
+- `253`: `11111101`
+- `254`: `11111110`
+- `255`: `11111111`
+
+Let `0 <= n <= 255` be the value the user selects with the knob. Every time we receive a clock signal we rotate
+the bits 1 place to the left, giving us `n'`:
+```
+00000001 -> 00000010 -> 00000100 -> 00001000 -> 00010000 -> 00100000 -> 01000000 -> 10000000 -> 00000001
+```
+
+The "current bit` is the least-significant bit.
+
+The trigger output will emit a trgger signal if the current 1s bit is 1, and no trigger if the current bit is 0. The
+duration of the trigger is the same as the incoming clock signal (or the duration of the button press).
+
+The gate output will go high if the current bit is 1, and will go low if the current bit is 0.
+
+The CV output set to `MAX_OUTPUT_VOLTAGE * n' / 255`.

--- a/software/contrib/itty_bitty.md
+++ b/software/contrib/itty_bitty.md
@@ -58,7 +58,9 @@ duration of the trigger is the same as the incoming clock signal (or the duratio
 
 The gate output will go high if the current bit is 1, and will go low if the current bit is 0.
 
-The CV output set to `MAX_OUTPUT_VOLTAGE * n' / 255`.
+The CV output set to `MAX_OUTPUT_VOLTAGE * reverse(n') / 255`. The bits are reversed so as to prevent a situation
+where the CV is always high when the active bit is also high; this forcibly de-couples the gate & CV outputs,
+which can lead to more interesting interactions between them
 
 ## Configuration
 

--- a/software/contrib/itty_bitty.md
+++ b/software/contrib/itty_bitty.md
@@ -70,7 +70,7 @@ This program has the following configuration options:
   CV signal connected to `AIN`
 - `USE_AIN_B`: if `true`, channel B's value is determined by `AIN` and `k2` will act as an attenuator for the
   CV signal connected to `AIN`
-- `USE_GRAY_ENCODING`: if `true`, instead of traditional binary encoding, the pattery is encoded using
+- `USE_GRAY_ENCODING`: if `true`, instead of traditional binary encoding, the pattern is encoded using
   [gray encoding](https://en.wikipedia.org/wiki/Gray_encoding). This means that adjacent sequences will
   always differ by exactly 1 bit.
 

--- a/software/contrib/itty_bitty.md
+++ b/software/contrib/itty_bitty.md
@@ -71,7 +71,7 @@ This program has the following configuration options:
 - `USE_AIN_B`: if `true`, channel B's value is determined by `AIN` and `k2` will act as an attenuator for the
   CV signal connected to `AIN`
 - `USE_GRAY_ENCODING`: if `true`, instead of traditional binary encoding, the pattern is encoded using
-  [gray encoding](https://en.wikipedia.org/wiki/Gray_encoding). This means that adjacent sequences will
+  [gray encoding](https://en.wikipedia.org/wiki/Gray_encoding). This means that consecutive sequences will
   always differ by exactly 1 bit.
 
 | Decimal value | Traditional binary | Gray encoding |

--- a/software/contrib/itty_bitty.md
+++ b/software/contrib/itty_bitty.md
@@ -60,7 +60,55 @@ The gate output will go high if the current bit is 1, and will go low if the cur
 
 The CV output set to `MAX_OUTPUT_VOLTAGE * reverse(n') / 255`. The bits are reversed so as to prevent a situation
 where the CV is always high when the active bit is also high; this forcibly de-couples the gate & CV outputs,
-which can lead to more interesting interactions between them
+which can lead to more interesting interactions between them.
+
+### Example sequence
+
+Let's assume sequence 83 is selected.  `83 = 01010011`
+
+| Step | Gate       | Trigger | CV Out    |
+|      | (High/Low) | (Y/N)   | (10V max) |
+|------|------------|---------|-----------|
+| 1    | Low        | N       | 7.921V    |
+| 2    | High       | Y       | 3.961V    |
+| 3    | Low        | N       | 6.980V    |
+| 4    | High       | Y       | 3.490V    |
+| 5    | Low        | N       | 6.745V    |
+| 6    | Low        | N       | 3.723V    |
+| 7    | High       | Y       | 1.686V    |
+| 8    | High       | Y       | 5.843V    |
+
+Time graph
+```
+Clock In
+____      ____      ____      ____      ____      ____      ____      ____
+    |    |    |    |    |    |    |    |    |    |    |    |    |    |    |
+    |____|    |____|    |____|    |____|    |____|    |____|    |____|    |____
+         .         .         .         .         .         .         .
+Gate Out .         .         .         .         .         .         .
+         ._________.         ._________.         .         .____________________
+         |         |         |         |         .         |         .
+_________|         |_________|         |___________________|         .
+         .         .         .         .         .         .         .
+Trigger Out        .         .         .         .         .         .
+         ._        .         ._        .         .         ._        ._
+         | |       .         | |       .         .         | |       | |
+_________| |_________________| |___________________________| |_______| |________
+         .         .         .         .         .         .         .
+CV Out (approx)    .         .         .         .         .         .
+10V---   .         .         .         .         .         .         .
+         .         .         .         .         .         .         .
+_________.         .         .         .         .         .         .
+         |         ._________.         ._________.         .         .
+         |         |         |         |         |         .         .__________
+5V----   |         |         |         |         |         .         |
+         |_________|         |_________|         |_________.         |
+         .         .         ,         .         .         |         |
+         .         .         .         .         .         |_________|
+         .         .         .         .         .         .         .
+0V----   .         .         .         .         .         .         .
+
+```
 
 ## Configuration
 

--- a/software/contrib/itty_bitty.md
+++ b/software/contrib/itty_bitty.md
@@ -11,7 +11,7 @@ new module.
 ## Ins & Outs
 
 - `DIN`: an input clock/gate/trigger signal used to advance the sequences
-- `AIN`: not used
+- `AIN`: optional CV control for sequence A and/or B (see configuration, below)
 - `K1`: determines the value of sequence A: 0-255
 - `K2`: determines the value of sequence B: 0-255
 - `B1`: manually advance sequence A
@@ -64,9 +64,13 @@ which can lead to more interesting interactions between them
 
 ## Configuration
 
-This program has one configuration option:
+This program has the following configuration options:
 
-- `USE_GRAY_ENCODING`: it `true`, instead of traditional binary encoding, the pattery is encoded using
+- `USE_AIN_A`: if `true`, channel A's value is determined by `AIN` and `k1` will act as an attenuator for the
+  CV signal connected to `AIN`
+- `USE_AIN_B`: if `true`, channel B's value is determined by `AIN` and `k2` will act as an attenuator for the
+  CV signal connected to `AIN`
+- `USE_GRAY_ENCODING`: if `true`, instead of traditional binary encoding, the pattery is encoded using
   [gray encoding](https://en.wikipedia.org/wiki/Gray_encoding). This means that adjacent sequences will
   always differ by exactly 1 bit.
 

--- a/software/contrib/itty_bitty.md
+++ b/software/contrib/itty_bitty.md
@@ -64,19 +64,18 @@ which can lead to more interesting interactions between them.
 
 ### Example sequence
 
-Let's assume sequence 83 is selected.  `83 = 01010011`
+Let's assume sequence 83 is selected. `83 = 01010011`
 
-| Step | Gate       | Trigger | CV Out    |
-|      | (High/Low) | (Y/N)   | (10V max) |
-|------|------------|---------|-----------|
-| 1    | Low        | N       | 7.921V    |
-| 2    | High       | Y       | 3.961V    |
-| 3    | Low        | N       | 6.980V    |
-| 4    | High       | Y       | 3.490V    |
-| 5    | Low        | N       | 6.745V    |
-| 6    | Low        | N       | 3.723V    |
-| 7    | High       | Y       | 1.686V    |
-| 8    | High       | Y       | 5.843V    |
+| Step | Gate (High/Low) | Trigger (Y/N) | CV Out (10V max) |
+|------|-----------------|---------------|------------------|
+| 1    | Low             | N             | 7.921V           |
+| 2    | High            | Y             | 3.961V           |
+| 3    | Low             | N             | 6.980V           |
+| 4    | High            | Y             | 3.490V           |
+| 5    | Low             | N             | 6.745V           |
+| 6    | Low             | N             | 3.723V           |
+| 7    | High            | Y             | 1.686V           |
+| 8    | High            | Y             | 5.843V           |
 
 Time graph
 ```

--- a/software/contrib/itty_bitty.md
+++ b/software/contrib/itty_bitty.md
@@ -51,7 +51,7 @@ the bits 1 place to the left, giving us `n'`:
 ...
 ```
 
-The "current bit` is the least-significant bit.
+The "current bit` is the most-significant bit.
 
 The trigger output will emit a trigger signal if the current 1s bit is 1, and no trigger if the current bit is 0. The
 duration of the trigger is the same as the incoming clock signal (or the duration of the button press).

--- a/software/contrib/itty_bitty.md
+++ b/software/contrib/itty_bitty.md
@@ -59,3 +59,31 @@ duration of the trigger is the same as the incoming clock signal (or the duratio
 The gate output will go high if the current bit is 1, and will go low if the current bit is 0.
 
 The CV output set to `MAX_OUTPUT_VOLTAGE * n' / 255`.
+
+## Configuration
+
+This program has one configuration option:
+
+- `USE_GRAY_ENCODING`: it `true`, instead of traditional binary encoding, the pattery is encoded using
+  [gray encoding](https://en.wikipedia.org/wiki/Gray_encoding). This means that adjacent sequences will
+  always differ by exactly 1 bit.
+
+| Decimal value | Traditional binary | Gray encoding |
+|---------------|--------------------|---------------|
+| 0             | `00000000`         | `000000000`   |
+| 1             | `00000001`         | `000000001`   |
+| 2             | `00000010`         | `000000011`   |
+| 3             | `00000011`         | `000000010`   |
+| 4             | `00000100`         | `000000110`   |
+| 5             | `00000101`         | `000000111`   |
+| 6             | `00000110`         | `000000101`   |
+| 7             | `00000111`         | `000000100`   |
+| ...           | ...                | ...           |
+
+To enable Gray encoding, create/edit `/config/IttyBitty.json` to contain the following:
+```json
+{
+    "USE_GRAY_ENCODING": true
+}
+
+```

--- a/software/contrib/itty_bitty.py
+++ b/software/contrib/itty_bitty.py
@@ -1,0 +1,115 @@
+"""
+Two 8-step trigger, gate & CV sequencers based on the binary representation of an 8-bit number
+"""
+
+from europi import *
+from europi_script import EuroPiScript
+import time
+
+
+class BittySequence:
+    """
+    A container class for one sequencer
+    """
+    def __init__(self, button_in, trigger_out, gate_out, cv_out):
+        """
+        Create a new sequencer
+
+        @param button_in  The button the user can press to manually advance the sequence
+        @param trigger_out  The CV output for the trigger signal
+        @param gate_out  The CV output for the gate signal
+        @param cv_out  The CV output for the CV signal
+        """
+        button_in.handler(self.advance)
+        button_in.handler_falling(self.trigger_off)
+
+        self.trigger_out = trigger_out
+        self.gate_out = gate_out
+        self.cv_out = cv_out
+
+        # the 0-255 value that's the basis for our sequence
+        self.sequence_n = 0
+
+        # the current step
+        self.step = 0
+
+        # is the current output state in need of refreshing?
+        self.output_dirty = False
+
+        # turn everything off initially
+        self.trigger_out.off()
+        self.gate_out.off()
+        self.cv_out.off()
+
+    def advance(self):
+        self.step = (self.step + 1) & 0x07  # restrict this to 0-7
+        self.output_dirty = True
+
+    def trigger_off(self):
+        self.trigger_out.off()
+
+    def apply_output(self):
+        now = time.ticks_ms()
+
+        # shift the sequence
+        n_prime = ((self.sequence_n << self.step) & 0xff) | ((self.sequence_n & 0xff) >> (8 - self.step))
+        current_bit = n_prime & 0x01
+
+        if current_bit:
+            self.trigger_out.on()
+            self.gate_out.on()
+        else:
+            self.trigger_out.off()
+            self.gate_out.off()
+
+        self.cv_out.voltage(europi_config.MAX_OUTPUT_VOLTAGE * n_prime / 255)
+
+        self.output_dirty = False
+
+    def change_sequence(self, n):
+        if n == self.sequence_n:
+            return
+
+        self.sequence_n = n
+
+
+class IttyBitty(EuroPiScript):
+    def __init__(self):
+        super().__init__()
+
+        self.sequencers = [
+            BittySequence(b1, cv1, cv2, cv3),
+            BittySequence(b2, cv4, cv5, cv6),
+        ]
+
+        @din.handler
+        def on_clock_rise():
+            for s in self.sequencers:
+                s.advance()
+
+        @din.handler_falling
+        def on_clock_fall():
+            for s in self.sequencers:
+                s.trigger_off()
+
+    def main(self):
+        while True:
+            n1 = k1.read_position(steps=256, samples=200)
+            n2 = k2.read_position(steps=256, samples=200)
+
+            self.sequencers[0].change_sequence(n1)
+            self.sequencers[1].change_sequence(n2)
+
+            display_text = ""
+            for s in self.sequencers:
+                n_prime = ((s.sequence_n << s.step) & 0xff) | ((s.sequence_n & 0xff) >> (8 - s.step))
+                display_text = display_text + f"\n{s.sequence_n:3} {n_prime:08b}"
+                if s.output_dirty:
+                    s.apply_output()
+
+            display_text = display_text.strip()
+            oled.centre_text(display_text)
+
+
+if __name__ == "__main__":
+    IttyBitty().main()

--- a/software/contrib/itty_bitty.py
+++ b/software/contrib/itty_bitty.py
@@ -67,10 +67,7 @@ class BittySequence:
         self.output_dirty = False
 
     def change_sequence(self, n):
-        if n == self.sequence_n:
-            return
-
-        self.sequence_n = n
+         self.sequence_n = n
 
 
 class IttyBitty(EuroPiScript):

--- a/software/contrib/itty_bitty.py
+++ b/software/contrib/itty_bitty.py
@@ -67,7 +67,7 @@ class BittySequence:
             self.trigger_out.off()
             self.gate_out.off()
 
-        self.cv_out.voltage(europi_config.MAX_OUTPUT_VOLTAGE * self.shifted_sequence / 255)
+        self.cv_out.voltage(europi_config.MAX_OUTPUT_VOLTAGE * self.cv_sequence / 255)
 
         self.output_dirty = False
 
@@ -85,6 +85,17 @@ class BittySequence:
     @property
     def shifted_sequence(self):
         return ((self.binary_sequence << self.step) & 0xff) | ((self.binary_sequence & 0xff) >> (8 - self.step))
+
+    @property
+    def cv_sequence(self):
+        # reverse the bits of the shifted sequence
+        s = self.shifted_sequence
+        cv = 0x00
+        while s:
+            cv = cv << 1
+            cv = cv | (s & 0x01)
+            s = s >> 1
+        return cv & 0xff
 
     @property
     def current_bit(self):

--- a/software/contrib/menu.py
+++ b/software/contrib/menu.py
@@ -38,7 +38,7 @@ EUROPI_SCRIPTS = OrderedDict([
     ["Hamlet",            "contrib.hamlet.Hamlet"],
     ["HarmonicLFOs",      "contrib.harmonic_lfos.HarmonicLFOs"],
     ["HelloWorld",        "contrib.hello_world.HelloWorld"],
-    ["Itty Bitty",        "contrib.hello_world.IttyBitty"],
+    ["Itty Bitty",        "contrib.itty_bitty.IttyBitty"],
     ["KnobPlayground",    "contrib.knob_playground.KnobPlayground"],
     ["Kompari",           "contrib.kompari.Kompari"],
     ["Logic",             "contrib.logic.Logic"],

--- a/software/contrib/menu.py
+++ b/software/contrib/menu.py
@@ -38,6 +38,7 @@ EUROPI_SCRIPTS = OrderedDict([
     ["Hamlet",            "contrib.hamlet.Hamlet"],
     ["HarmonicLFOs",      "contrib.harmonic_lfos.HarmonicLFOs"],
     ["HelloWorld",        "contrib.hello_world.HelloWorld"],
+    ["Itty Bitty",        "contrib.hello_world.IttyBitty"],
     ["KnobPlayground",    "contrib.knob_playground.KnobPlayground"],
     ["Kompari",           "contrib.kompari.Kompari"],
     ["Logic",             "contrib.logic.Logic"],


### PR DESCRIPTION
Adds a new dual-channel gate+trigger+cv sequencer.

User selects 2 8-bit numbers (0-255) using K1 and K2. When a clock signal is sent into DIN each sequence number's binary representation is used to turn CV1/4 on/off as a trigger output, CV2/5 on/off as a gate signal, and set CV3/6 to a 0-MAX_OUTPUT_VOLTAGE control signal.

B1 and B2 can be used to manually advance each channel.

Short video showing the script in action, using the trigger & CV outputs from channel A going into the Doepfer A-111-6: https://www.instagram.com/reel/DDa7RyFu8i9