### PR TITLE
Fix settings menu + knob bank interaction

### DIFF
--- a/software/firmware/experimental/knobs.py
+++ b/software/firmware/experimental/knobs.py
@@ -89,7 +89,7 @@ class LockableKnob(Knob):
 
         @param percent  The 0-1 value we want to re-lock the knob at
         """
-        self.value = int(MAX_UINT16 * (1.0-percent))
+        self.value = int(MAX_UINT16 * (1.0 - percent))
 
     def request_unlock(self):
         """Requests that the knob be unlocked. The knob will unlock the next time a reading of it's

--- a/software/firmware/experimental/knobs.py
+++ b/software/firmware/experimental/knobs.py
@@ -84,6 +84,13 @@ class LockableKnob(Knob):
         self.value = self._sample_adc(samples=samples)
         self.state = LockableKnob.STATE_LOCKED
 
+    def change_lock_value(self, percent=0.0):
+        """Change the current value to reflect a desired percentage
+
+        @param percent  The 0-1 value we want to re-lock the knob at
+        """
+        self.value = int(MAX_UINT16 * (1.0-percent))
+
     def request_unlock(self):
         """Requests that the knob be unlocked. The knob will unlock the next time a reading of it's
         position is taken that is withing the threshold percentage of the locked value. That is,

--- a/software/firmware/experimental/settings_menu.py
+++ b/software/firmware/experimental/settings_menu.py
@@ -22,7 +22,7 @@ Additional, more complex, examples can be found in:
 import europi
 
 from configuration import *
-from experimental.knobs import KnobBank
+from experimental.knobs import KnobBank, LockableKnob
 from framebuf import FrameBuffer, MONO_HLSB
 from machine import Timer
 import os
@@ -399,6 +399,10 @@ class SettingMenuItem(ChoiceMenuItem):
                 self.choose(new_choice)
                 self.ui_dirty = True
                 self.menu.settings_dirty = True
+        else:
+            # lock the knob to our current value
+            if type(self.menu.knob) is LockableKnob:
+                self.menu.knob.value = self.choices.index(self.value_choice) / len(self.choices)
 
         super().short_press()
 
@@ -598,6 +602,10 @@ class ActionMenuItem(ChoiceMenuItem):
             # fire the callback if we're exiting edit-mode
             choice = self.menu.knob.choice(self.choices)
             self.callback(choice, self.callback_arg)
+        else:
+            # lock the knob to the default action
+            if type(self.menu.knob) is LockableKnob:
+                self.menu.knob.value = 0
 
         super().short_press()
 
@@ -776,9 +784,6 @@ class SettingsMenu:
         if type(self._knob) is KnobBank:
             if self.active_item.is_editable:
                 self._knob.set_current("choice")
-                if issubclass(type(self.active_item), ChoiceMenuItem):
-                    self.knob.value = self.active_item.choices.index(
-                        self.active_item.value_choice) / len(self.active_item.choices)
             elif self.active_item.children and len(self.active_item.children) > 0:
                 self._knob.set_current("main_menu")
             else:

--- a/software/firmware/experimental/settings_menu.py
+++ b/software/firmware/experimental/settings_menu.py
@@ -776,6 +776,9 @@ class SettingsMenu:
         if type(self._knob) is KnobBank:
             if self.active_item.is_editable:
                 self._knob.set_current("choice")
+                if issubclass(type(self.active_item), ChoiceMenuItem):
+                    self.knob.value = self.active_item.choices.index(
+                        self.active_item.value_choice) / len(self.active_item.choices)
             elif self.active_item.children and len(self.active_item.children) > 0:
                 self._knob.set_current("main_menu")
             else:

--- a/software/firmware/experimental/settings_menu.py
+++ b/software/firmware/experimental/settings_menu.py
@@ -773,13 +773,13 @@ class SettingsMenu:
         self.active_item.short_press()
 
         # Cycle the knob bank, if necessary
-        if type(self.knob) is KnobBank:
+        if type(self._knob) is KnobBank:
             if self.active_item.is_editable:
-                self.knob.set_current("choice")
+                self._knob.set_current("choice")
             elif self.active_item.children and len(self.active_item.children) > 0:
-                self.knob.set_current("main_menu")
+                self._knob.set_current("main_menu")
             else:
-                self.active_item.set_current("submenu")
+                self._knob.set_current("submenu")
 
         self.short_press_cb()
 

--- a/software/firmware/experimental/settings_menu.py
+++ b/software/firmware/experimental/settings_menu.py
@@ -399,10 +399,6 @@ class SettingMenuItem(ChoiceMenuItem):
                 self.choose(new_choice)
                 self.ui_dirty = True
                 self.menu.settings_dirty = True
-        else:
-            # lock the knob to our current value
-            if type(self.menu.knob) is LockableKnob:
-                self.menu.knob.value = self.choices.index(self.value_choice) / len(self.choices)
 
         super().short_press()
 
@@ -602,10 +598,6 @@ class ActionMenuItem(ChoiceMenuItem):
             # fire the callback if we're exiting edit-mode
             choice = self.menu.knob.choice(self.choices)
             self.callback(choice, self.callback_arg)
-        else:
-            # lock the knob to the default action
-            if type(self.menu.knob) is LockableKnob:
-                self.menu.knob.value = 0
 
         super().short_press()
 
@@ -784,6 +776,12 @@ class SettingsMenu:
         if type(self._knob) is KnobBank:
             if self.active_item.is_editable:
                 self._knob.set_current("choice")
+                if issubclass(type(self.active_item), SettingMenuItem):
+                    # lock the knob to our current value
+                    self._knob.current.change_lock_value(
+                        self.active_item.choices.index(self.active_item.value_choice) /
+                            len(self.active_item.choices)
+                    )
             elif self.active_item.children and len(self.active_item.children) > 0:
                 self._knob.set_current("main_menu")
             else:

--- a/software/firmware/tools/conf_edit.py
+++ b/software/firmware/tools/conf_edit.py
@@ -9,8 +9,24 @@ from europi_config import EuroPiConfig
 from europi_script import EuroPiScript
 
 from configuration import ConfigFile
+
+from experimental.knobs import KnobBank
 from experimental.settings_menu import *
+
 from framebuf import FrameBuffer, MONO_HLSB
+
+
+## Lockable knob bank for K2 to make menu navigation a little easier
+#
+#  Note that this does mean _sometimes_ you'll need to sweep the knob all the way left/right
+#  to unlock it
+k2_bank = (
+    KnobBank.builder(k2)
+    .with_unlocked_knob("main_menu")
+    .with_locked_knob("submenu", initial_percentage_value=0)
+    .with_locked_knob("choice", initial_percentage_value=0)
+    .build()
+)
 
 
 class SectionHeader(MenuItem):
@@ -101,7 +117,8 @@ class ConfigurationEditor(EuroPiScript):
                     title="I2C",
                     children=i2c_items
                 ),
-            ]
+            ],
+            navigation_knob=k2_bank,
         )
         self.menu.load_defaults(ConfigFile.config_filename(EuroPiConfig))
         # fmt: on

--- a/software/firmware/tools/experimental_conf_edit.py
+++ b/software/firmware/tools/experimental_conf_edit.py
@@ -11,7 +11,21 @@ from europi_script import EuroPiScript
 from configuration import ConfigFile
 
 from experimental.experimental_config import *
+from experimental.knobs import KnobBank
 from experimental.settings_menu import *
+
+
+## Lockable knob bank for K2 to make menu navigation a little easier
+#
+#  Note that this does mean _sometimes_ you'll need to sweep the knob all the way left/right
+#  to unlock it
+k2_bank = (
+    KnobBank.builder(k2)
+    .with_unlocked_knob("main_menu")
+    .with_locked_knob("submenu", initial_percentage_value=0)
+    .with_locked_knob("choice", initial_percentage_value=0)
+    .build()
+)
 
 
 class ExperimentalConfigurationEditor(EuroPiScript):
@@ -47,7 +61,8 @@ class ExperimentalConfigurationEditor(EuroPiScript):
             )
 
         self.menu = SettingsMenu(
-            menu_items=items
+            menu_items=items,
+            navigation_knob=k2_bank,
         )
         self.menu.load_defaults(ConfigFile.config_filename(ExperimentalConfig))
         # fmt: on


### PR DESCRIPTION
Fixes a bug where the KnobBank's sub-knobs weren't being automatically locked & unlocked.

Also enables lockable knobs for the configuration editor `tools`