### PR TITLE
Use Sphinx-style docstrings

### DIFF
--- a/software/firmware/bootloader.py
+++ b/software/firmware/bootloader.py
@@ -68,8 +68,8 @@ class BootloaderMenu(EuroPiScript):
     def __init__(self, scripts):
         """Create the bootloader menu
 
-        @param scripts  Dictionary where the keys are the display names of the classes to include in the menu and the
-                        values are the fully-qualified names of the EuroPiScript classes that we launch
+        :param scripts:  Dictionary where the keys are the display names of the classes to include in the menu and the
+            values are the fully-qualified names of the EuroPiScript classes that we launch
         """
         self.scripts = scripts
         self.run_request = None
@@ -99,9 +99,9 @@ class BootloaderMenu(EuroPiScript):
     def show_error(cls, title, message, duration=1):
         """Show a brief error message on-screen saying we can't launch the requested script
 
-        @param title    The title of the error
-        @param message  The body of the error message
-        @param duration The number of seconds the message should show. If negative the message is shown forever
+        :param title:    The title of the error
+        :param message:  The body of the error message
+        :param duration: The number of seconds the message should show. If negative the message is shown forever
         """
         oled.centre_text(f"--{title}--\n{message}")
 
@@ -127,7 +127,7 @@ class BootloaderMenu(EuroPiScript):
 
         If the class is not a valid EuroPiScript an error message is shown and selection continues
 
-        @return The type corresponding to self.run_request as set by the self.launch callback
+        :return: The type corresponding to self.run_request as set by the self.launch callback
         """
         self.menu = Menu(
             items=list(sorted(self.scripts.keys())),

--- a/software/firmware/configuration.py
+++ b/software/firmware/configuration.py
@@ -275,7 +275,7 @@ class ConfigSpec:
     def __iter__(self):
         return iter(self.points.values())
 
-    def default_config(self) -> dict:
+    def default_config(self) -> dict[str, Any]:
         """Returns the default configuration for this spec."""
         return {point.name: point.default for point in self.points.values()}
 
@@ -302,8 +302,8 @@ class ConfigFile:
         """
         Load the configuration settings from an arbitrary file
 
-        @param path  The path to the fole to read
-        @param config_spec  The specification of the configuration we're saving
+        :param path:  The path to the fole to read
+        :param config_spec:  The specification of the configuration we're saving
         """
         if len(config_spec):
             saved_config = load_json_file(path)
@@ -327,8 +327,8 @@ class ConfigFile:
         intend to save to a directory that may not exist, make sure to create it
         first.
 
-        @param path  The path to the file we're saving to
-        @param dict  The data to save
+        :param path:  The path to the file we're saving to
+        :param dict:  The data to save
         """
         with open(path, "w") as file:
             # put newlines between items to make the resulting file easier to read
@@ -378,7 +378,7 @@ class ConfigSettings:
     def __init__(self, d):
         """Constructor
 
-        @param d  The raw dict loaded from the configuration file
+        :param d:  The raw dict loaded from the configuration file
         """
         self.__dict__ = {}  # required for getattr & setattr
         self.__keys__ = set()
@@ -391,11 +391,12 @@ class ConfigSettings:
     def validate_key(self, key):
         """Ensures that a `dict` key is a valid attribute name
 
-        @param key  The string to check
-        @return     True if the key is valid. Otherwise an exception is raised
+        :param key:  The string to check
 
-        @exception  ValueError if the key contains invalid characters; only letters, numbers, hyphens, and underscores
-                    are permitted. They key cannot be length 0, nor can it begin with a number
+        :return:     True if the key is valid. Otherwise an exception is raised
+
+        :raises ValueError: if the key contains invalid characters; only letters, numbers, hyphens, and underscores
+            are permitted. They key cannot be length 0, nor can it begin with a number
         """
         key = key.strip()
         for ch in key:
@@ -420,9 +421,9 @@ class ConfigSettings:
     def __eq__(self, that):
         """Allows comparing the config object directly to either another config object or a dict
 
-        @param that  The object we're comparing to, either a dict or another ConfigSettings object
+        :param that:  The object we're comparing to, either a dict or another ConfigSettings object
 
-        @return True if the two objects are equivalent, otherwise False
+        :return True: if the two objects are equivalent, otherwise False
         """
         if type(that) is dict:
             try:

--- a/software/firmware/configuration.py
+++ b/software/firmware/configuration.py
@@ -275,7 +275,7 @@ class ConfigSpec:
     def __iter__(self):
         return iter(self.points.values())
 
-    def default_config(self) -> dict[str, Any]:
+    def default_config(self) -> dict[str, object]:
         """Returns the default configuration for this spec."""
         return {point.name: point.default for point in self.points.values()}
 

--- a/software/firmware/europi_display.py
+++ b/software/firmware/europi_display.py
@@ -63,7 +63,7 @@ class Display(SSD1306_I2C):
     def rotate(self, rotate):
         """Flip the screen from its default orientation
 
-        @param rotate  True or False, indicating whether we want to flip the screen from its default orientation
+        :param rotate:  True or False, indicating whether we want to flip the screen from its default orientation
         """
         # From a hardware perspective, the default screen orientation of the display _is_ rotated
         # But logically we treat this as right-way-up.
@@ -77,9 +77,9 @@ class Display(SSD1306_I2C):
     def centre_text(self, text, clear_first=True, auto_show=True):
         """Display one or more lines of text centred both horizontally and vertically.
 
-        @param text  The text to display
-        @param clear_first  If true, the screen buffer is cleared before rendering the text
-        @param auto_show  If true, oled.show() is called after rendering the text. If false, you must call oled.show() yourself
+        :param text:  The text to display
+        :param clear_first:  If true, the screen buffer is cleared before rendering the text
+        :param auto_show:  If true, oled.show() is called after rendering the text. If false, you must call oled.show() yourself
         """
         if clear_first:
             self.fill(0)

--- a/software/firmware/europi_hardware.py
+++ b/software/firmware/europi_hardware.py
@@ -111,9 +111,9 @@ def clamp(value: int | float, low: int | float, high: int | float):
     """
     Returns a value that is no lower than 'low' and no higher than 'high'.
 
-    @param value  The value to clamp
-    @param low  The inclusive lower bound
-    @param high  The inclusive upper bound
+    :param value:  The value to clamp
+    :param low:  The inclusive lower bound
+    :param high:  The inclusive upper bound
     """
     return max(min(value, high), low)
 
@@ -388,6 +388,8 @@ class DigitalInput(DigitalReader):
     Here is another example how you can write digital input handlers to react
     to a clock source and match its trigger duration.::
 
+    .. code-block:: python
+
         @din.handler
         def gate_on():
             # Trigger outputs with a probability set by knobs.
@@ -494,7 +496,7 @@ class Output:
 
         By default this range is 0-10, but can be overridden via the configuration file
 
-        @param voltage  The desired volts to send to the output. If None the current voltage is returned
+        :param voltage:  The desired volts to send to the output. If None the current voltage is returned
         """
         if voltage is None:
             return self._duty / MAX_UINT16 * self.MAX_VOLTAGE
@@ -525,7 +527,7 @@ class Output:
         """
         Sets the output to 0V or 5V based on a binary input, 0 or 1.
 
-        @param value  HIGH or LOW, according to the desired state.
+        :param value:  HIGH or LOW, according to the desired state.
         """
         if value:  # silently allow booleans too!
             self.on()
@@ -558,7 +560,7 @@ class Thermometer:
         """
         Read the ADC and return the current temperature
 
-        @return  The current temperature in Celsius, or None if the hardware did not initialze properly
+        :return:  The current temperature in Celsius, or None if the hardware did not initialze properly
         """
         if self.pin:
             # See the Pico's datasheet for the details of this calculation

--- a/software/firmware/europi_script.py
+++ b/software/firmware/europi_script.py
@@ -75,6 +75,8 @@ class EuroPiScript:
 
     Here is an extension of the script above with some added trivial features that incorporate saving and loading script state::
 
+    .. code-block:: python
+
         from europi import oled
         from europi_script import EuroPiScript
 

--- a/software/firmware/experimental/a_to_d.py
+++ b/software/firmware/experimental/a_to_d.py
@@ -30,12 +30,11 @@ class AnalogReaderDigitalWrapper:
     ):
         """Constructor
 
-        @param ain  The AnalogReader we're wrapping
-        @param debounce  The number of consecutive high/low signals needed to flip the digital state
-        @param high_low_cutoff  The threshold at which the analog signal is considered high
-
-        @param cb_rising  A function to call on the rising edge of the signal
-        @param cb_falling  A function to call on the falling edge of the signal
+        :param ain:  The AnalogReader we're wrapping
+        :param debounce:  The number of consecutive high/low signals needed to flip the digital state
+        :param high_low_cutoff:  The threshold at which the analog signal is considered high
+        :param cb_rising:  A function to call on the rising edge of the signal
+        :param cb_falling:  A function to call on the falling edge of the signal
         """
         self.ain = ain
         self.debounce = debounce

--- a/software/firmware/experimental/bitarray.py
+++ b/software/firmware/experimental/bitarray.py
@@ -21,14 +21,14 @@ easier bit-level access.
 
 
 def make_bit_array(length):
-    """Create a bit array that contains at least @length bits
+    """Create a bit array that contains at least length bits
 
     The resulting byte array will have a length rounded up to the
-    next byte if @length is not divisible by 8
+    next byte if length is not divisible by 8
 
-    @param length  The number of bits in the array
+    :param length:  The number of bits in the array
 
-    @return A bytearray containing at least @length bits
+    :return: A bytearray containing at least @length bits
     """
     # Use bitwise operations instead of integer division and modulo operations to keep things fast
     if length & 0x07:
@@ -44,10 +44,10 @@ def get_bit(arr, index):
     Bytes are stored most significant bit first, so the 8th bit of [1] comes immediately after
     the first bit of `[0]`: `[ B0b7 B0b6 B0b5 B0b4 B0b3 B0b2 B0b1 B0b0 B1b7 B1b6 ... ]`
 
-    @param arr    The bytearray to operate on
-    @param index  The bit index to retrieve
+    :param arr:    The bytearray to operate on
+    :param index:  The bit index to retrieve
 
-    @return 0 or 1, depending on the state at position @index
+    :return: 0 or 1, depending on the state at position index
     """
     # Use bitwise operations instead of integer division and modulo operations to keep things fast
     byte = arr[index >> 3]
@@ -62,9 +62,9 @@ def set_bit(arr, index, value):
     Bytes are stored most significant bit first, so the 8th bit of [1] comes immediately after
     the first bit of `[0]`: `[ B0b7 B0b6 B0b5 B0b4 B0b3 B0b2 B0b1 B0b0 B1b7 B1b6 ... ]`
 
-    @param arr    The bytearray to operate on
-    @param index  The bit position within the array
-    @param value  A truthy value indicating whether the bit should be set to 1 or 0
+    :param arr:    The bytearray to operate on
+    :param index:  The bit position within the array
+    :param value:  A truthy value indicating whether the bit should be set to 1 or 0
     """
     # Use bitwise operations instead of integer division and modulo operations to keep things fast
     byte = arr[index >> 3]
@@ -79,8 +79,8 @@ def set_bit(arr, index, value):
 def set_all_bits(arr, value=0):
     """Set all bits in the array to the same value
 
-    @param arr    The bytearray to reset
-    @param value  A truthy value indicating whether all bits should be set to 0 or 1
+    :param arr:    The bytearray to reset
+    :param value:  A truthy value indicating whether all bits should be set to 0 or 1
     """
     for i in range(len(arr)):
         if value:

--- a/software/firmware/experimental/clocks/clock_source.py
+++ b/software/firmware/experimental/clocks/clock_source.py
@@ -73,7 +73,7 @@ class ExternalClockSource:
 
         see: https://docs.micropython.org/en/latest/library/time.html#time.localtime
 
-        @return a tuple of the form (0-year, 1-month, 2-day, 3-hour, 4-minutes, 5-seconds, 6-weekday, 7-yearday)
+        :return: a tuple of the form (0-year, 1-month, 2-day, 3-hour, 4-minutes, 5-seconds, 6-weekday, 7-yearday)
         """
         raise NotImplementedError()
 
@@ -86,7 +86,7 @@ class ExternalClockSource:
 
         see: https://docs.micropython.org/en/latest/library/time.html#time.localtime
 
-        @param datetime  A tuple of the form (0-year, 1-month, 2-day, 3-hour, 4-minutes, 5-seconds, 6-weekday, 7-yearday)
+        :param datetime:  A tuple of the form (0-year, 1-month, 2-day, 3-hour, 4-minutes, 5-seconds, 6-weekday, 7-yearday)
         """
         raise NotImplementedError()
 
@@ -94,7 +94,7 @@ class ExternalClockSource:
         """
         Determine if the datetime's year is a leap year or not.
 
-        @return  True if the datetime is a leap year, otherwise False
+        :return:  True if the datetime is a leap year, otherwise False
         """
         # a year is a leap year if it is divisible by 4
         # but NOT a multple of 100, unless it's also a multiple of 400
@@ -105,7 +105,7 @@ class ExternalClockSource:
         """
         Determine the number of days in the datetime's year.
 
-        @return  The number of days in the year, taking leap years into account
+        :return:  The number of days in the year, taking leap years into account
         """
         if self.is_leap_year(datetime):
             return 366
@@ -117,7 +117,7 @@ class ExternalClockSource:
 
         This takes leap-years into consideration
 
-        @return  The number of days in the datetime's month
+        :return:  The number of days in the datetime's month
         """
         if datetime[self.MONTH] == 2 and self.is_leap_year(datetime):
             return 29
@@ -127,9 +127,9 @@ class ExternalClockSource:
         """
         Check if a datetime contains valid values.
 
-        Raises a ValueError if any field is out of range
+        :raises ValueError: if any field is out of range
 
-        @param datetime
+        :param datetime:  The datetime tuple to validate
         """
         # fmt: off
         n_days = self.month_length(datetime)

--- a/software/firmware/experimental/clocks/ds1307.py
+++ b/software/firmware/experimental/clocks/ds1307.py
@@ -71,7 +71,7 @@ class DS1307(ExternalClockSource):
         """
         Get the current time.
 
-        @return a tuple of the form (0-year, 1-month, 2-day, 3-hour, 4-minutes, 5-seconds, 6-weekday, 7-yearday)
+        :return: a tuple of the form (0-year, 1-month, 2-day, 3-hour, 4-minutes, 5-seconds, 6-weekday, 7-yearday)
         """
         buf = self.i2c.readfrom_mem(self.addr, DATETIME_REG, 7)
         # fmt: off
@@ -91,7 +91,7 @@ class DS1307(ExternalClockSource):
         """
         Set the current time.
 
-        @param datetime : tuple of the form (0-year, 1-month, 2-day, 3-hour, 4-minutes, 5-seconds, 6-weekday, 7-yearday)
+        :param datetime: tuple of the form (0-year, 1-month, 2-day, 3-hour, 4-minutes, 5-seconds, 6-weekday, 7-yearday)
         """
         self.check_valid_datetime(datetime)
 

--- a/software/firmware/experimental/clocks/ds3231.py
+++ b/software/firmware/experimental/clocks/ds3231.py
@@ -37,10 +37,11 @@ the clock.  To do so:
 3. Open Thonny and make sure experimental_config is configured to use the DS3231. If you make any changes to experimental_config, restart the Raspberry Pi Pico before proceeding.
 4. In Thonny's Python terminal, run the following code:
 
-```
->>> from experimental.rtc import clock
->>> clock.source.set_datetime((2025, 6, 14, 22, 59, 0, 6, 0))
-```
+.. code-block::
+
+    >>> from experimental.rtc import clock
+    >>> clock.source.set_datetime((2025, 6, 14, 22, 59, 0, 6, 0))
+
 
 This will set the clock to 14 June 2025, 22:59:00, and set the weekday to Saturday (6).
 The tuple is of the form (Year, Month, Day, Hour, Minute, Second, Weekday, Yearday). It is recommended
@@ -125,7 +126,8 @@ class DS3231(ExternalClockSource):
         Get the current time.
 
         Returns in 24h format, converts to 24h if clock is set to 12h format
-        @return a tuple of the form (0-year, 1-month, 2-day, 3-hour, 4-minutes, 5-seconds, 6-weekday, 7-yearday)
+
+        :return: a tuple of the form (0-year, 1-month, 2-day, 3-hour, 4-minutes, 5-seconds, 6-weekday, 7-yearday)
         """
         self.i2c.readfrom_mem_into(self.addr, DATETIME_REG, self._timebuf)
         # 0x00 - Seconds    BCD
@@ -171,7 +173,7 @@ class DS3231(ExternalClockSource):
         """
         Set the current time.
 
-        @param datetime : tuple of the form (0-year, 1-month, 2-day, 3-hour, 4-minutes, 5-seconds, 6-weekday, 7-yearday)
+        :param datetime: tuple of the form (0-year, 1-month, 2-day, 3-hour, 4-minutes, 5-seconds, 6-weekday, 7-yearday)
         """
         self.check_valid_datetime(datetime)
 
@@ -201,13 +203,13 @@ class DS3231(ExternalClockSource):
         The alarm interrupts are disabled when enabling a square wave output. Disabling SWQ out does
         not enable the alarm interrupts. Set them manually with the alarm_int() method.
 
-        freq : int,
-        * None: returns current setting
-        * False = disable SQW output,
-        * 1 =     1 Hz,
-        * 2 = 1.024 kHz,
-        * 3 = 4.096 kHz,
-        * 4 = 8.192 kHz
+        :param freq: specify the frequency:
+            * None: returns current setting
+            * False = disable SQW output,
+            * 1 =     1 Hz,
+            * 2 = 1.024 kHz,
+            * 3 = 4.096 kHz,
+            * 4 = 8.192 kHz
         """
         # fmt: off
         if freq is None:
@@ -228,10 +230,10 @@ class DS3231(ExternalClockSource):
     def alarm1(self, time=None, match=AL1_MATCH_DHMS, int_en=True, weekday=False):
         """Set alarm1, can match mday, wday, hour, minute, second
 
-        time    : tuple, (second,[ minute[, hour[, day]]])
-        weekday : bool, select mday (False) or wday (True)
-        match   : int, match const
-        int_en  : bool, enable interrupt on alarm match on SQW/INT pin (disables SQW output)"""
+        :param time: tuple, (second,[ minute[, hour[, day]]])
+        :param weekday: bool, select mday (False) or wday (True)
+        :param match: int, match const
+        :param int_en: bool, enable interrupt on alarm match on SQW/INT pin (disables SQW output)"""
         if time is None:
             # TODO Return readable string
             self.i2c.readfrom_mem_into(self.addr, ALARM1_REG, self._al1_buf)
@@ -267,11 +269,11 @@ class DS3231(ExternalClockSource):
     def alarm2(self, time=None, match=AL2_MATCH_DHM, int_en=True, weekday=False):
         """Get/set alarm 2 (can match minute, hour, day)
 
-        time    : tuple, (minute[, hour[, day]])
-        weekday : bool, select mday (False) or wday (True)
-        match   : int, match const
-        int_en  : bool, enable interrupt on alarm match on SQW/INT pin (disables SQW output)
-        Returns : bytearray(3), the alarm settings register"""
+        :param time: tuple, (minute[, hour[, day]])
+        :param weekday: bool, select mday (False) or wday (True)
+        :param match: int, match const
+        :param int_en: bool, enable interrupt on alarm match on SQW/INT pin (disables SQW output)
+        :return: bytearray(3), the alarm settings register"""
         if time is None:
             # TODO Return readable string
             self.i2c.readfrom_mem_into(self.addr, ALARM2_REG, self._al2buf)
@@ -305,9 +307,10 @@ class DS3231(ExternalClockSource):
         """Enable/disable interrupt for alarm1, alarm2 or both.
 
         Enabling the interrupts disables the SQW output
-        enable : bool, enable/disable interrupts
-        alarm : int, alarm nr (0 to set both interrupts)
-        returns: the control register"""
+
+        :param enable: bool, enable/disable interrupts
+        :param alarm: int, alarm nr (0 to set both interrupts)
+        :return: the control register"""
         # fmt: off
         if alarm in (0, 1):
             self.i2c.readfrom_mem_into(self.addr, CONTROL_REG, self._buf)

--- a/software/firmware/experimental/clocks/ntp.py
+++ b/software/firmware/experimental/clocks/ntp.py
@@ -66,6 +66,6 @@ class NtpClock(ExternalClockSource):
         """
         Get the latest time from our NTP source and return it
 
-        @return a tuple of the form tuple of the form (0-year, 1-month, 2-day, 3-hour, 4-minutes, 5-seconds, 6-weekday, 7-yearday)
+        :return: a tuple of the form tuple of the form (0-year, 1-month, 2-day, 3-hour, 4-minutes, 5-seconds, 6-weekday, 7-yearday)
         """
         return utime.gmtime()

--- a/software/firmware/experimental/euclid.py
+++ b/software/firmware/experimental/euclid.py
@@ -22,17 +22,17 @@ def generate_euclidean_pattern(steps, pulses, rot=0):
 
     Copied from https://github.com/brianhouse/bjorklund with all due gratitude
 
-    @param steps  The number of steps in the pattern
-    @param pulses The number of ON steps in the pattern (must be <= steps)
-    @param rot    Optional rotation to offset the pattern. Must be in the range [0, steps]
+    :param steps:  The number of steps in the pattern
+    :param pulses: The number of ON steps in the pattern (must be <= steps)
+    :param rot:    Optional rotation to offset the pattern. Must be in the range [0, steps]
 
-    @return An int array of length steps consisting of 1 and 0 values only
+    :return: An int array of length steps consisting of 1 and 0 values only
 
-    @exception ValueError if pulses or rot is out of range
+    :raises ValueError: if pulses or rot is out of range
 
-    @author Brian House
-    @year 2011
-    @license MIT
+    :author: Brian House
+    :year: 2011
+    :license: MIT
     """
     steps = int(steps)
     pulses = int(pulses)

--- a/software/firmware/experimental/http_server.py
+++ b/software/firmware/experimental/http_server.py
@@ -168,7 +168,8 @@ class HttpServer:
 
         After creating the HTTP server, you should assign a handler function to process requests:
 
-        ```python
+        .. code-block::python
+
             srv = HttpServer(8080)
             @srv.request_handler
             def handle_http_request(connection=None, request=None):
@@ -183,34 +184,33 @@ class HttpServer:
                     HttpStatus.OK,
                     MimeTypes.HTML,
                 )
-        ```
+
         Response can be an HTTP page, plain text, or JSON/CSV/YAML/XML formatted data. See
         MimeTypes for supported types. The response should always be a string; if sending
         a dict as JSON data you'll need to stringify it before passing it to send_response.
 
         You may send your own error codes as desired:
-        ```python
+
+        .. code-block:: python
             def handle_http_request(connection=None, request=None):
                 srv.send_error_page(
                     Exception("We're out of coffee!")
                     connection,
                     HttpStatus.TEAPOT,  # send error 418 "I'm a teapot"
                 )
-        ```
 
         Inside the program's main loop you should call srv.check_connections() to process any
         incoming requests:
 
-        ```python
+        .. code-block:: python
             def main(self):
                 # ...
                 while True:
                     # ...
                     srv.check_requests()
                     # ...
-        ```
 
-        @param port  The port to listen on
+        :param port:  The port to listen on
         """
         self.port = port
         self.get_callback = self.default_request_handler
@@ -232,8 +232,8 @@ class HttpServer:
         to replace this function. So all we do is raise a NotImplementedError that's handled
         by self.check_requests() and will serve our HTTP 501 error page accordingly.
 
-        @param connection  The socket the client connected on
-        @param request  The client's request
+        :param connection:  The socket the client connected on
+        :param request:  The client's request
         """
         raise NotImplementedError("No request handler set")
 
@@ -306,7 +306,7 @@ class HttpServer:
         - request: str  The request the client sent
         - conn: socket  A socket connection to the client
 
-        @param func  The function to handle the request.
+        :param func:  The function to handle the request.
         """
 
         def wrapper(*args, **kwargs):
@@ -323,7 +323,7 @@ class HttpServer:
         - request: str  The request the client sent
         - conn: socket  A socket connection to the client
 
-        @param func  The function to handle the request.
+        :param func:  The function to handle the request.
         """
 
         def wrapper(*args, **kwargs):
@@ -342,10 +342,10 @@ class HttpServer:
         """
         Serve our customized HTTP error page
 
-        @param error  The exception that caused the error
-        @param connection  The socket to send the response over
-        @param status  The error status to respond with
-        @param headers  Optional additional headers
+        :param error:  The exception that caused the error
+        :param connection:  The socket to send the response over
+        :param status:  The error status to respond with
+        :param headers:  Optional additional headers
         """
         self.send_html(
             connection,
@@ -362,9 +362,9 @@ class HttpServer:
         """
         Send a JSON object to the client
 
-        @param connection  The socket connection to the client
-        @param data  A dict to be converted to a JSON object
-        @param headers  Optional additional HTTP headers to include
+        :param connection:  The socket connection to the client
+        :param data:  A dict to be converted to a JSON object
+        :param headers:  Optional additional HTTP headers to include
         """
         self.send_response(
             connection,
@@ -378,10 +378,10 @@ class HttpServer:
         """
         Send an HTML document to the client
 
-        @param connection  The socket to send the data over
-        @param html_page  A string containing the HTML document.
-        @param status  The HTTP status to send the page with
-        @param headers  Optional additional HTTP headers
+        :param connection:  The socket to send the data over
+        :param html_page:  A string containing the HTML document.
+        :param status:  The HTTP status to send the page with
+        :param headers:  Optional additional HTTP headers
         """
         self.send_response(
             connection, html_page, content_type=MimeTypes.HTML, status=status, headers=headers
@@ -398,11 +398,11 @@ class HttpServer:
         """
         Send a response to the client
 
-        @param connection  The socket connection to the client
-        @param response  The response payload
-        @param status  The HTTP status to respond with
-        @param content_type  The MIME type to include in the HTTP header
-        @param headers  Optional dict of key/value pairs for addtional HTTP headers. Charset is ALWAYS utf-8
+        :param connection:  The socket connection to the client
+        :param response:  The response payload
+        :param status:  The HTTP status to respond with
+        :param content_type:  The MIME type to include in the HTTP header
+        :param headers:  Optional dict of key/value pairs for addtional HTTP headers. Charset is ALWAYS utf-8
         """
         header = f"HTTP/1.0 {status} {HttpStatus.StatusText[status]}\r\nContent-type: {content_type}\r\ncharset=utf-8"
 

--- a/software/firmware/experimental/knobs.py
+++ b/software/firmware/experimental/knobs.py
@@ -100,7 +100,7 @@ class LockableKnob(Knob):
     def change_lock_value(self, percent=0.0):
         """Change the current value to reflect a desired percentage
 
-        @param percent  The 0-1 value we want to re-lock the knob at
+        :param percent:  The 0-1 value we want to re-lock the knob at
         """
         self.value = int(MAX_UINT16 * (1.0 - percent))
 
@@ -215,7 +215,7 @@ class KnobBank:
     def set_current(self, name):
         """Set the currently-unlocked knob to the one whose name matches the argument
 
-        @param name  The name of the knob to set as the current one
+        :param name:  The name of the knob to set as the current one
         """
         try:
             index = self.names.index(name)
@@ -229,7 +229,7 @@ class KnobBank:
     def __getitem__(self, name):
         """Get the LockableKnob in this bank with the given name
 
-        @param name  The name of the knob to return, or None if the name isn't found
+        :param name:  The name of the knob to return, or None if the name isn't found
         """
         try:
             index = self.names.index(name)
@@ -369,18 +369,13 @@ class BufferedKnob(Knob):
     def __init__(self, knob):
         """Create a buffered wrapper for the given analogue input
 
-        The parameter @knob can be any Knob instance, including:
+        The parameter knob can be any Knob instance, including:
         - europi_hardware.k1
         - europi_hardware.k2
 
         Until the .update() method is called, this class will return a value of 0.
 
-        @param knob The analogue input to wrap e.g.:
-                    ```python
-                    from europi_hardware import *
-                    from experimental.knobs import *
-                    k1_buffered = BufferedKnob(k1)
-                    ```
+        :param knob: The analogue input to wrap e.g. ``europi_hardware.k1``
         """
         super().__init__(knob.pin_id)
         self.value = 0
@@ -390,15 +385,15 @@ class BufferedKnob(Knob):
 
         Instead of sampling we simply return the most recent sample value
 
-        @param samples  Ignored, but needed by the _sample_adc API used by AnalogueReader
+        :param samples:  Ignored, but needed by the _sample_adc API used by AnalogueReader
         """
         return self.value
 
     def update(self, samples=None):
         """Re-read the ADC and update the buffered value
 
-        @param samples  Specifies the number of samples to average to de-noise the ADC reading
-                        See europi_hardware.AnalogueReader for details on ADC sampling
+        :param samples:  Specifies the number of samples to average to de-noise the ADC reading
+            See europi_hardware.AnalogueReader for details on ADC sampling
         """
         self.value = super()._sample_adc(samples)
 
@@ -414,9 +409,9 @@ class MedianAnalogInput:
     def __init__(self, analog_in, samples=100, window_size=5):
         """Create the wrapper
 
-        @param analog_in    The input we're wrapping (e.g. k1, k2, ain)
-        @param samples      The number of samples to use when reading from analog_in
-        @param window_size  The number of samples used for calculating the median
+        :param analog_in:    The input we're wrapping (e.g. k1, k2, ain)
+        :param samples:      The number of samples to use when reading from analog_in
+        :param window_size:  The number of samples used for calculating the median
         """
         self.analog_in = analog_in
         self.n_samples = samples

--- a/software/firmware/experimental/math_extras.py
+++ b/software/firmware/experimental/math_extras.py
@@ -25,9 +25,9 @@ def prod(l):
 
     Equivalent the Python3's math.prod
 
-    @param l  An iterable collection of numbers
+    :param l:  An iterable collection of numbers
 
-    @return  The product of all items in the list, or 0 if the list is empty
+    :return:  The product of all items in the list, or 0 if the list is empty
     """
     if len(l) == 0:
         return 0
@@ -44,9 +44,9 @@ def median(l):
     This is a cheater median, as we always choose the lower value if the length is even instead of
     averaging the middle two values. This is faster, but mathematically incorrect.
 
-    @param l  An iterable collection of numbers
+    :param l:  An iterable collection of numbers
 
-    @return  The median value from the list, or 0 if the list is empty
+    :return:  The median value from the list, or 0 if the list is empty
     """
     if len(l) == 0:
         return 0
@@ -59,9 +59,9 @@ def mean(l):
     """
     Calculate the arithmetic mean value from an array
 
-    @param l  An iterable collection of numbers
+    :param l:  An iterable collection of numbers
 
-    @return  The arithmetic mean of the list, or 0 of the list is empty
+    :return:  The arithmetic mean of the list, or 0 of the list is empty
     """
     if len(l) == 0:
         return 0
@@ -72,9 +72,9 @@ def geometric_mean(l):
     """
     Calculate the geometric mean value of an array
 
-    @param l  An iterable collection of numbers
+    :param l:  An iterable collection of numbers
 
-    @return  The geometric mean of the list, or 0 of the list is empty
+    :return:  The geometric mean of the list, or 0 of the list is empty
     """
     if len(l) == 0:
         return 0
@@ -85,9 +85,9 @@ def harmonic_mean(l):
     """
     Calculate the harmonic mean value of an array
 
-    @param l  An iterable collection of numbers
+    :param l:  An iterable collection of numbers
 
-    @return  The harmonic mean of the list, or 0 of the list is empty
+    :return:  The harmonic mean of the list, or 0 of the list is empty
     """
     if len(l) == 0:
         return 0
@@ -104,9 +104,9 @@ def mode(l):
     The mode is the most-occurring item; if multiple items are tied,
     the median of the tied items is returned
 
-    @param l  An iterable collection of numbers
+    :param l:  An iterable collection of numbers
 
-    @return  The mode of the list, or 0 if the list is empty
+    :return:  The mode of the list, or 0 if the list is empty
     """
     if len(l) == 0:
         return 0
@@ -137,12 +137,12 @@ def rescale(x, old_min, old_max, new_min, new_max, clip=True):
     """
     Convert x in [old_min, old_max] -> y in [new_min, new_max] using linear interpolation
 
-    @param x  The value to convert
-    @param old_min  The old (inclusive) minimum
-    @param old_max  The old (inclusive) maximum
-    @param new_min  The new (inclusive) minimum
-    @param new_max  The new (inclusive) maximum
-    @param clip     If true, we clip values within the [min, max] range; otherwise we extrapolate based on the ranges
+    :param x:  The value to convert
+    :param old_min:  The old (inclusive) minimum
+    :param old_max:  The old (inclusive) maximum
+    :param new_min:  The new (inclusive) minimum
+    :param new_max:  The new (inclusive) maximum
+    :param clip:     If true, we clip values within the [min, max] range; otherwise we extrapolate based on the ranges
     """
     if clip and x < old_min:
         return new_min
@@ -169,10 +169,10 @@ def solve_linear_system(m):
             [kmn kmn kmn ... kmn  am]
         ]
 
-    @param m  The augmented matrix representation of the series of equations. This array is mangled in the process
+    :param m:  The augmented matrix representation of the series of equations. This array is mangled in the process
               of calculation
 
-    @return   A matrix of the coefficients of the equation
+    :return:   A matrix of the coefficients of the equation
     """
     n_eqs = len(m)
 

--- a/software/firmware/experimental/osc.py
+++ b/software/firmware/experimental/osc.py
@@ -33,7 +33,7 @@ def align_next_word(n):
     We assume 4-byte/32-bit words. If we're already word-aligned,
     we increment to the next one
 
-    @param n  The current index in a byte array
+    :param n:  The current index in a byte array
     """
     return n + (4 - (n % 4)) % 4
 
@@ -44,8 +44,8 @@ class OpenSoundPacket:
 
     Contains the address of the message and the data
 
-    @property address  The address string of the packet
-    @property values  The values included in the packet
+    :property address:  The address string of the packet
+    :property values:  The values included in the packet
     """
 
     def __init__(self, data: bytes):
@@ -53,23 +53,23 @@ class OpenSoundPacket:
         Read the raw packet and create this container
 
         The raw data consists of the following fields:
-            1. leading '/' character
-            2. slash-separated address (e.g. foo/bar)
-            3. null terminator (0x00 byte)
-            4. ',' character
-            5. type arguments
-                a. "f" character for 32-bit float
-                b. "i" character for 32-bit signed integer
-                c. "s" character for string (null-terminated)
-                d. "b" character for blob (32-bit int -> n, followed by n bytes of data)
-                e. assorted non-standard types
-            6. null terminator(s)
-            7. payload bytes (lengths are type dependent)
+        1. leading '/' character
+        2. slash-separated address (e.g. foo/bar)
+        3. null terminator (0x00 byte)
+        4. ',' character
+        5. type arguments
+            a. "f" character for 32-bit float
+            b. "i" character for 32-bit signed integer
+            c. "s" character for string (null-terminated)
+            d. "b" character for blob (32-bit int -> n, followed by n bytes of data)
+            e. assorted non-standard types
+        6. null terminator(s)
+        7. payload bytes (lengths are type dependent)
 
         Every argument starts on an 4-aligned byte, so there are
         filler nulls to pad strings out to a multiple of 32 bits
 
-        @param data  The raw byte data read from the UDP socket
+        :param data:  The raw byte data read from the UDP socket
         """
         address_end = data.index(b"\0", 1)
         self._address = data[0:address_end].decode("utf-8")
@@ -206,7 +206,9 @@ class OpenSoundServer:
 
         TouchOSC uses port 9000 by default, so use that here for convenience
 
-        @param port  The UDP port we accept messages on.
+        :param recv_port:  The UDP port we accept messages on.
+        :param send_port:  The UDP port we send outgoing messages on.
+        :param send_addr:  The IP address of the host we send outgoing messages to
         """
         log_info(f"Listening for OSC packets on port {recv_port}", "osc")
         addr = socket.getaddrinfo("0.0.0.0", recv_port)[0][-1]
@@ -239,7 +241,7 @@ class OpenSoundServer:
         - connection: socket  A socket connection to the client
         - data: str  The request the client sent
 
-        @param func  The function to handle the request.
+        :param func:  The function to handle the request.
         """
 
         def wrapper(*args, **kwargs):
@@ -272,8 +274,8 @@ class OpenSoundServer:
         """
         Transmit a packet
 
-        @param address  The OSC address to send to
-        @param args  The values to encode in the packet. Allowed types are int, float, bool, str, and bytearray. Bools are converted to 0/1 integers
+        :param address:  The OSC address to send to
+        :param args:  The values to encode in the packet. Allowed types are int, float, bool, str, and bytearray. Bools are converted to 0/1 integers
         """
 
         def pad_length(arr):

--- a/software/firmware/experimental/quantizer.py
+++ b/software/firmware/experimental/quantizer.py
@@ -48,9 +48,10 @@ class Quantizer:
         By default all notes are enabled (chromatic scale). The provided array is
         deep-copied into this object
 
-        @param notes  A boolean array of length SEMITONES_PER_OCTAVE indicating what semitones are enabled (True) or disabled (False)
+        :param notes:  A boolean array of length SEMITONES_PER_OCTAVE indicating what semitones
+            are enabled (True) or disabled (False)
 
-        @raises ValueError if len(notes) is not equal to SEMITONES_PER_OCTAVE
+        :raises ValueError: if len(notes) is not equal to SEMITONES_PER_OCTAVE
         """
         if notes is None:
             self.notes = [True] * SEMITONES_PER_OCTAVE
@@ -82,10 +83,12 @@ class Quantizer:
     def quantize(self, analog_in, root=0):
         """Take an analog input voltage and round it to the nearest note on our scale
 
-        @param analog_in  The input voltage to quantize, as a float
-        @param root       An integer in the range [0, 12) indicating the number of semitones up to transpose the quantized scale
+        :param analog_in:  The input voltage to quantize, as a float
+        :param root:       An integer in the range [0, 12) indicating the number of semitones up
+            to transpose the quantized scale
 
-        @return A tuple of the form (voltage, note) where voltage is the raw voltage to output, and note is a value from 0-11 indicating the semitone
+        :return: A tuple of the form (voltage, note) where voltage is the raw voltage to output,
+            and note is a value from 0-11 indicating the semitone
         """
         # Make sure we've got at least 1 note in the scale enabled, otherwise we might have infinite loop problems
         # If we have nothing to quantize to, just output zero for both outputs

--- a/software/firmware/experimental/random_extras.py
+++ b/software/firmware/experimental/random_extras.py
@@ -31,11 +31,11 @@ def normal(mean=0.0, stdev=1.0):
     Uses the Marsaglia-Tsang algorithm, which isn't a perfectly normal
     distribution, but is likely close enough for EuroPi applications
 
-    @param mean   The desired mean for the distribution
-    @param stdev  The standard deviation of the distribution
+    :param mean:   The desired mean for the distribution
+    :param stdev:  The standard deviation of the distribution
 
-    @return A floating-point number chosen from a normal distribution with the
-            given mean and standard deviation
+    :return: A floating-point number chosen from a normal distribution with the
+        given mean and standard deviation
     """
     x = 0.0
     y = 0.0
@@ -56,7 +56,7 @@ def shuffle(l):
     """
     Re-order the elements of a list in-situ
 
-    @param l  The list to shuffle
+    :param l:  The list to shuffle
     """
     for i in range(len(l)):
         n = random.randint(i, len(l) - 1)

--- a/software/firmware/experimental/rtc.py
+++ b/software/firmware/experimental/rtc.py
@@ -99,8 +99,8 @@ class Timezone:
         """
         Create a time zone we can add to a datetime to get local time
 
-        @param hours  The number of hours ahead/behind we need to adjust [-24 to +24]
-        @param minutes  The number of minutes ahead/behind we need to adjust [-59 to +59]
+        :param hours:  The number of hours ahead/behind we need to adjust [-24 to +24]
+        :param minutes:  The number of minutes ahead/behind we need to adjust [-59 to +59]
         """
         if (hours < 0 and minutes > 0) or (hours > 0 and minutes < 0):
             raise ValueError("Timezone offset must be in a consistent direction")
@@ -130,14 +130,14 @@ class DateTime:
         """
         Create a DateTime representing a specific moment
 
-        @param year  The current year (e.g. 2025)
-        @param month  The current month (e.g. Month.JANUARY)
-        @param day  The current day within the month (e.g. 17)
-        @param hour  The current hour on a 24-hour clock (0-23)
-        @param minute  The current minute within the hour (0-59)
-        @param second  The current second within the minute (0-59, optional)
-        @param weekday  The current day of the week (e.g. Weekday.MONDAY, optional)
-        @param yearday  The current day of the year (1-365, 1-366 if leap year, optional)
+        :param year:  The current year (e.g. 2025)
+        :param month:  The current month (e.g. Month.JANUARY)
+        :param day:  The current day within the month (e.g. 17)
+        :param hour:  The current hour on a 24-hour clock (0-23)
+        :param minute:  The current minute within the hour (0-59)
+        :param second:  The current second within the minute (0-59, optional)
+        :param weekday:  The current day of the week (e.g. Weekday.MONDAY, optional)
+        :param yearday:  The current day of the year (1-365, 1-366 if leap year, optional)
         """
         self.year = year
         self.month = month
@@ -165,7 +165,7 @@ class DateTime:
         """
         Add a timezone offset to the current time, returning the result
 
-        @param tz  The timezone we're adding to this Datetime
+        :param tz:  The timezone we're adding to this Datetime
         """
         t = DateTime(
             self.year, self.month, self.day, self.hour, self.minute, self.second, self.weekday
@@ -349,7 +349,7 @@ class RealtimeClock:
         """
         Create a new realtime clock.
 
-        @param source  An ExternalClockSource implementation we read the time from
+        :param source:  An ExternalClockSource implementation we read the time from
         """
         self.source = source
 
@@ -357,7 +357,7 @@ class RealtimeClock:
         """
         Get the current UTC time.
 
-        @return A DateTime object representing the current UTC time
+        :return: A DateTime object representing the current UTC time
         """
 
         # get the raw tuple from the clock, append Nones so we have all 7 fields
@@ -384,7 +384,7 @@ class RealtimeClock:
 
         See experimental_config for instructions on how to configure the local timezone
 
-        @return a DateTime object representing the current local time
+        :return: a DateTime object representing the current local time
         """
         return self.utcnow() + local_timezone
 

--- a/software/firmware/experimental/screensaver.py
+++ b/software/firmware/experimental/screensaver.py
@@ -60,7 +60,7 @@ class Screensaver:
         or the `force` paramter is True, we will draw.  Otherwise this does
         nothing
 
-        @param force  Force the logo to be drawn, regardless of the current ticks
+        :param force:  Force the logo to be drawn, regardless of the current ticks
         """
         LOGO_UPDATE_INTERVAL = 2000
 
@@ -90,14 +90,12 @@ class OledWithScreensaver:
 
     Set .enable_screensaver or .enable_blank to False to disable the screensaver/blanking activation completely
     (though if you do that, just use europi.oled instead of this class)
+
+    :param enable_screensaver:  If true, the screensaver will activate when needed
+    :param enable_blank:        If true, the screen will blank after the screensaver has been active for a while
     """
 
     def __init__(self, enable_screensaver=True, enable_blank=True):
-        """Constructor
-
-        @param enable_screensaver  If true, the screensaver will activate when needed
-        @param enable_blank        If true, the screen will blank after the screensaver has been active for a while
-        """
         self.screensaver = Screensaver()
         self.enable_screensaver = enable_screensaver
         self.enable_blank = enable_blank

--- a/software/firmware/experimental/settings_menu.py
+++ b/software/firmware/experimental/settings_menu.py
@@ -66,9 +66,9 @@ class MenuItem:
         """
         Create a new abstract menu item
 
-        @param parent  A MenuItem representing this item's parent, if this item is the bottom-level of a multi-level menu
-        @param children  A list of MenuItems representing this item's children, if this is the top-level of a multi-level menu
-        @param is_visible  Is this menu item visible by default?
+        :param parent:  A MenuItem representing this item's parent, if this item is the bottom-level of a multi-level menu
+        :param children:  A list of MenuItems representing this item's children, if this is the top-level of a multi-level menu
+        :param is_visible:  Is this menu item visible by default?
         """
         self.menu = None
         self.parent = parent
@@ -89,7 +89,7 @@ class MenuItem:
         """
         Draw the item to the screen
 
-        @param oled   A Display-compatible object we draw to
+        :param oled:   A Display-compatible object we draw to
         """
         self.ui_dirty = False
 
@@ -138,15 +138,15 @@ class ChoiceMenuItem(MenuItem):
         """
         Create a new choice menu item
 
-        @param parent  If the menu has multiple levels, what is this item's parent control?
-        @param children  If this menu has multiple levels, whar are this item's child controls?
-        @param title  The title to display at the top of the display when this control is active
-        @param prefix  A prefix to display before the title when this control is active
-        @param graphics  A dict of values mapped to FrameBuffer or bytearray objects, representing
+        :param parent:  If the menu has multiple levels, what is this item's parent control?
+        :param children:  If this menu has multiple levels, whar are this item's child controls?
+        :param title:  The title to display at the top of the display when this control is active
+        :param prefix:  A prefix to display before the title when this control is active
+        :param graphics:  A dict of values mapped to FrameBuffer or bytearray objects, representing
             12x12 MONO_HLSB graphics to display along with the keyed values
-        @param labels  A dict of values mapped to strings, representing human-readible versions of the ConfigPoint
+        :param labels:  A dict of values mapped to strings, representing human-readible versions of the ConfigPoint
                        options
-        @param is_visible  Is this menu item visible by default?
+        :param is_visible:  Is this menu item visible by default?
         """
         super().__init__(
             children=children,
@@ -172,7 +172,7 @@ class ChoiceMenuItem(MenuItem):
         You MUST call the display's .show() function after calling this in order to send the buffer to the display
         hardware
 
-        @param oled  A Display instance (or compatible class) to render the item
+        :param oled:  A Display instance (or compatible class) to render the item
         """
         super().draw(oled)
 
@@ -279,24 +279,24 @@ class SettingMenuItem(ChoiceMenuItem):
 
         If the item has a callback function defined, it will be invoked once during initialization
 
-        @param config_point  The configration option this menu item controls
-        @param parent  If the menu has multiple levels, what is this item's parent control?
-        @param children  If this menu has multiple levels, whar are this item's child controls?
-        @param title  The title to display at the top of the display when this control is active
-        @param prefix  A prefix to display before the title when this control is active
-        @param graphics  A dict of values mapped to FrameBuffer or bytearray objects, representing
+        :param config_point:  The configration option this menu item controls
+        :param parent:  If the menu has multiple levels, what is this item's parent control?
+        :param children:  If this menu has multiple levels, whar are this item's child controls?
+        :param title:  The title to display at the top of the display when this control is active
+        :param prefix:  A prefix to display before the title when this control is active
+        :param graphics:  A dict of values mapped to FrameBuffer or bytearray objects, representing
             12x12 MONO_HLSB graphics to display along with the keyed values
-        @param labels  A dict of values mapped to strings, representing human-readible versions of the ConfigPoint options
-        @param callback  A function to invoke when this item's value changes. Must accept
+        :param labels:  A dict of values mapped to strings, representing human-readible versions of the ConfigPoint options
+        :param callback:  A function to invoke when this item's value changes. Must accept
             (new_value, old_value, config_point, arg=None) as parameters
-        @param callback_arg  An optional additional argument to pass to the callback function
-        @param float_resolution  The resolution of floating-point config points
+        :param callback_arg:  An optional additional argument to pass to the callback function
+        :param float_resolution:  The resolution of floating-point config points
             (ignored if config_point is not a FloatConfigPoint)
-        @param value_map  An optional dict to map the underlying simple ConfigPoint values
+        :param value_map:  An optional dict to map the underlying simple ConfigPoint values
             to more complex objects e.g. map the string "CMaj" to a Quantizer object
-        @param is_visible  Is this menu item visible by default?
-        @param autoselect_knob  If True, this item gets "Knob" as an additional choice, allowing ad-hoc selection via the knob
-        @param autoselect_cv  If True, this item gets "AIN" as an additional choice, allowing ad-hoc selection via the CV input
+        :param is_visible:  Is this menu item visible by default?
+        :param autoselect_knob:  If True, this item gets "Knob" as an additional choice, allowing ad-hoc selection via the knob
+        :param autoselect_cv:  If True, this item gets "AIN" as an additional choice, allowing ad-hoc selection via the CV input
         """
         if title is None:
             title = config_point.name
@@ -375,8 +375,8 @@ class SettingMenuItem(ChoiceMenuItem):
         This is needed if we externally modify e.g. the maximum/minimum values of the underlying
         config point as a result of one option needing to be within a range determined by another.
 
-        @param choices  The list of new options we want to allow the user to choose from, excluding any autoselections
-        @param new_default  A value to assign to this setting if its existing value is out-of-range
+        :param choices:  The list of new options we want to allow the user to choose from, excluding any autoselections
+        :param new_default:  A value to assign to this setting if its existing value is out-of-range
         """
         if choices is None:
             choices = self.get_option_list()
@@ -417,7 +417,7 @@ class SettingMenuItem(ChoiceMenuItem):
         """
         Get the list of options the user can choose from
 
-        @return  A list of choices
+        :return:  A list of choices
         """
         t = type(self.src_config)
         if t is FloatConfigPoint:
@@ -452,7 +452,7 @@ class SettingMenuItem(ChoiceMenuItem):
         """
         Called by the parent menu when the Knob/CV timer fires, automatically updating the value of this item
 
-        @param percent  A value 0-1 indicating the level of the knob/cv source
+        :param percent:  A value 0-1 indicating the level of the knob/cv source
         """
         last_choice = len(self.config_point.choices) - self.NUM_AUTOINPUT_CHOICES
         index = int(
@@ -472,9 +472,9 @@ class SettingMenuItem(ChoiceMenuItem):
         """
         Set the raw value of this item's ConfigPoint
 
-        @param choice  The value to assign to the ConfigPoint.
+        :param choice:  The value to assign to the ConfigPoint.
 
-        @exception  ValueError if the given choice is not valid for this setting
+        :raises ValueError: if the given choice is not valid for this setting
         """
         # choose whatever string we're given
         if type(self.src_config) is StringConfigPoint:
@@ -582,17 +582,17 @@ class ActionMenuItem(ChoiceMenuItem):
 
         If the item has a callback function defined, it will be invoked once during initialization
 
-        @param actions  The list of choices the user can pick from. e.g. ["Cancel", "Ok"]
-        @param callback  The function to call when the user invokes the action. The selected item from choices is passed as the first parameter
-        @param callback_arg  The second parameter passed to the callback
-        @param parent  If the menu has multiple levels, what is this item's parent control?
-        @param children  If this menu has multiple levels, whar are this item's child controls?
-        @param title  The title to display at the top of the display when this control is active
-        @param prefix  A prefix to display before the title when this control is active
-        @param graphics  A dict of values mapped to FrameBuffer or bytearray objects, representing
+        :param actions:  The list of choices the user can pick from. e.g. ["Cancel", "Ok"]
+        :param callback:  The function to call when the user invokes the action. The selected item from choices is passed as the first parameter
+        :param callback_arg:  The second parameter passed to the callback
+        :param parent:  If the menu has multiple levels, what is this item's parent control?
+        :param children:  If this menu has multiple levels, whar are this item's child controls?
+        :param title:  The title to display at the top of the display when this control is active
+        :param prefix:  A prefix to display before the title when this control is active
+        :param graphics:  A dict of values mapped to FrameBuffer or bytearray objects, representing
             12x12 MONO_HLSB graphics to display along with the keyed values
-        @param labels  A dict of values mapped to strings, representing human-readible versions of the ConfigPoint options
-        @param is_visible  Is this menu item visible by default?
+        :param labels:  A dict of values mapped to strings, representing human-readible versions of the ConfigPoint options
+        :param is_visible:  Is this menu item visible by default?
         """
         super().__init__(
             parent=parent,
@@ -657,14 +657,14 @@ class SettingsMenu:
         to avoid any lengthy operations inside these callbacks, as they may prevent other interrupts from being
         handled properly.
 
-        @param menu_items  A list of MenuItem objects representing the top-level of the menu
-        @param navigation_button  The button the user presses to interact with the menu
-        @param navigation_knob  The knob the user turns to scroll through the menu. This may be an
+        :param menu_items:  A list of MenuItem objects representing the top-level of the menu
+        :param navigation_button:  The button the user presses to interact with the menu
+        :param navigation_knob:  The knob the user turns to scroll through the menu. This may be an
             experimental.knobs.KnobBank with 3 menu levels called "main_menu", "submenu" and "choice", or a raw knob like europi.k2
-        @param short_press_cb  An optional callback function to invoke when the user interacts with a short-press of the button
-        @param long_press_cb  An optional callback function to invoke when the user interacts with a long-press of the button
-        @param autoselect_knob  A knob that the user can turn to select items without needing to menu-dive
-        @param autoselect_cv  An analogue input the user can use to select items with CV
+        :param short_press_cb:  An optional callback function to invoke when the user interacts with a short-press of the button
+        :param long_press_cb:  An optional callback function to invoke when the user interacts with a long-press of the button
+        :param autoselect_knob:  A knob that the user can turn to select items without needing to menu-dive
+        :param autoselect_cv:  An analogue input the user can use to select items with CV
         """
         self._knob = navigation_knob
         self.button = navigation_button
@@ -732,7 +732,7 @@ class SettingsMenu:
         """
         Load the initial settings from the file
 
-        @param settings_file  The path to a JSON file where the user's settings are saved
+        :param settings_file:  The path to a JSON file where the user's settings are saved
         """
         failed_key_counts = {}
 
@@ -846,7 +846,7 @@ class SettingsMenu:
         You MUST call the display's .show() function after calling this in order to send the buffer to the display
         hardware
 
-        @param oled  The display object to draw to
+        :param oled:  The display object to draw to
         """
         if not self.active_item.is_editable:
             self.active_item = self.knob.choice(self.visible_items)
@@ -857,7 +857,7 @@ class SettingsMenu:
         """
         Connects a menu item to this menu's CV input
 
-        @param menu_item  The item that wants to subscribe to the CV input
+        :param menu_item:  The item that wants to subscribe to the CV input
         """
         if len(self.autoselect_cv_items) == 0 and len(self.autoselect_knob_items) == 0:
             self.autoselect_timer.init(freq=10, mode=Timer.PERIODIC, callback=self.do_autoselect)
@@ -867,7 +867,7 @@ class SettingsMenu:
         """
         Connects a menu item to this menu's knob input
 
-        @param menu_item  The item that wants to subscribe to the knob input
+        :param menu_item:  The item that wants to subscribe to the knob input
         """
         if len(self.autoselect_cv_items) == 0 and len(self.autoselect_knob_items) == 0:
             self.autoselect_timer.init(freq=10, mode=Timer.PERIODIC, callback=self.do_autoselect)
@@ -877,7 +877,7 @@ class SettingsMenu:
         """
         Disconnects a menu item to this menu's CV input
 
-        @param menu_item  The item that wants to unsubscribe from the CV input
+        :param menu_item:  The item that wants to unsubscribe from the CV input
         """
         self.autoselect_cv_items.remove(menu_item)
         if len(self.autoselect_cv_items) == 0 and len(self.autoselect_knob_items) == 0:
@@ -887,7 +887,7 @@ class SettingsMenu:
         """
         Disconnects a menu item to this menu's knob input
 
-        @param menu_item  The item that wants to unsubscribe from the knob input
+        :param menu_item:  The item that wants to unsubscribe from the knob input
         """
         self.autoselect_knob_items.remove(menu_item)
         if len(self.autoselect_cv_items) == 0 and len(self.autoselect_knob_items) == 0:

--- a/software/firmware/experimental/thread.py
+++ b/software/firmware/experimental/thread.py
@@ -29,21 +29,28 @@ class DigitalInputHelper:
     functions
 
     Calling `.update()` will populate the following fields of the DigitalInputHelper:
-    - b1_last_pressed: the ms tick time that b1 was last pressed
-    - b1_last_released: the ms tick time that b1 was last released
-    - b1_pressed: True if b1 is currently pressed down, otherwise False
-    - b1_rising: True if b1 transitioned to the pressed state during the last update() call, otherwise False
-    - b1_falling: True if b1 transitioned to the released state during the last update() call, otherwise False
-    - b2_last_pressed: the ms tick time that b2 was last pressed
-    - b2_last_released: the ms tick time that b2 was last released
-    - b2_pressed: True if b2 is currently pressed down, otherwise False
-    - b2_rising: True if b1 transitioned to the pressed state during the last update() call, otherwise False
-    - b2_falling: True if b1 transitioned to the released state during the last update() call, otherwise False
-    - din_last_rise: the ms tick time that din last received a rising signal
-    - din_last_fall: the ms tick time that din last received a falling signal
-    - din_high: True if din is currently high, otherwise False
-    - din_rising: True if din transitioned to the high state during the last update() call, otherwise False
-    - din_falling: True if b1 transitioned to the low state during the last update() call, otherwise False
+    * b1_last_pressed: the ms tick time that b1 was last pressed
+    * b1_last_released: the ms tick time that b1 was last released
+    * b1_pressed: True if b1 is currently pressed down, otherwise False
+    * b1_rising: True if b1 transitioned to the pressed state during the last update() call, otherwise False
+    * b1_falling: True if b1 transitioned to the released state during the last update() call, otherwise False
+    * b2_last_pressed: the ms tick time that b2 was last pressed
+    * b2_last_released: the ms tick time that b2 was last released
+    * b2_pressed: True if b2 is currently pressed down, otherwise False
+    * b2_rising: True if b1 transitioned to the pressed state during the last update() call, otherwise False
+    * b2_falling: True if b1 transitioned to the released state during the last update() call, otherwise False
+    * din_last_rise: the ms tick time that din last received a rising signal
+    * din_last_fall: the ms tick time that din last received a falling signal
+    * din_high: True if din is currently high, otherwise False
+    * din_rising: True if din transitioned to the high state during the last update() call, otherwise False
+    * din_falling: True if b1 transitioned to the low state during the last update() call, otherwise False
+
+    :param on_din_rising:   Callback function to invoke when din detects a rising edge
+    :param on_din_falling:  Callback function to invoke when din detects a falling edge
+    :param on_b1_rising:    Callback function to invoke when b1 detects a rising edge
+    :param on_b1_falling:   Callback function to invoke when b1 detects a falling edge
+    :param on_b2_rising:    Callback function to invoke when b2 detects a rising edge
+    :param on_b2_falling:   Callback function to invoke when b2 detects a falling edge
     """
 
     def __init__(
@@ -55,15 +62,6 @@ class DigitalInputHelper:
         on_b2_rising=lambda: None,
         on_b2_falling=lambda: None,
     ):
-        """Constructor
-
-        @param on_din_rising   Callback function to invoke when din detects a rising edge
-        @param on_din_falling  Callback function to invoke when din detects a falling edge
-        @param on_b1_rising    Callback function to invoke when b1 detects a rising edge
-        @param on_b1_falling   Callback function to invoke when b1 detects a falling edge
-        @param on_b2_rising    Callback function to invoke when b2 detects a rising edge
-        @param on_b2_falling   Callback function to invoke when b2 detects a falling edge
-        """
         # Connect the callback functions
         self.on_din_rising = on_din_rising
         self.on_din_falling = on_din_falling

--- a/software/firmware/experimental/wifi.py
+++ b/software/firmware/experimental/wifi.py
@@ -42,7 +42,8 @@ class WifiConnection:
     """
     Class to manage the wifi connection
 
-    Raises a WifiError if the model doesn't support wifi
+    :raises WifiError: if the model doesn't support wifi, if we fail to import the
+        necessary libraries, or if the network fails to connect
     """
 
     def __init__(self):
@@ -92,7 +93,7 @@ class WifiConnection:
         """
         Connect to an external wireless router as a client
 
-        @param cfg  The ExperimentalConfig object
+        :param cfg:  The ExperimentalConfig object
         """
         import network
 
@@ -164,7 +165,7 @@ class WifiConnection:
 
         We can optionally set the IP address and netmask in this mode
 
-        @param cfg  The ExperimentalConfig object
+        :param cfg:  The ExperimentalConfig object
         """
         import network
 

--- a/software/firmware/file_utils.py
+++ b/software/firmware/file_utils.py
@@ -18,13 +18,13 @@ import json
 from europi_log import *
 
 
-def load_file(filename, mode: str = "r"):
+def load_file(filename, mode: str = "r") -> Any:
     """Load a file and return its contents
 
-    @param filename  The name of the file to load
-    @param mode      The mode to open the file in. Should be "r" for text files or "rb" for binary files
+    :param filename:  The name of the file to load
+    :param mode:      The mode to open the file in. Should be "r" for text files or "rb" for binary files
 
-    @return  The file's contents, either as a string or bytes, depending on mode.
+    :return:  The file's contents, either as a string or bytes, depending on mode.
     """
     try:
         with open(filename, mode) as file:
@@ -40,10 +40,10 @@ def load_file(filename, mode: str = "r"):
 def load_json_file(filename, mode="r") -> dict:
     """Load a file and return its contents
 
-    @param filename  The name of the file to load
-    @param mode      The mode to open the file in. Should be "r" except in very unique circumstances
+    :param filename  The name of the file to load
+    :param mode      The mode to open the file in. Should be "r" except in very unique circumstances
 
-    @return  The file's contents as a dict
+    :return  The file's contents as a dict
     """
     try:
         with open(filename, mode) as file:

--- a/software/firmware/file_utils.py
+++ b/software/firmware/file_utils.py
@@ -18,7 +18,7 @@ import json
 from europi_log import *
 
 
-def load_file(filename, mode: str = "r") -> Any:
+def load_file(filename, mode: str = "r") -> object:
     """Load a file and return its contents
 
     :param filename:  The name of the file to load

--- a/software/firmware/tools/calibrate.py
+++ b/software/firmware/tools/calibrate.py
@@ -43,7 +43,7 @@ class CalibrationValues:
     def __init__(self, mode):
         """Create the calibration values, specifying the mode we're operating in
 
-        @param mode  The calibration mode, one of MODE_LOW_10, MODE_LOW_5, or MODE_HIGH
+        :param mode:  The calibration mode, one of MODE_LOW_10, MODE_LOW_5, or MODE_HIGH
         """
         self.mode = mode
 
@@ -67,14 +67,14 @@ class Calibrate(EuroPiScript):
     A script to interactively calibrate the module
 
     General flow:
-        1. Sanity check (rack power, necessary file structure exists)
-        2. Input calibration. One of:
-            a. low-accuracy 10V in
-            b. low-accuracy 5V in
-            c. high-accuracy 0-10V in
-        3. Output calibration
-        4. Save calibration
-        5. Idle for reboot
+    1. Sanity check (rack power, necessary file structure exists)
+    2. Input calibration. One of:
+        a. low-accuracy 10V in
+        b. low-accuracy 5V in
+        c. high-accuracy 0-10V in
+    3. Output calibration
+    4. Save calibration
+    5. Idle for reboot
 
     Output calibration only applies to CV1; all other outputs will
     use the same calibration values.
@@ -120,8 +120,8 @@ class Calibrate(EuroPiScript):
         """
         Display text on the screen and block for the specified duration
 
-        @param text  The text to display
-        @param duration  The duration to wait in seconds
+        :param text:  The text to display
+        :param duration:  The duration to wait in seconds
         """
         oled.centre_text(text)
         sleep(duration)
@@ -130,7 +130,7 @@ class Calibrate(EuroPiScript):
         """
         Read from the raw ain pin and return the average across several readings
 
-        @return  The average across several distinct readings from the pin
+        :return:  The average across several distinct readings from the pin
         """
         N_READINGS = 512
         readings = []
@@ -146,9 +146,9 @@ class Calibrate(EuroPiScript):
         """
         Wait for the user to connect the desired voltage to ain & press b1
 
-        @param voltage  The voltage to instruct the user to connect. Used for display only
+        :param voltage:  The voltage to instruct the user to connect. Used for display only
 
-        @return  The average samples read from ain (see @read_sample)
+        :return:  The average samples read from ain (see read_sample)
         """
         if voltage == 0:
             oled.centre_text("Unplug all\n\nDone: Button 1")
@@ -163,7 +163,7 @@ class Calibrate(EuroPiScript):
         """
         Wait for the user to press B1, returning to the original state when they have
 
-        @param wait_fn  A function to execute while waiting (e.g. refresh the UI)
+        :param wait_fn:  A function to execute while waiting (e.g. refresh the UI)
         """
         if wait_fn is None:
             wait_fn = lambda: sleep(0.01)
@@ -178,7 +178,7 @@ class Calibrate(EuroPiScript):
         """
         Wait for the user to press B2, returning to the original state when they have
 
-        @param wait_fn  A function to execute while waiting (e.g. refresh the UI)
+        :param wait_fn:  A function to execute while waiting (e.g. refresh the UI)
         """
         if wait_fn is None:
             wait_fn = lambda: sleep(0.01)
@@ -207,7 +207,7 @@ class Calibrate(EuroPiScript):
 
         Prompt the user for 0 and 10V inputs only
 
-        @return  The sample readings for 0 and 10V
+        :return:  The sample readings for 0 and 10V
         """
         self.state = self.STATE_START_LOW_10
         readings = [
@@ -222,7 +222,7 @@ class Calibrate(EuroPiScript):
 
         Prompt the user for 0 and 5V inputs only. The 5V reading is extrapolated to 10V.
 
-        @return  The sample readings for 0 and 10V
+        :return:  The sample readings for 0 and 10V
         """
         self.state = self.STATE_START_LOW_5
         readings = [
@@ -242,7 +242,7 @@ class Calibrate(EuroPiScript):
 
         User is prompted to connect 0, 1, 2, ..., 9, 10V
 
-        @return  The sample readings for 0 to 10V (inclusive)
+        :return:  The sample readings for 0 to 10V (inclusive)
         """
         self.state = self.STATE_START_HIGH
         readings = []
@@ -254,9 +254,9 @@ class Calibrate(EuroPiScript):
         """
         Send volts from CVx to AIN, adjusting the duty cycle so the output is correct.
 
-        @param cv_n  A value 0 <= cv_n < len(cvs) indicating which CV output we're calibrating
-        @param calibration_values  The array of calibration values we append our results to
-        @param input_readings  The duty cycles of AIN corresponding to 0, 1, 2, ..., 9, 10 volts
+        :param cv_n:  A value 0 <= cv_n < len(cvs) indicating which CV output we're calibrating
+        :param calibration_values:  The array of calibration values we append our results to
+        :param input_readings:  The duty cycles of AIN corresponding to 0, 1, 2, ..., 9, 10 volts
         """
         oled.centre_text(f"Plug CV{cv_n+1} into\nanalogue in\nDone: Button 1")
         self.wait_for_b1()
@@ -301,12 +301,12 @@ class Calibrate(EuroPiScript):
         This will exit if either the calibration is within +/- the step_size OR if the measured duty
         cycle is higher than the goal (i.e. we've over-shot the goal)
 
-        @param cv  The CV output pin we're adjusting
-        @param goal_duty  The AIN duty cycle we're expecting to read
-        @param start_duty  The CVx duty cycle we're applying to the output initially
-        @param step_size  The amount by which we adjust the duty cycle up to reach the goal
+        :param cv:  The CV output pin we're adjusting
+        :param goal_duty:  The AIN duty cycle we're expecting to read
+        :param start_duty:  The CVx duty cycle we're applying to the output initially
+        :param step_size:  The amount by which we adjust the duty cycle up to reach the goal
 
-        @return The adjusted output duty cycle
+        :return: The adjusted output duty cycle
         """
         read_duty = self.read_sample()
         duty = start_duty
@@ -324,13 +324,13 @@ class Calibrate(EuroPiScript):
         This exits if the measured duty cycle is within +/- 2*step_size OR if we make
         2*prev_step_size adjustments
 
-        @param cv  The CV output pin we're adjusting
-        @param goal_duty  The AIN duty cycle we're expecting to read
-        @param start_duty  The CVx duty cycle we're applying to the output initially
-        @param step_size  The amount by which we adjust the duty cycle up/down to reach the goal
-        @param prev_step_size  The previous iteration's step size, used to limit how many adjustments we make
+        :param cv:  The CV output pin we're adjusting
+        :param goal_duty:  The AIN duty cycle we're expecting to read
+        :param start_duty:  The CVx duty cycle we're applying to the output initially
+        :param step_size:  The amount by which we adjust the duty cycle up/down to reach the goal
+        :param prev_step_size:  The previous iteration's step size, used to limit how many adjustments we make
 
-        @return The adjusted output duty cycle
+        :return: The adjusted output duty cycle
         """
         MAX_COUNT = 2 * prev_step_size
         count = 0

--- a/software/tests/mocks/network.py
+++ b/software/tests/mocks/network.py
@@ -30,8 +30,8 @@ def country(code=None):
     """
     Get/set the country code.
 
-    @param code  The ISO-compatible 2-character country code
-    @return The ISO-compatible 2-character country code, or XX if unset
+    :param code:  The ISO-compatible 2-character country code
+    :return: The ISO-compatible 2-character country code, or XX if unset
     """
     if code:
         return code
@@ -43,8 +43,8 @@ def hostname(name=None):
     """
     Get/set the hostname.
 
-    @param name  The new hostname to assign
-    @return This device's hostname
+    :param name:  The new hostname to assign
+    :return: This device's hostname
     """
     if name:
         return name
@@ -56,8 +56,8 @@ def ipconfig(**kwargs):
     """
     Get/set global IP paramters.
 
-    @param kwargs  Keyword arguments to assign: dns, prefer
-    @return The value of the parameter
+    :param kwargs:  Keyword arguments to assign: dns, prefer
+    :return: The value of the parameter
     """
     return None
 


### PR DESCRIPTION
Replace javadoc-style docstrings with sphinx-style ones

I've done the firmware, experimental, and tests folders so far. Not sure how much I want to bother with `contrib` since it's not used for autodoc generation.