### PR TITLE
Add DFAM controller

### DIFF
--- a/software/contrib/README.md
+++ b/software/contrib/README.md
@@ -100,6 +100,16 @@ A loopable random gate sequencer based on a binary tree.  Inspired by the Robaux
 <i>Author: [chrisib](https://github.com/chrisib)</i>
 <br><i>Labels: sequencer, gates, triggers, randomness</i>
 
+### DFAM Controller \[ [documentation](/software/contrib/dfam.md) | [script](/software/contrib/dfam.md) \]
+
+A trigger sequencer designed to interact with the [Moog DFAM](https://www.moogmusic.com/products/dfam-drummer-another-mother).
+Allows DFAM to play sequences of different lengths and adds a reset button & patch point.
+
+Inspired by the [Sonoclast MAFD](https://sonoclast.com/products/mafd/).
+
+<i>Author: [chrisib](https://github.com/chrisib)</i>
+<br><i>Labels: trigger, dfam</i>
+
 ### Egressus Melodium \[ [documentation](/software/contrib/egressus_melodiam.md) | [script](/software/contrib/egressus_melodiam.py) \]
 
 Clockable and free-running LFO and random CV pattern generator

--- a/software/contrib/dfam.md
+++ b/software/contrib/dfam.md
@@ -34,3 +34,12 @@ Patch EuroPi and DFAM as described above.
 Manually advance DFAM so the last sequence LED is
 illuminated. Then start DFAM by pressing the Start/Stop button. DFAM will now automatically
 advance every time a pulse is sent from `cv1` of EuroPi
+
+## A Note on DFAM's Sequencer
+
+When using DFAM Controller with a pattern length that is not 8, DFAM will skip steps
+between `length - 1` and `7`; this is to say, the last Velocity and Pitch knobs on DFAM's
+sequencer will always control the last element of the sequence.
+
+For example, if you only want a 5-step sequence, you should set DFAM's 1, 2, 3, 4, and 8 knobs,
+not 1, 2, 3, 4, and 5.

--- a/software/contrib/dfam.md
+++ b/software/contrib/dfam.md
@@ -12,7 +12,7 @@ This program is intended to be used with the Moog DFAM semi-modular. It allows f
 | `b1`          | Manual advance button    |
 | `b2`          | Manual reset button      |
 | `k1`          | Pattern length selection |
-| `k2`          | Unused                   |
+| `k2`          | Step size selection      |
 | `cv1`         | Clock output             |
 | `cv2`         | End of sequence gate     |
 | `cv3`         | Unused                   |

--- a/software/contrib/dfam.md
+++ b/software/contrib/dfam.md
@@ -1,0 +1,36 @@
+# DFAM Controller
+
+This program is intended to be used with the Moog DFAM semi-modular. It allows for sequences less than
+8 steps long to be played and features a fast-reset button and reset input
+
+## I/O Mapping
+
+| I/O           | Usage
+|---------------|--------------------------|
+| `din`         | External clock signal    |
+| `ain`         | External reset signal    |
+| `b1`          | Manual advance button    |
+| `b2`          | Manual reset button      |
+| `k1`          | Pattern length selection |
+| `k2`          | Unused                   |
+| `cv1`         | Clock output             |
+| `cv2`         | End of sequence gate     |
+| `cv3`         | Unused                   |
+| `cv4`         | Unused                   |
+| `cv5`         | Unused                   |
+| `cv6`         | Unused                   |
+
+## Patching
+
+Connect your clock source or square LFO to `din` and connect `cv1` to DFAM's `ADV/CLOCK` input.
+
+Optionally, connect a reset source to `ain` to automatically reset EuroPi and DFAM (e.g. a clock-stop signal
+from [`Pam's Workout`](/software/contrib/pams.md)).
+
+## Preparing DFAM
+
+Patch EuroPi and DFAM as described above.
+
+Manually advance DFAM so the last sequence LED is
+illuminated. Then start DFAM by pressing the Start/Stop button. DFAM will now automatically
+advance every time a pulse is sent from `cv1` of EuroPi

--- a/software/contrib/dfam.py
+++ b/software/contrib/dfam.py
@@ -105,16 +105,31 @@ class DfamController(EuroPiScript):
                 self.advance_request = False
                 self.current_step += 1
                 if self.current_step >= self.max_steps:
+                    if self.max_steps == 1:
+                        self.advance()
+
                     end_of_sequence_output.on()
                     self.reset()
                 else:
+
                     end_of_sequence_output.off()
 
-                self.advance()
+                    self.advance()
 
             if render_needed:
                 render_needed = False
-                oled.centre_text(f"{self.current_step + 1}/{self.max_steps}\nx{self.step_size}")
+                oled.fill(0)
+                oled.centre_text(f"{self.current_step + 1}/{self.max_steps}\nx{self.step_size}\n", auto_show=False, clear_first=False)
+
+                for i in range(8):
+                    # the 0th LED is actually the last one, so the pattern should be shifted 1 to the left
+                    if i == (self.dfam_sync_counter - 1) % 8:
+                        fill = -1
+                    else:
+                        fill = 0
+                    oled.ellipse(i * OLED_WIDTH // 8 + 4, OLED_HEIGHT - 5, 4, 4, 1, fill)
+
+                oled.show()
 
 
 if __name__ == "__main__":

--- a/software/contrib/dfam.py
+++ b/software/contrib/dfam.py
@@ -14,7 +14,7 @@ end_of_sequence_output = cv2
 sequence_length_knob = k1
 
 
-class Dfam(EuroPiScript):
+class DfamController(EuroPiScript):
     def __init__(self):
         super().__init__()
 
@@ -77,3 +77,7 @@ class Dfam(EuroPiScript):
                 self.advance()
 
             oled.centre_text(f"{self.current_step + 1}/{self.max_steps}")
+
+
+if __name__ == "__main__":
+    DfamController().main()

--- a/software/contrib/dfam.py
+++ b/software/contrib/dfam.py
@@ -89,8 +89,10 @@ class DfamController(EuroPiScript):
     def request_advance(self):
         self.advance_request = True
 
-    def reset(self):
+    def reset(self, force_trigger=False):
         pulses = (DFAM_SEQUENCER_LENGTH - self.dfam_sync_counter) % DFAM_SEQUENCER_LENGTH
+        if force_trigger and pulses == 0:
+            pulses = DFAM_SEQUENCER_LENGTH
         self.current_step = 0
         self.dfam_sync_counter = 0
         for _ in range(pulses):
@@ -137,11 +139,9 @@ class DfamController(EuroPiScript):
                         self.advance()
 
                     end_of_sequence_output.on()
-                    self.reset()
+                    self.reset(force_trigger=True)
                 else:
-
                     end_of_sequence_output.off()
-
                     self.advance()
 
             if render_needed:

--- a/software/contrib/dfam.py
+++ b/software/contrib/dfam.py
@@ -51,7 +51,7 @@ class Dfam(EuroPiScript):
         while True:
             din2.update()
 
-            self.max_steps = int(k1.percent() * 8)
+            self.max_steps = max(int(k1.percent() * 8), 1)
 
             if self.reset_request:
                 self.reset_request = False

--- a/software/contrib/dfam.py
+++ b/software/contrib/dfam.py
@@ -1,0 +1,71 @@
+from europi import *
+from europi_script import EuroPiScript
+
+from experimental.a_to_d import AnalogReaderDigitalWrapper
+
+din1 = din
+din2 = AnalogReaderDigitalWrapper(ain)
+
+class Dfam(EuroPiScript):
+    def __init__(self):
+        super().__init__()
+
+        self.reset_request = False
+        self.advance_request = False
+
+        # the current step of the sequence, [0, max_steps)
+        # this is the NEXT step in DFAM's sequencer, so if the last LED
+        # is lit up, current_step is 0
+        self.current_step = 0
+
+        # the maximum number of steps in the sequence
+        self.max_steps = 8
+
+        b1.handler(self.request_advance)
+        din1.handler(self.request_advance)
+
+        b2.handler(self.request_reset)
+        din2.handler(self.request_reset)
+
+    def request_reset(self):
+        self.reset_request = True
+
+    def request_advance(self):
+        self.advance_request = True
+
+    def reset(self):
+        pulses = (8 - self.current_step) % 8
+        self.current_step = 0
+        for i in range(pulses):
+            cv1.on()
+            time.sleep(0.0001)
+            cv1.off()
+            time.sleep(0.0001)
+
+    def advance(self):
+        cv1.on()
+        time.sleep(0.0001)
+        cv1.off()
+
+    def main(self):
+        while True:
+            din2.update()
+
+            self.max_steps = int(k1.percent() * 8)
+
+            if self.reset_request:
+                self.reset_request = False
+                self.reset()
+
+            if self.advance_request:
+                self.advance_request = False
+                self.current_step = (self.current_step + 1) % 8
+                if self.current_step >= self.max_steps:
+                    cv2.on()
+                    self.reset()
+                else:
+                    cv2.off()
+
+                self.advance()
+
+            oled.centre_text(f"{self.current_step + 1}/{self.max_steps}")

--- a/software/contrib/dfam.py
+++ b/software/contrib/dfam.py
@@ -1,3 +1,16 @@
+# Copyright 2025 Allen Synthesis
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from europi import *
 from europi_script import EuroPiScript
 
@@ -56,16 +69,23 @@ class DfamController(EuroPiScript):
         advance_output.off()
 
     def main(self):
+        render_needed = True
+
         while True:
             reset_input.update()  # a-to-d wrapper, so we need to poll it!
 
-            self.max_steps = max(int(sequence_length_knob.percent() * 15), 1)
+            new_steps = max(int(sequence_length_knob.percent() * 15), 1)
+            if new_steps != self.max_steps:
+                render_needed = True
+                self.max_steps = new_steps
 
             if self.reset_request:
+                render_needed = True
                 self.reset_request = False
                 self.reset()
 
             if self.advance_request:
+                render_needed = True
                 self.advance_request = False
                 self.current_step += 1
                 if self.current_step >= self.max_steps:
@@ -76,7 +96,9 @@ class DfamController(EuroPiScript):
 
                 self.advance()
 
-            oled.centre_text(f"{self.current_step + 1}/{self.max_steps}")
+            if render_needed:
+                render_needed = False
+                oled.centre_text(f"{self.current_step + 1}/{self.max_steps}")
 
 
 if __name__ == "__main__":

--- a/software/contrib/menu.py
+++ b/software/contrib/menu.py
@@ -45,6 +45,7 @@ EUROPI_SCRIPTS = OrderedDict([
     ["CVecorder",         "contrib.cvecorder.CVecorder"],
     ["Daily Random",      "contrib.daily_random.DailyRandom"],
     ["DCSN-2",            "contrib.dscn2.Dcsn2"],
+    ["DFAM Controller",   "contrib.dfam.DfamController"],
     ["EgressusMelodiam",  "contrib.egressus_melodiam.EgressusMelodiam"],
     ["EnvelopeGen",       "contrib.envelope_generator.EnvelopeGenerator"],
     ["Euclid",            "contrib.euclid.EuclideanRhythms"],


### PR DESCRIPTION
Adds a new script inspired by the Midi Adapter For DFAM (MAFD). Allows a DFAM-user to play sequences that aren't limited to 8 steps, a reset button, a patchable reset input and an advance button that can be used while the module is playing.