### PR TITLE
Try creating `main.py` as part of `europi_contrib` package

### DIFF
--- a/software/main.py
+++ b/software/main.py
@@ -1,0 +1,18 @@
+# Copyright 2025 Allen Synthesis
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import gc
+from contrib.menu import *
+
+gc.collect()
+BootloaderMenu(EUROPI_SCRIPTS).main()

--- a/software/setup.py
+++ b/software/setup.py
@@ -26,6 +26,9 @@ setup(
     author_email="contact@allensynthesis.co.uk",
     license="Apache 2.0",
     packages=["contrib"],
+    data_files=[
+        ('/', ['main.py'])
+    ],
     py_modules=["firmware.version"],
     namespace_packages=["contrib"],
 )

--- a/software/setup.py
+++ b/software/setup.py
@@ -26,9 +26,7 @@ setup(
     author_email="contact@allensynthesis.co.uk",
     license="Apache 2.0",
     packages=["contrib"],
-    data_files=[
-        ('/', ['main.py'])
-    ],
+    data_files=[("/", ["main.py"])],
     py_modules=["firmware.version"],
     namespace_packages=["contrib"],
 )


### PR DESCRIPTION
I _think_ we should be able to automatically install `main.py` to the root folder using the `data_files` field of `setuptools.setup`; I've never tried this before, but it's probably worth a shot.