### PR TITLE
Add a visualizer to Pam's Workout

### DIFF
--- a/software/contrib/pams.md
+++ b/software/contrib/pams.md
@@ -79,6 +79,8 @@ CV2 to 6
 AIN
  +-- Gain
  |    +-- Precision
+ |
+Visualization
 ```
 
 `*` These settings can be automatically selected using voltage coming into `ain`.
@@ -87,6 +89,8 @@ AIN
 
 Some settings (e.g. ADSR envelope parameters, quantization root) are hidden from the menu if they would be ignored
 by the current configuration for that channel.
+
+The vizualization does not have any submenu items and simply displays the voltages of `CV1`-`6`, `AIN`, and `K1`.
 
 ## Main Clock Options
 

--- a/software/contrib/pams.py
+++ b/software/contrib/pams.py
@@ -1313,8 +1313,8 @@ class Visualizer(MenuItem):
         BAR_SEPARATION = 1
         y = 0
         w = 0
-        for ch in self.pams.channels:
-            w = max(1, int(ch.out_volts / MAX_OUTPUT_VOLTAGE * OLED_WIDTH))
+        for cv in cvs:
+            w = max(1, int(cv.voltage() / MAX_OUTPUT_VOLTAGE * OLED_WIDTH))
             oled.fill_rect(0, y, w, BAR_HEIGHT, 1)
             y += BAR_HEIGHT + BAR_SEPARATION
 
@@ -1323,10 +1323,12 @@ class Visualizer(MenuItem):
             oled.fill_rect(0, y, w, BAR_HEIGHT, 1)
             y += BAR_HEIGHT + BAR_SEPARATION
 
-        if din.value():
-            w = OLED_WIDTH
-        else:
-            w = 1
+        # put verical bars at the quarters
+        oled.line(0, 0, 0, OLED_HEIGHT, 1)
+        oled.line(OLED_WIDTH // 4, 0, OLED_WIDTH // 4, OLED_HEIGHT, 1)
+        oled.line(OLED_WIDTH // 2, 0, OLED_WIDTH // 2, OLED_HEIGHT, 1)
+        oled.line(3 * OLED_WIDTH // 4, 0, 3 * OLED_WIDTH // 4, OLED_HEIGHT, 1)
+        oled.line(OLED_WIDTH - 1, 0, OLED_WIDTH - 1, OLED_HEIGHT, 1)
 
 
 class PamsWorkout2(EuroPiScript):

--- a/software/firmware/europi.py
+++ b/software/firmware/europi.py
@@ -536,15 +536,25 @@ class Output:
         self._duty = cycle
 
     def voltage(self, voltage=None):
-        """Set the output voltage to the provided value within the range of 0 to 10."""
+        """
+        Set the output voltage to the provided value within the range of MIN_VOLTAGE to MAX_VOLTAGE
+
+        By default this range is 0-10, but can be overridden via the configuration file
+
+        @param voltage  The desired volts to send to the output. If None the current voltage is returned
+        """
         if voltage is None:
-            return self._duty / MAX_UINT16
+            return self._duty / MAX_UINT16 * self.MAX_VOLTAGE
         voltage = clamp(voltage, self.MIN_VOLTAGE, self.MAX_VOLTAGE)
         index = int(voltage // 1)
         self._set_duty(self._calibration_values[index] + (self._gradients[index] * (voltage % 1)))
 
     def on(self):
-        """Set the voltage HIGH at 5 volts."""
+        """
+        Set the voltage HIGH according to the gate voltage
+
+        By default this is 5V, but can be overridden via the configuration file
+        """
         self.voltage(self.gate_voltage)
 
     def off(self):
@@ -559,8 +569,12 @@ class Output:
             self.on()
 
     def value(self, value):
-        """Sets the output to 0V or 5V based on a binary input, 0 or 1."""
-        if value == HIGH:
+        """
+        Sets the output to 0V or 5V based on a binary input, 0 or 1.
+
+        @param value  HIGH or LOW, according to the desired state.
+        """
+        if value:  # silently allow booleans too!
             self.on()
         else:
             self.off()


### PR DESCRIPTION
Currently just a basic bar graph showing channels 1-6 + K1 + AIN states.  The Play/Pause indicator overlaps with the top few channels, but I rarely have 10V outputs, so usually these bars are only 50%.

I'm torn between an oscilloscope-style rolling graph vs this current-state visualization. Neither is honestly _that_ useful, so I may just close this.

If anyone uses this and has feedback, please leave me a note either here on on Discord!