### PR TITLE
Build UF2 files for additional boards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ venv
 dist/
 *.egg-info/
 config
+
+# EuroPi builds
+software/uf2_build/*.uf2

--- a/software/contrib/README.md
+++ b/software/contrib/README.md
@@ -411,6 +411,13 @@ This script can be copied and altered as a starting point for your own scripts t
 <i>Author: [mjaskula](https://github.com/mjaskula)</i>
 <br><i>Labels: example</i>
 
+### Custom Fonts \[ [script](/software/contrib/custom_font_demo.py) \]
+
+An example demonstrating the use of custom fonts.
+
+<i>Author: [François Georgy](https://github.com/francoisgeorgy)</i>
+<br><i>Labels: example</i>
+
 ### Knob Playground \[ [script](/software/contrib/knob_playground.py) \]
 
 An example showing the use of knob banks and lockable knobs.

--- a/software/contrib/menu.py
+++ b/software/contrib/menu.py
@@ -83,6 +83,7 @@ EUROPI_SCRIPTS = OrderedDict([
 
     # Examples & proof-of-concept scripts that aren't generally useful
     # but someone might want to enable to test out
+    #["Custom Fonts",      "contrib.custom_font_demo.CustomFontDemo"],
     #["HelloWorld",        "contrib.hello_world.HelloWorld"],
     #["KnobPlayground",    "contrib.knob_playground.KnobPlayground"],
     #["Menu Example",      "contrib.settings_menu_example.SettingsMenuExample"],

--- a/software/uf2_build/Dockerfile
+++ b/software/uf2_build/Dockerfile
@@ -5,6 +5,8 @@ ENV TERM=xterm DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -y \
     cmake git-core gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential wget python3
 
+WORKDIR /
+
 RUN git clone -b v1.24.1 --depth=1 --recursive https://github.com/micropython/micropython.git
 
 WORKDIR micropython

--- a/software/uf2_build/copy_and_compile.sh
+++ b/software/uf2_build/copy_and_compile.sh
@@ -1,18 +1,23 @@
-#/bin/sh
+#/bin/bash
 set -e
 
 echo "Copying EuroPi firmware and scripts to container..."
-mkdir micropython/ports/rp2/modules/contrib
-mkdir micropython/ports/rp2/modules/experimental
-mkdir micropython/ports/rp2/modules/tools
-cp -r europi/software/firmware/*.py micropython/ports/rp2/modules
-cp -r europi/software/firmware/experimental/*.py micropython/ports/rp2/modules/experimental
-cp -r europi/software/firmware/tools/*.py micropython/ports/rp2/modules/tools
-cp -r europi/software/contrib/*.py micropython/ports/rp2/modules/contrib
+mkdir /micropython/ports/rp2/modules/contrib
+mkdir /micropython/ports/rp2/modules/experimental
+mkdir /micropython/ports/rp2/modules/tools
+cp -r europi/software/firmware/*.py /micropython/ports/rp2/modules
+cp -r europi/software/firmware/experimental/*.py /micropython/ports/rp2/modules/experimental
+cp -r europi/software/firmware/tools/*.py /micropython/ports/rp2/modules/tools
+cp -r europi/software/contrib/*.py /micropython/ports/rp2/modules/contrib
 
 echo "Compiling micropython and firmware modules..."
-cd micropython/ports/rp2
-make
+cd /micropython/ports/rp2
 
-echo "Copying firmware file to /europi/software/uf2_build/europi-dev.uf2"
-cp build-RPI_PICO/firmware.uf2 /europi/software/uf2_build/europi-dev.uf2
+BOARDS="RPI_PICO RPI_PICO2 RPI_PICO_W RPI_PICO2_W"
+
+for b in $BOARDS; do
+    echo "make BOARD=$b"
+    make BOARD=$b
+    echo "Moving firmware file to /europi/software/uf2_build/europi-$b-dev.uf2"
+    mv build-$b/firmware.uf2 /europi/software/uf2_build/europi-$b-dev.uf2
+done

--- a/software/uf2_build/copy_and_compile.sh
+++ b/software/uf2_build/copy_and_compile.sh
@@ -13,7 +13,9 @@ cp -r europi/software/contrib/*.py /micropython/ports/rp2/modules/contrib
 echo "Compiling micropython and firmware modules..."
 cd /micropython/ports/rp2
 
-BOARDS="RPI_PICO RPI_PICO2 RPI_PICO_W RPI_PICO2_W"
+# Pico W must be last; we need to remove some code to make it fit
+# TODO: add RPI_PICO2_W once it's supported
+BOARDS="RPI_PICO RPI_PICO2 RPI_PICO_W"
 
 for b in $BOARDS; do
     echo "make BOARD=$b"


### PR DESCRIPTION
Updates the UF2 builder script to create UF2 files for the standard Pico, Pico 2, and Pico W. Pico 2 W isn't available _yet_, but there's a note to add it once its firmware is out of the preview stage.