### PR TITLE
Optimize Conway with a Summed Area Table

### DIFF
--- a/software/contrib/conway.md
+++ b/software/contrib/conway.md
@@ -83,7 +83,7 @@ Size 2: [-6, 6, -6, 6, -6, 6] -> 0.0, 6.0
 Size 3: [-2, -4, -6, 12]      -> 0.0, 7.071068
 Size 4: [0, 0, 0]             -> 0.0, 0.0
 ```
-we would assume we have reached stasis, as the mean and standard deviation of the size-3 buckets are less than 1.0.
+we would assume we have reached stasis, as the mean and standard deviation of the size-4 buckets are less than 1.0.
 
 ## LFO Rate Variablility
 

--- a/software/contrib/conway.py
+++ b/software/contrib/conway.py
@@ -18,9 +18,6 @@ Outputs 1-3 are 0-10V control voltages, outputs 4-6 are 5V gates
 
 @author Chris I-B <ve4cib@gmail.com>
 @year   2023
-
-Throughout the program we frequently use `>> 3` instead of `//8` for doing integer division when converting
-from bit indices to byte indices.
 """
 
 from europi import *
@@ -84,8 +81,8 @@ class Conway(EuroPiScript):
         # For ease of blitting, store the field as a bit array
         # Each byte is 8 horizontally adjacent pixels, with the most significant bit
         # on the left
-        self.field = bytearray(NUM_PIXELS >> 3)
-        self.next_field = bytearray(NUM_PIXELS >> 3)
+        self.field = bytearray(NUM_PIXELS // 8)
+        self.next_field = bytearray(NUM_PIXELS // 8)
 
         # Keep 2 separate frame buffer instances so we don't need to recreate the FB objects when we draw
         self.frame = FrameBuffer(self.field, OLED_WIDTH, OLED_HEIGHT, MONO_HLSB)


### PR DESCRIPTION
Simple performance optimization for Conway to use a Summed Area Table instead of iterating through the neighbourhoods of changed pixels. This should keep the framerate more stable.

Replaces https://github.com/Allen-Synthesis/EuroPi/pull/435, though the multi-threaded approach may be reintroduced later.