### PR TITLE
Rewrite `Logic` to use the `AnalogReaderDigitalWrapper`

### DIFF
--- a/software/contrib/logic.md
+++ b/software/contrib/logic.md
@@ -3,32 +3,33 @@
 This program implements six digital logic operations, with each
 operation's result sent to a different output jack.
 
-- `din`: the first boolean input. Holding down `b1` is equivalent to
-  applying voltage to `din`.
-- `ain`: the second boolean input; any signal above 0.8V is treated
-  as ON, anything below that is OFF. (Note: this is the same voltage
-  threshold used on the digital input.) Holding `b2` is equivalent to
-  applying voltage to `ain`.
-- `cv1`: `ain` AND `din`
-- `cv2`: `ain` OR `din`
-- `cv3`: `ain` XOR `din`
-- `cv4`: `ain` NAND `din`
-- `cv5`: `ain` NOR `din`
-- `cv6`: `ain` XNOR `din`
+## I/O Mapping
 
-The outputs are as follows:
+| I/O   | Notes                          |
+|-------|--------------------------------|
+| `din` | The first digital input        |
+| `ain` | The second digital input       |
+| `k1`  | Unused                         |
+| `k2`  | Unused                         |
+| `b1`  | Alternate first digital input  |
+| `b2`  | Alternate second digital input |
+| `cv1` | Digital AND output             |
+| `cv2` | Digital OR output              |
+| `cv3` | Digital XOR output             |
+| `cv4` | Digital NAND output            |
+| `cv5` | Digital NOR output             |
+| `cv6` | Digital XNOR output            |
 
-| Output No. | Operation |
-|------------|-----------|
-| Out 1      | AND       |
-| Out 2      | OR        |
-| Out 3      | XOR       |
-| Out 4      | NAND      |
-| Out 5      | NOR       |
-| Out 6      | XNOR      |
+Holding `b1` or `b2` will have the same effect as applying positive voltage
+to `din` or `ain` respectively.
 
-The following table shows the value for each operation for every
-input combination:
+### Note on button interaction
+
+Holding both buttons for a few seconds will send the reboot signal to the module,
+forcing the module to return to the main menu.  For this reason it is recommended to
+use only one button at a time when using the logic module performatively.
+
+## Digital Logic Reference
 
 | Din | Ain | AND | OR | XOR | NAND | NOR | XNOR |
 |-----|-----|-----|----|-----|------|-----|------|
@@ -37,13 +38,9 @@ input combination:
 |  1  |  0  |  0  |  1 |  1  |  1   |  0  |  0   |
 |  1  |  1  |  1  |  1 |  0  |  0   |  0  |  1   |
 
+## Screensaver
+
 The screen will go to sleep after 20 minutes of inactivity. Pressing
 either button will wake the screen up.
 
 The knobs are not used in this program.
-
-## Note on button interaction
-
-Holding both buttons for a few seconds will send the reboot signal to the module,
-forcing the module to return to the main menu.  For this reason it is recommended to
-use only one button at a time when using the logic module performatively.

--- a/software/contrib/logic.md
+++ b/software/contrib/logic.md
@@ -41,6 +41,4 @@ use only one button at a time when using the logic module performatively.
 ## Screensaver
 
 The screen will go to sleep after 20 minutes of inactivity. Pressing
-either button will wake the screen up.
-
-The knobs are not used in this program.
+either button or moving either knob will wake the screen up.

--- a/software/contrib/logic.py
+++ b/software/contrib/logic.py
@@ -66,14 +66,26 @@ class Logic(EuroPiScript):
         self.x_xnor_y = abs(self.x_xor_y -1)  # so some simple int math will suffice
 
     def main(self):
-        """The main loop
+        knob_wakeup_threshold = 0.05
 
-        Connects event handlers for clock-in and button presses
-        and runs the main loop
-        """
+        prev_k1 = k1.percent()
+        prev_k2 = k2.percent()
+
         while True:
             # update ain
             self.din2.update()
+
+            # check to see if we've wiggled a knob to exit the screensaver
+            current_k1 = k1.percent()
+            current_k2 = k2.percent()
+
+            if (
+                abs(current_k1 - prev_k1) >= knob_wakeup_threshold or
+                abs(current_k2 - prev_k2) >= knob_wakeup_threshold
+            ):
+                ssoled.notify_user_interaction()
+                prev_k1 = current_k1
+                prev_k2 = current_k2
 
             # set the output voltages
             cv1.value(self.x_and_y)

--- a/software/contrib/logic.py
+++ b/software/contrib/logic.py
@@ -33,30 +33,20 @@ class Logic(EuroPiScript):
         self.x_nor_y = 0
         self.x_xnor_y = 0
 
-        @b1.handler
-        def on_b1_press():
-            ssoled.notify_user_interaction()
-
-        @b2.handler
-        def on_b2_press():
-            ssoled.notify_user_interaction()
-
-        @din.handler
-        def on_din_rising():
-            self.update_logic()
-
-        @din.handler_falling
-        def on_din_falling():
-            self.update_logic()
-
-        def on_ain_rising():
-            self.update_logic()
-
-        def on_ain_falling():
-            self.update_logic()
-
         self.din1 = din
-        self.din2 = AnalogReaderDigitalWrapper(ain, cb_rising = on_ain_rising, cb_falling = on_ain_falling)
+        self.din2 = AnalogReaderDigitalWrapper(ain, cb_rising = self.update_logic, cb_falling = self.update_logic)
+
+        # connect ISRs
+        self.din1.handler(self.update_logic)
+        self.din1.handler_falling(self.update_logic)
+        b1.handler(self.button_state_change)
+        b1.handler_falling(self.button_state_change)
+        b2.handler(self.button_state_change)
+        b2.handler_falling(self.button_state_change)
+
+    def button_state_change(self):
+        self.update_logic()
+        ssoled.notify_user_interaction()
 
     @classmethod
     def display_name(cls):
@@ -65,8 +55,8 @@ class Logic(EuroPiScript):
     def update_logic(self):
         """Updates the values of our 6 logic operations
         """
-        x = self.din1.value()
-        y = self.din2.value()
+        x = self.din1.value() | b1.value()
+        y = self.din2.value() | b2.value()
 
         self.x_and_y = x & y
         self.x_or_y = x | y

--- a/software/contrib/logic.py
+++ b/software/contrib/logic.py
@@ -9,13 +9,10 @@ Treats ain as a digital input with a threshold of 0.8V
 from europi import *
 from europi_script import EuroPiScript
 
+from experimental.a_to_d import AnalogReaderDigitalWrapper
 from experimental.screensaver import OledWithScreensaver
 
 ssoled = OledWithScreensaver()
-
-## Anything above this threshold is considered ON for the analog
-#  input
-AIN_VOLTAGE_CUTOFF = 0.8
 
 class Logic(EuroPiScript):
     """The main workhorse of the whole module
@@ -26,16 +23,15 @@ class Logic(EuroPiScript):
     def __init__(self):
         super().__init__()
 
-    @classmethod
-    def display_name(cls):
-        return "Logic"
-
-    def main(self):
-        """The main loop
-
-        Connects event handlers for clock-in and button presses
-        and runs the main loop
-        """
+        # the six logic operations' outputs, as 0/1 values
+        # this lets us use bitwise math operations to set the output voltages to either 0 or 1V
+        # as well as satisfying the input requirements for the europi.Output.value function
+        self.x_and_y = 0
+        self.x_or_y = 0
+        self.x_xor_y = 0
+        self.x_nand_y = 0
+        self.x_nor_y = 0
+        self.x_xnor_y = 0
 
         @b1.handler
         def on_b1_press():
@@ -45,32 +41,65 @@ class Logic(EuroPiScript):
         def on_b2_press():
             ssoled.notify_user_interaction()
 
+        @din.handler
+        def on_din_rising():
+            self.update_logic()
+
+        @din.handler_falling
+        def on_din_falling():
+            self.update_logic()
+
+        def on_ain_rising():
+            self.update_logic()
+
+        def on_ain_falling():
+            self.update_logic()
+
+        self.din1 = din
+        self.din2 = AnalogReaderDigitalWrapper(ain, cb_rising = on_ain_rising, cb_falling = on_ain_falling)
+
+    @classmethod
+    def display_name(cls):
+        return "Logic"
+
+    def update_logic(self):
+        """Updates the values of our 6 logic operations
+        """
+        x = self.din1.value()
+        y = self.din2.value()
+
+        self.x_and_y = x & y
+        self.x_or_y = x | y
+        self.x_xor_y = x ^ y
+        self.x_nand_y = abs(self.x_and_y - 1) # bit of a hack to get the inverted values
+        self.x_nor_y = abs(self.x_or_y -1)    # ~ results in some -2 results, which we don't want
+        self.x_xnor_y = abs(self.x_xor_y -1)  # so some simple int math will suffice
+
+    def main(self):
+        """The main loop
+
+        Connects event handlers for clock-in and button presses
+        and runs the main loop
+        """
         while True:
+            # update ain
+            self.din2.update()
 
-            # read both inputs as 0/1
-            x = din.value() | b1.value()
-            y = (1 if ain.read_voltage() > AIN_VOLTAGE_CUTOFF else 0) | b2.value()
+            # set the output voltages
+            cv1.value(self.x_and_y)
+            cv2.value(self.x_or_y)
+            cv3.value(self.x_xor_y)
+            cv4.value(self.x_nand_y)
+            cv5.value(self.x_nor_y)
+            cv6.value(self.x_xnor_y)
 
-            x_and_y = x & y
-            x_or_y = x | y
-            x_xor_y = x ^ y
-            x_nand_y = abs(x_and_y - 1) # bit of a hack to get the inverted values
-            x_nor_y = abs(x_or_y -1)    # ~ results in some -2 results, which we don't want
-            x_xnor_y = abs(x_xor_y -1)  # so some simple int math will suffice
-
-            cv1.value(x_and_y)
-            cv2.value(x_or_y)
-            cv3.value(x_xor_y)
-            cv4.value(x_nand_y)
-            cv5.value(x_nor_y)
-            cv6.value(x_xnor_y)
             display_txt = " &:{0}  |:{1}  ^:{2}\n!&:{3} !|:{4} !^:{5}".format(
-                x_and_y,
-                x_or_y,
-                x_xor_y,
-                x_nand_y,
-                x_nor_y,
-                x_xnor_y
+                self.x_and_y,
+                self.x_or_y,
+                self.x_xor_y,
+                self.x_nand_y,
+                self.x_nor_y,
+                self.x_xnor_y
             )
 
             ssoled.centre_text(display_txt)

--- a/software/contrib/logic.py
+++ b/software/contrib/logic.py
@@ -34,11 +34,13 @@ class Logic(EuroPiScript):
         self.x_xnor_y = 0
 
         self.din1 = din
-        self.din2 = AnalogReaderDigitalWrapper(ain, cb_rising = self.update_logic, cb_falling = self.update_logic)
+        self.din2 = AnalogReaderDigitalWrapper(ain)
 
         # connect ISRs
         self.din1.handler(self.update_logic)
         self.din1.handler_falling(self.update_logic)
+        self.din2.handler(self.update_logic)
+        self.din2.handler_falling(self.update_logic)
         b1.handler(self.button_state_change)
         b1.handler_falling(self.button_state_change)
         b2.handler(self.button_state_change)

--- a/software/firmware/experimental/a_to_d.py
+++ b/software/firmware/experimental/a_to_d.py
@@ -68,3 +68,15 @@ class AnalogReaderDigitalWrapper:
 
     def last_falling_ms(self):
         return self.last_falling_time
+
+    def handler(self, func):
+        """Define the callback function to call when rising edge detected."""
+        if not callable(func):
+            raise ValueError("Provided handler func is not callable")
+        self.cb_rising = func
+
+    def handler_falling(self, func):
+        """Define the callback function to call when falling edge detected."""
+        if not callable(func):
+            raise ValueError("Provided handler func is not callable")
+        self.cb_falling = func


### PR DESCRIPTION
Streamlines the `Logic` script implementation to take advantage of newer `experimental` components. Adds support for using the buttons as inputs as well.