### PR TITLE
Fix typos, formatting for contrib readmes

### DIFF
--- a/software/contrib/bernoulli_gates.md
+++ b/software/contrib/bernoulli_gates.md
@@ -1,43 +1,53 @@
 # Bernoulli Gates
 
-author: Bridgee
+This script is based on Mutable Instruments Branches. Because EuroPi only haa a pair of digital/analogue
+inputs, the dual Bernoulli gates share the same clock (from the digital input), and only one Bernoulli
+gate has CV input.
 
-date: 03/13/22
+A Bernoulli gate takes a logic signal (trigger or gate) as an input, and routes it to either of its
+two outputs according to a random coin toss.
 
-labels: Random
+## Inputs & Outputs
 
-### General
-This app is based on Mutable Instruments Branches. Because EuroPi only have a pair of digital/analogue inputs, the dual Bernoulli gates share the same clock (from the digital input), and only one Bernoulli gate have CV input.
+Inputs:
+- `din`: trigger/clock
+- `ain`: probability control of gate 1 (summed with Knob 1)
+- `k1`: probability control of gate 1
+- `k2`: probability control of gate 2
+- `b1`: mode switch of gate 1
+- `b2`: mode switch of gate 2
 
-A Bernoulli gate takes a logic signal (trigger or gate) as an input, and routes it to either of its two outputs according to a random coin toss.
+Outputs:
+- `cv1`: output A of gate 1
+- `cv2`: output B of gate 1
+- `cv3`: copy of input trigger/clock
+- `cv4`: output A of gate 2
+- `cv5`: output B of gate 2
+- `cv6`: logical AND of both output A (`cv1` and `cv4`)
 
-Knob 1 adjusts the probability of the Bernoulli gate 1, and Knob 2 adjusts the probability of the Bernoulli gate 2.
+Turning a knob anticlockwise increases the probability that a signal will be routed to the
+corresponding gate's A-output, while turning it clockwise increases the probablility of the signal
+being routed to the gate's B-output. At 12-o'clock the probability of either is 50/50. Fully
+anticlockwise the probability of either is 100/0 and fully clockwise is 0/100.
 
-Button 1 switches the mode of gate 1 between trigger mode, toggle mode, and gate mode (latch mode), and Button 2 switches the mode of gate 2 between trigger mode, toggle mode, and gate mode (latch mode).
+Gate modes can be switched between
+- trigger: `Tr`
+- toggle: `Tg`
+- gate (latch): `G`
+by pressing the buttons. These modes are described in more detail below.
 
-### Tigger mode (Tr)
+## Tigger mode (Tr)
 
-When the **trigger mode** is enabled, an output A/B changes to +5V for 10ms every time they are activated by the corresponding Bernoulli gate.
+When the **trigger mode** is enabled, an output A/B changes to +5V for 10ms every time they are
+activated by the corresponding Bernoulli gate.
 
-### Gate mode/Latch mode (G)
+## Toggle mode (Tg)
+
+In **toggle mode**, the module associates the “heads” and “tails” outcomes to a different pair of
+decisions: “continue sending the trigger to the same output as before” and “send the trigger to the
+opposite output”. As a result, when the probability knob 1 is set to its maximum value, the trigger
+will alternate between outputs A and B.
+
+## Gate mode/Latch mode (G)
 
 When the **gate mode** is enabled, an output A/B stays at +5V until the other output gets activated.
-
-### Toggle mode (Tg)
-
-In **toggle mode**, the module associates the “heads” and “tails” outcomes to a different pair of decisions: “continue sending the trigger to the same output as before” and “send the trigger to the opposite output”. As a result, when the probability knob 1 is set to its maximum value, the trigger will alternate between outputs A and B.
-
-
-
-
-
-    digital in: trigger/clock
-    analogue in: probability control of gate 1 (summed with Knob 1)
-    knob 1: probability control of gate 1
-    knob 2: probability control of gate 2
-    button 1: mode switch of gate 1
-    button 2: mode switch of gate 2
-    cv1/cv2: output A/B of gate 1
-    cv4/cv5: output A/B of gate 2
-    cv3: copy of trigger/clock
-    cv6: logic AND of the two output A

--- a/software/contrib/bezier.md
+++ b/software/contrib/bezier.md
@@ -5,41 +5,45 @@ This script generates two random CV outputs using [Bezier curves](https://en.wik
 This work is inspired by the [ADDAC507](https://www.addacsystem.com/en/products/modules/addac500-series/addac507),
 a collaboration between ADDAC System and [Monotrail](https://youtu.be/9PxVmeMrOoQ?si=GsNDKNipjHtBIPT1)
 
-## Input & Output
+## Inputs & Outputs
 
-The module has two separate output channels, referred to as A and B. Each has identical controls, though channel B's
-controls can only be accessed by holding `b2`.  Note that when changing channels, the knobs will "lock" in their
-previous positions, so you may need to sweep the knob to unlock it.
+The module has two separate output channels, referred to as A and B. Each has identical controls,
+though channel B's controls can only be accessed by holding `b2`.  Note that when changing channels,
+the knobs will "lock" in their previous positions, so you may need to sweep the knob to unlock it.
 
 - `b1` -- press to change the clipping mode for both channels (see below)
 - `b2` -- hold to change `k1` and `k2` to channel B input
 
 - `k1` -- set the frequency of channel A or B
 - `k2` -- set the curve of channel A or B
-- `ain` -- configurable CV input to control either the frequency or curve (see below for how to set routing)
-- `din` -- on a rising edge, force channels A and B to choose new goal voltages. This will not generate an output gate
-   on `cv4` (see below), but may change the gate state on `cv5` and `cv6`.
+- `ain` -- configurable CV input to control either the frequency or curve (see below for how to set
+  routing)
+- `din` -- on a rising edge, force channels A and B to choose new goal voltages. This will not
+  generate an output gate on `cv4` (see below), but may change the gate state on `cv5` and `cv6`.
 
 - `cv1` -- CV output from channel A
 - `cv2` -- CV output from channel B
 - `cv3` -- the average of channel A and B CV outputs
 - `cv4` -- gate output of channel A
 - `cv5` -- gate output of channel B
-- `cv6` -- logic combination of gate outputs of channels A and B (see below for how to configure the logic mode)
+- `cv6` -- logic combination of gate outputs of channels A and B (see below for how to configure the
+  logic mode)
 
 Gate outputs are different for channels A and B:
-- Channel A (`cv4`) outputs a 10ms trigger every time a new sample is generated (determined by the frequency)
-- Channel B (`cv5`) is high whenever its voltage output is higher than 50%. e.g. if the range is set to 0-10V, `cv5`
-  will be high if `cv2` is 5V or more.
+- Channel A (`cv4`) outputs a 10ms trigger every time a new sample is generated (determined by the
+  frequency)
+- Channel B (`cv5`) is high whenever its voltage output is higher than 50%. e.g. if the range is set
+  to 0-10V, `cv5` will be high if `cv2` is 5V or more.
 
-Patching a clock/gate/trigger signal into `din` will force the output channels to choose a new goal voltage. This can
-(and frequently will) cause an abrupt change in the CV output of channels A and B, rather than the smoothly changing
+Patching a clock/gate/trigger signal into `din` will force the output channels to choose a new goal
+voltage. This can (and frequently will) cause an abrupt change in the CV output of channels A and B,
+rather than the smoothly changing
 voltages they normally output.
 
 ## Additional Configuration
 
-The script has additional parameters that can be set by manually editing/creating `/config/Bezier.json`. The default
-values for this file are below:
+The script has additional parameters that can be set by manually editing/creating
+`/config/Bezier.json`. The default values for this file are below:
 
 ```json
 {
@@ -55,38 +59,44 @@ The following fields may be set:
 
 - `MIN_VOLTAGE` -- the minimum voltage that channel A or channel B may output. Default: 0.0
 - `MAX_VOLTAGE` -- the maximum voltage that channel A or channel B may output. Default 10.0
-- `AIN_MODE` -- changes what parameter voltage to `ain` controls. Must be one of `curve` or `frequency`. Default: `frequency`
-- `LOGIC_MODE` -- sets the logical operation used to determine the gate output of `cv6`. Must be one of
-   `and`, `or`, `xor`, `nand`, `nor`, or `xnor`. Default: `xor`.
-- `MIN_FREQUENCY` -- the minumum frequency (Hz) for choosing new random values. Must be between 0.001 and 10.0. Default: 0.01
-- `MAX_FREQUENCY` -- the maximum frequency (Hz) for choosing new random values. Must be between 0.001 and 10.0. Default: 1.0
+- `AIN_MODE` -- changes what parameter voltage to `ain` controls. Must be one of `curve` or
+  `frequency`. Default: `frequency`
+- `LOGIC_MODE` -- sets the logical operation used to determine the gate output of `cv6`. Must be one
+  of `and`, `or`, `xor`, `nand`, `nor`, or `xnor`. Default: `xor`.
+- `MIN_FREQUENCY` -- the minumum frequency (Hz) for choosing new random values. Must be between
+  0.001 and 10.0. Default: 0.01
+- `MAX_FREQUENCY` -- the maximum frequency (Hz) for choosing new random values. Must be between
+  0.001 and 10.0. Default: 1.0
 - `MAX_INPUT_VOLTAGE` -- the maximum CV input voltage (default: 10.0)
 
 Note that the maximum and minimum voltages must be defined such that:
 - `MIN_VOLTAGE` is less than `MAX_VOLTAGE`
 - `MIN_VOLTAGE` and `MAX_VOLTAGE` are positive
-- `MIN_VOLTAGE` and `MAX_VOLTAGE` do not fall outside the range defined by the module's master configuration
+- `MIN_VOLTAGE` and `MAX_VOLTAGE` do not fall outside the range defined by the module's master
+  configuration
 - `MAX_INPUT_VOLTAGE` is less than the module's master configuration.
 
-See [Configuration](/software/CONFIGURATION.md) for more information on input & output voltage options for the
-entire module.
+See [Configuration](/software/CONFIGURATION.md) for more information on input & output voltage
+options for the entire module.
 
-If you plan on using CV to control Bezier, make sure you set the maximum input voltage according to your modules'
-output.  For example if you plan on connecting it to an LFO that outputs 0-5V, you may find it helpful to set the
-`MAX_INPUT_VOLTAGE` to `5.0` to allow the full modulation range.  If your LFO is bipolar (e.g. `+/-5V`), the input
-will be clamped at 0 as EuroPi does not support bipolar CV input.  In this case, the use of a voltage rectifier is
-recommended.
+If you plan on using CV to control Bezier, make sure you set the maximum input voltage according to
+your modules' output.  For example if you plan on connecting it to an LFO that outputs 0-5V, you may
+find it helpful to set the `MAX_INPUT_VOLTAGE` to `5.0` to allow the full modulation range.  If your
+LFO is bipolar (e.g. `+/-5V`), the input will be clamped at 0 as EuroPi does not support bipolar CV
+input.  In this case, the use of a voltage rectifier is recommended.
 
 ## Clipping mode
 
-The output can behave in one of 3 ways if the output wave moves outside the defined maximum/minimum voltage range:
+The output can behave in one of 3 ways if the output wave moves outside the defined maximum/minimum
+voltage range:
 - `limit` -- the output is clipped to the maximum/minimum value
 - `fold` -- the output is flipped such that the shape of the curve is reflected
 - `thru` -- the output wraps around through the opposite end of the range
 
 ## Curve Shapes
 
-The shape of the bezier curves is defined by the "curve constant" `k`. This value lies in the range `[-1, 1]`, and is
+The shape of the bezier curves is defined by the "curve constant" `k`. This value lies in the range
+`[-1, 1]`, and is
 interpreted as follows:
 - `0.0` -- linear interpolation between voltages
 - `k < 0` -- horizontal approach to each new voltage
@@ -95,16 +105,17 @@ interpreted as follows:
 The following image illustrates this concept, copied from the ADDAC507 manual:
 ![Bezier Curves](bezier-docs/curve-knob.png.png)
 
-Negative values of `k` will generally result in a smoother overall shape to the output voltage. Positive values will
-have more abrupt changes in voltage whenever a new goal value is generated.
+Negative values of `k` will generally result in a smoother overall shape to the output voltage.
+Positive values will have more abrupt changes in voltage whenever a new goal value is generated.
 
 ## CV Control
 
-If CV control is set to `frequency` (the default), `ain` will accept positive voltage, increasing the frequency of both
-channels as voltage increases.
+If CV control is set to `frequency` (the default), `ain` will accept positive voltage, increasing
+the frequency of both channels as voltage increases.
 
-If CV control is set to `curve`, `ain` will accept positive voltage, changing the curve constant of both channels. The
-channels' curve constants are set to the average between the knob value (`[-1, 1]`) and the CV value:
+If CV control is set to `curve`, `ain` will accept positive voltage, changing the curve constant of
+both channels. The channels' curve constants are set to the average between the knob value
+(`[-1, 1]`) and the CV value:
 - `0V` is equivalent to a curve constant of `-1`
 - `50%` of `MAX_INPUT_VOLTAGE` is equivalent to a curve constant of `0`
 - `100%` of `MAX_INPUT_VOLTAGE` is equivalent to a curve constant of `+1`

--- a/software/contrib/bit_garden.md
+++ b/software/contrib/bit_garden.md
@@ -1,14 +1,8 @@
 # Bit Garden - pseudo-random deterministic repeated triggers
 
-author: Adam Wonak (github.com/awonak)
-
-date: 2024-03-21
-
-labels: triggers, random
-
 Connect a trigger or gate source to the Digital input and the each output will
 mirror that signal according to a decreasing deterministic probability pattern
-set by the seed value. Use the Analog input as a trigger to get a new random 
+set by the seed value. Use the Analog input as a trigger to get a new random
 seed. From the main page, use the left knob adjust the pattern length. The
 right knob will scroll through each output to show the current trigger pattern
 for that output. Left button will change the cv output mode from Trigger

--- a/software/contrib/bouncing_pixels.md
+++ b/software/contrib/bouncing_pixels.md
@@ -1,11 +1,5 @@
 # Bouncing Pixels
 
-author: [Jorin](https://github.com/jorins)
-
-date: 2025-04-12
-
-labels: gates, random, simulation, triggers
-
 Pixels bounce around the display and trigger gates when hitting the edges.
 Inspired by the classic bouncing DVD logo!
 
@@ -41,7 +35,7 @@ One possible over and under speed behaviour is that pixels are deactivated.
 When deactivated, a pixel will not be processed or rendered until reset. Resets
 can be manually triggered by pressing B1 or using the digital input (must be
 configured). A reset is automatically triggered when all pixels in play are
-deactivated. 
+deactivated.
 
 ## Outputs
 
@@ -167,7 +161,7 @@ controller.
 ## Known issues & limitations
 
 * Gate lengths are not entirely precise. They're guaranteed to be at least the
-  set length, but they may exceed it slightly on account of running on 
+  set length, but they may exceed it slightly on account of running on
   tick-based timers.
 * Corners aren't actually corners, they're just the top and bottom most
   parts of the side edges. This means that if a pixel is traveling parallel and

--- a/software/contrib/clock_mod.md
+++ b/software/contrib/clock_mod.md
@@ -2,8 +2,9 @@
 
 This program performs clock multiplications and divisions based on an incoming gate signal on DIN.
 
-Each output is a multiple or a division of the incoming clock signal on `DIN`.  The duration of the output gates
-are not adjustable and are fixed to approximately a 50% duty cycle (some rounding will occur).
+Each output is a multiple or a division of the incoming clock signal on `DIN`.  The duration of the
+output gates are not adjustable and are fixed to approximately a 50% duty cycle (some rounding will
+occur).
 
 ## I/O Mapping
 
@@ -17,24 +18,25 @@ are not adjustable and are fixed to approximately a 50% duty cycle (some roundin
 | `k2`          | Clock modifier for CV4/5/6                                        |
 | `cv1-6`       | Multiplied/divided clock signals                                  |
 
-The outputs will begin firing automatically when clock signals are received on `din`, and will stop if the input
-signals are stopped for 5s or longer.  Upon stopping all output channels will reset.  (NOTE: this means the signal
-coming into `din` cannot be 0.2Hz or slower!)
+The outputs will begin firing automatically when clock signals are received on `din`, and will stop
+if the input signals are stopped for 5s or longer.  Upon stopping all output channels will reset.
+(NOTE: this means the signal coming into `din` cannot be 0.2Hz or slower!)
 
 Applying a signal of at least 0.8V to `ain` will reset all output channels.
 
 ## Persistence
 
-The clock modifiers for output channels 1 and 4 are read directly from the positions of `k1` and `k2` on startup.
-The modifiers for the other channels (2, 3, 5, and 6) are saved in a configuration file and will persist across
-restarts.
+The clock modifiers for output channels 1 and 4 are read directly from the positions of `k1` and
+`k2` on startup. The modifiers for the other channels (2, 3, 5, and 6) are saved in a configuration
+file and will persist across restarts.
 
 ## Note on Phase Alignment
 
-Changing the clock modifers while the module is running is possible, but can (and generally will) result in some
-phase-shifting of the outputs. e.g. if `cv1` and `cv2` are set to `x1`, changing `cv1` to `x2` and then back to `x1`
-will probably result in `cv1` and `cv2` no longer being synchronized.
+Changing the clock modifers while the module is running is possible, but can (and generally will)
+result in some phase-shifting of the outputs. e.g. if `cv1` and `cv2` are set to `x1`, changing
+`cv1` to `x2` and then back to `x1` will probably result in `cv1` and `cv2` no longer being
+synchronized.
 
-This can be mitigated either by not adjusting the clock modifers while the module is running, or by patching a reset
-signal into `ain` to force the module to re-synchronize periodically.  Alternatively, embrace the chaos and use the
-de-syncronization as a performance effect.
+This can be mitigated either by not adjusting the clock modifers while the module is running, or by
+patching a reset signal into `ain` to force the module to re-synchronize periodically.
+Alternatively, embrace the chaos and use the de-syncronization as a performance effect.

--- a/software/contrib/coin_toss.md
+++ b/software/contrib/coin_toss.md
@@ -1,12 +1,22 @@
 # Coin Toss
 
-author: awonak
-
-date: 03/01/22
-
-labels: Clock, Random, CV Generation
-
 Two pairs of clocked probability gates.
+
+## Inputs & Outputs
+
+Inputs:
+- `din`: External clock (when in external clock mode)
+- `ain`: Threshold control (summed with threshold knob)
+- `k1`: internal clock speed
+- `k2`: probability threshold
+- `b1`: toggle internal / external clock source
+- `b2`: toggle gate/trigger mode
+
+Outputs:
+- `cv1` & `cv2`: Coin 1 gate output pair when voltage above/below threshold
+- `cv3`: Coin 1 clock
+- `cv4` & `cv5`: Coin 2 gate output pair at 1/4x speed
+- `cv6`: Coin 2 clock
 
 Knob 1 adjusts the master clock speed of gate change probability. Knob 2 moves
 the probability thresholed between A and B with a 50% chance at noon. Output
@@ -15,23 +25,3 @@ row 1 (cv1 and cv2) run at 1x speed and output row 2 (cv4 and cv5) run at
 internal and external clock source. Push button 2 to toggle between gate and
 trigger mode. Analogue input is summed with the threshold knob value to allow
 external threshold control.
-
-    digital in: External clock (when in external clock mode)
-    analogue in: Threshold control (summed with threshold knob)
-    knob 1: internal clock speed
-    knob 2: probability threshold
-    button 1: toggle internal / external clock source
-    button 2: toggle gate/trigger mode
-    cv1/cv2: Coin 1 gate output pair when voltage above/below threshold
-    cv4/cv5: Coin 2 gate output pair at 1/4x speed
-    cv3: Coin 1 clock
-    cv6: Coin 2 clock
-
-For developing, I like to use Visual Studio Code as my IDE and `rshell` to copy
-and run my scripts.
-
-From the root dir of the repo, enter rshell:
-
-    $ rshell
-    > cp software/contrib/coin_toss.py /pyboard/main.py
-    > repl pyboard ~ import main

--- a/software/contrib/consequencer.md
+++ b/software/contrib/consequencer.md
@@ -1,14 +1,9 @@
 # EuroPi Consequencer - A 6-channel open source sequencer and random source power house!
 
-author: Nik Ansell (github.com/gamecat69)
-
-date: 2022-02-09
-
-labels: sequencer, gates, triggers, drums, randomness
-
-Consequencer is a gate and stepped CV sequencer inspired by Grids from Mutable Instruments and the randomness created by the Turing Machine.
-Pattern changes and randomness are introduced as a consequence of both manual input and control voltages sent to the analogue input.
-A large number of popular gate patterns are pre-loaded. Stepped CV sequences are automatically generated.
+Consequencer is a gate and stepped CV sequencer inspired by Grids from Mutable Instruments and the
+randomness created by the Turing Machine. Pattern changes and randomness are introduced as a
+consequence of both manual input and control voltages sent to the analogue input. A large number of
+popular gate patterns are pre-loaded. Stepped CV sequences are automatically generated.
 
 Both gate patterns and CV sequences can be smoothly morphed between without disrupting playback.
 Use outputs 1 - 3 for gates and outputs 4 - 6 for randomised stepped CV patterns.
@@ -24,7 +19,8 @@ Credits:
 
 Consequencer now includes the ability to add probability-based steps to patterns!
 You can use probability in patterns to add variabilty in interesting ways.
-Some example patterns have been included in this release and you can find instructions below in the "Advanced usage" section for adding your own.
+Some example patterns have been included in this release and you can find instructions below in the
+"Advanced usage" section for adding your own.
 
 You can easiliy identify steps within patterns that have a probability less than 100%.
 Normal steps are shown with a `^` character, whereas steps with a probability are shown with a `-`.
@@ -36,7 +32,8 @@ Normal steps are shown with a `^` character, whereas steps with a probability ar
 ## Inputs
 
 - digital_in: Clock in
-- analog_in: Mode 1: Adjusts randonmess, Mode 2: Selects gate pattern, Mode 3: Selects stepped CV pattern
+- analog_in: Mode 1: Adjusts randonmess, Mode 2: Selects gate pattern, Mode 3: Selects stepped CV
+  pattern
 
 ## Knobs
 
@@ -65,19 +62,25 @@ button_2:
 
 # Getting Started
 
-The following sections provide instructions for creating a simple 3 drum pattern with a kick, snare and hi-hat, then using random CV patterns to vary the timbre in each drum pattern.
-You can of course connect outputs 1 - 3 to any module which expects gates and outputs 4 - 6 to any module expecting a control voltage.
+The following sections provide instructions for creating a simple 3 drum pattern with a kick, snare
+and hi-hat, then using random CV patterns to vary the timbre in each drum pattern. You can of course
+connect outputs 1 - 3 to any module which expects gates and outputs 4 - 6 to any module expecting a
+control voltage.
 
 ## Basic Usage
 1. Connect a clock input to the Digital input
 2. Connect a Bass Drum to output 1, Snare to output 2 and Hi-hat to output 3
 3. Start your clock - a pattern will output gates on outputs 1 -3
-4. Select different patterns manually using knob 2 (right-hand knob). The selected pattern is shown visually on the screen.
+4. Select different patterns manually using knob 2 (right-hand knob). The selected pattern is shown
+   visually on the screen.
 
 ## Adding randomness
-1. A medium-press (>300ms and < 3000ms) and release of button 1 toggles on/off the real-time generation of a random gate pattern to output 3. A small filled rectangle is shown on the bottom left of the screen when this feature is active.
+1. A medium-press (>300ms and < 3000ms) and release of button 1 toggles on/off the real-time
+   generation of a random gate pattern to output 3. A small filled rectangle is shown on the bottom
+   left of the screen when this feature is active.
 2. Knob 1 increases or decreases the randomness of the patterns sent to outputs 1 -3
-3. Randomness can also be controlled by sending CV to the analogue input if analogInputMode 1 is selected (default).
+3. Randomness can also be controlled by sending CV to the analogue input if analogInputMode 1 is
+   selected (default).
 
 ## Using random CV from outputs 4 - 6
 
@@ -92,12 +95,13 @@ Example usage for these CV outputs, (this will depend on the inputs your drum mo
 - Kick decay
 - Kick accent
 - Send stepped CV into the cutoff frequencer of a VCF (Voltage Controlled Filter)
-- Send stepped CV into a quantizer, then feed the quantized output into a VCO (Voltage Controlled Oscillator)
+- Send stepped CV into a quantizer, then feed the quantized output into a VCO (Voltage Controlled
+  Oscillator)
 
 ## Selecting analogue input modes
 
-Consequencer can perform 3 different actions when a control voltage input is received at the analogue input.
-The current running mode is shown on the bottom right of the screen (e.g. Mr, Mp, Mc)
+Consequencer can perform 3 different actions when a control voltage input is received at the
+analogue input. The current running mode is shown on the bottom right of the screen (e.g. Mr, Mp, Mc)
 Cycle through the modes by long-pressing and releasing button 2. The following modes are available:
 
 - Mode 1 (Mr) : Control voltage adjusts randomness of the gate patterns sent to outputs 1 - 3
@@ -109,16 +113,21 @@ Cycle through the modes by long-pressing and releasing button 2. The following m
 1. Select analogInputMode 2 (Mr) using button 2.
 2. Send a control voltage into the analogue input
 
-A fixed voltage will select a single pattern and varying voltage (e.g. an envelope or LFO) will smoothly cycle through patterns.
+A fixed voltage will select a single pattern and varying voltage (e.g. an envelope or LFO) will
+smoothly cycle through patterns.
 
 # Grids Patterns
 
-The 25 different patterns from the Mutable Instruments Grids module were exported from the Grids code and added to the Consequencer.
+The 25 different patterns from the Mutable Instruments Grids module were exported from the Grids
+code and added to the Consequencer.
 
 Access the Grids patterns by holding button 2 for 3-5 seconds and releasing.
-When Grids mode is enabled, a period '.' is visible before the pattern number on the bottom right of the screen
+When Grids mode is enabled, a period '.' is visible before the pattern number on the bottom right of
+the screen
 
-Two different versions of each Grids pattern have been created. The first version (even numbers, including 0) are the equivalent of having all three Grids density knobs at 50%. The second version (odd numbers) are the equivalent of having all three Grids density knobs at 70%. An example is below:
+Two different versions of each Grids pattern have been created. The first version (even numbers,
+including 0) are the equivalent of having all three Grids density knobs at 50%. The second version
+(odd numbers) are the equivalent of having all three Grids density knobs at 70%. An example is below:
 
 - Pattern 0: Grids pattern 1, density: 50%
 - Pattern 1: Grids pattern 1, density: 70%
@@ -127,29 +136,40 @@ Two different versions of each Grids pattern have been created. The first versio
 
 # Screen saver
 
-To improve performance a little, a screen saver mode has been added which turns the screen off if the module has not been interacted with in 10 seconds. The screen saver is turned off as soon as an interaction occurs. Example interactions are knob movement and button presses.
+To improve performance a little, a screen saver mode has been added which turns the screen off if
+the module has not been interacted with in 10 seconds. The screen saver is turned off as soon as an
+interaction occurs. Example interactions are knob movement and button presses.
 
 # Advanced usage
 
 ## Adding / Removing / Updating Gate Patterns
 
-Patterns can be added, removed or updated by updating the relevant list structures at the end of the consequencer.py file in the pattern class (look for the line `class pattern:`). Once patterns are updated make sure you save a copy of the updated file to the EuroPi using yoru favourite method (Thonny / REPL), then restart the Consequencer script.
+Patterns can be added, removed or updated by updating the relevant list structures at the end of the
+consequencer.py file in the pattern class (look for the line `class pattern:`). Once patterns are
+updated make sure you save a copy of the updated file to the EuroPi using yoru favourite method
+(Thonny / REPL), then restart the Consequencer script.
 
-The syntax should be intuitive. An example pattern is shown below. Each `1` or `0` represents a gate or no gate at that point in the sequence.
+The syntax should be intuitive. An example pattern is shown below. Each `1` or `0` represents a gate
+or no gate at that point in the sequence.
 The mapping of `BD`, `SN`, `HH` is as follows:
 - BD: Output 1
 - SN: Output 2
 - HH: Output 3
 
-Starting with the July 2022 update, steps now also have a probability which is configured using the BdProb, SnProb and HhProb sections as shown below.
+Starting with the July 2022 update, steps now also have a probability which is configured using the
+BdProb, SnProb and HhProb sections as shown below.
 Use a value from `1` to `9` to set the desired level of probability for each step.
-A value of `9` will cause the step to trigger 100% of the time, any value from `1` to `8` will trigger the step from n/9 times.
+A value of `9` will cause the step to trigger 100% of the time, any value from `1` to `8` will
+trigger the step from n/9 times.
 
 You can also use shorthand to define probabilities, for example:
 
-- A single digit probability string is auto-populated for all values. e.g. a probability of `9` for an 8 step pattern will automatically become `99999999`
+- A single digit probability string is auto-populated for all values. e.g. a probability of `9` for
+  an 8 step pattern will automatically become `99999999`
 
-- A multi-digit probability string that is shorter in length than the pattern string is automatically filled with the last digit in the probability string. e.g. a probability of `9995` for an 8 step pattern will automatically become `99995555`.
+- A multi-digit probability string that is shorter in length than the pattern string is
+  automatically filled with the last digit in the probability string. e.g. a probability of `9995`
+  for an 8 step pattern will automatically become `99995555`.
 
 Example valid patterns and probability patterns are shown below.
 
@@ -172,10 +192,19 @@ Example valid patterns and probability patterns are shown below.
 
 ## Output clocks/gates on output 4
 
-The Consequencer has a small amount of latency between receiving a clock or gate at the digital input and sending out gates to the outputs. This may not be noticable depending on how you incorporate Consequencer into your patch. However, there is an option for Consequencer to send out gates on output which are perfectly in time with the sequence being played. This allows you to clock other modules using output 4.
+The Consequencer has a small amount of latency between receiving a clock or gate at the digital
+input and sending out gates to the outputs. This may not be noticable depending on how you
+incorporate Consequencer into your patch. However, there is an option for Consequencer to send out
+gates on output which are perfectly in time with the sequence being played. This allows you to clock
+other modules using output 4.
 
-To enable this feature hold down button 1 for longer than 3 seconds, then release the button. A small unfilled rectangle is shown on the bottom left of the screen when this feature is active. This visual indicator is on the right of the random hi-hat visual indicator (filled rectangle on the bottom left of the screen).
+To enable this feature hold down button 1 for longer than 3 seconds, then release the button. A
+small unfilled rectangle is shown on the bottom left of the screen when this feature is active. This
+visual indicator is on the right of the random hi-hat visual indicator (filled rectangle on the
+bottom left of the screen).
 
 # Known bugs / Interesting features
 
-A small amount of noise causes the analogue input to vary slightly. This can sometimes cause the randomness, gate pattern or stepped CV pattern to flicker between values. It happens only occassionally, but introduces an interesting and subtle variation to the sequence being played.
+A small amount of noise causes the analogue input to vary slightly. This can sometimes cause the
+randomness, gate pattern or stepped CV pattern to flicker between values. It happens only
+occassionally, but introduces an interesting and subtle variation to the sequence being played.

--- a/software/contrib/conway.md
+++ b/software/contrib/conway.md
@@ -83,7 +83,7 @@ Size 2: [-6, 6, -6, 6, -6, 6] -> 0.0, 6.0
 Size 3: [-2, -4, -6, 12]      -> 0.0, 7.071068
 Size 4: [0, 0, 0]             -> 0.0, 0.0
 ```
-we would assume we have reached stasis, as the mean and standard deviation of the size-3 buckets are less than 1.0.
+we would assume we have reached stasis, as the mean and standard deviation of the size-4 buckets are less than 1.0.
 
 ## LFO Rate Variablility
 

--- a/software/contrib/conway.md
+++ b/software/contrib/conway.md
@@ -1,20 +1,21 @@
 # John Conway's Game of LiFO
 
-This script implements [John Conway's Game Of Life](https://en.wikipedia.org/wiki/Conway%27s_Game_of_Life) as the
-procedural kernel for multiple LFOs.
+This script implements [John Conway's Game Of Life](https://en.wikipedia.org/wiki/Conway%27s_Game_of_Life)
+as the procedural kernel for multiple LFOs.
 
-The game is played on a 128x32 field (the size of the OLED). Every pixel is a cell. On every step an empty space will
-spawn a new cell if it has exactly 3 neighbours. Cells with 2 or 3 neighbours stay alive. Cells with 1 or 0 neighbours
-die of loneliness. Cells with 4 or more neighbours die of overcrowding.
+The game is played on a 128x32 field (the size of the OLED). Every pixel is a cell. On every step an
+empty space will spawn a new cell if it has exactly 3 neighbours. Cells with 2 or 3 neighbours stay
+alive. Cells with 1 or 0 neighbours die of loneliness. Cells with 4 or more neighbours die of
+overcrowding.
 
 This program acts as a free-running LFO; it is not clockable externally.
 
-On every step, a number of random new cells will also spawn, based on the CV input provided on `ain`. `k2` acts
-as an attenuator for the signal on `ain`.
+On every step, a number of random new cells will also spawn, based on the CV input provided on
+`ain`. `k2` acts as an attenuator for the signal on `ain`.
 
-## I/O Mapping
+## Inputs
 
-| I/O           | Usage
+| Input         | Usage                                                             |
 |---------------|-------------------------------------------------------------------|
 | `din`         | Clear the field & start a new random spawn                        |
 | `ain`         | Offset control for spawn density                                  |
@@ -22,35 +23,38 @@ as an attenuator for the signal on `ain`.
 | `b2`          | Manual equivalent to `din`                                        |
 | `k1`          | Base spawn density                                                |
 | `k2`          | Attenuverter for `ain`                                            |
-| `cv1` - `cv6` | Output signals. See below for details                             |
 
 ## Outputs
 
-The six outputs are stepped CV outputs, whose values vary according to the game state.
+| Output | Description                                                                                                  |
+|--------|--------------------------------------------------------------------------------------------------------------|
+| `cv1`  | 0-10V depending on the Shannon entropy of the entire field                                                   |
+| `cv2`  | 0-10V depending on the ratio between the number of births and the total population of the current generation |
+| `cv3`  | 0-10V depending on the ratio between the number of births and the number of deaths in the current generation |
+| `cv4`  | 5V trigger when every generation is computed                                                                 |
+| `cv5`  | 5V gate if the number of births in the current generation was greater than the number of deaths              |
+| `cv6`  | 5V trigger if the field has reached a point of stasis (see below)                                            |
 
-- `cv1`: outputs 0-10V depending on the Shannon entropy of the entire field
-- `cv2`: outputs 0-10V depending on the ratio between the number of new births and the current population
-- `cv3`: outputs 0-10V depending on the ratio between the number of births and the number of deaths in the
-         latest generation
-- `cv4`: outputs a 5V gate every generation
-- `cv5`: outputs a 5V gate signal if the number of births in the last generation was greater than the number
-         of deaths
-- `cv6`: outputs a 5V trigger if the field has reached a point of stasis
+If global voltage limits [have been changed](../CONFIGURATION.md) then those limits will be used
+instead of the 10V or 5V values described above.
 
 ## Stasis Detection
 
-Because of the modest computing power available, this program uses some simple statistics to infer if the game has
-reached a point of stasis. There is a chance that false-positives and false-negatives can be detected.
+Because of the modest computing power available, this program uses some simple statistics to infer
+if the game has reached a point of stasis. There is a chance that false-positives and
+false-negatives can be detected.
 
-When the game is believed to have reached a state of stasis it will automatically reset, as if a signal had been
-detected on `din`.  The field will clear and be filled with random data with a density governed by `ain`, `k1`, and
+When the game is believed to have reached a state of stasis it will automatically reset, as if a
+signal had been detected on `din`.  The field will clear and be filled with random data with a
+density governed by `ain`, `k1`, and
 `k2`.
 
 The game is assumed to have reached a state of stasis under these conditions:
-1. At least 12 generations have passed since the last reset
-2. The number of game spaces that have changed from dead to alive or alive to dead is equal to zero OR
-3. The sum of population changes in groups of 2, 3, or 4 generations has a standard deviation of 1.0 or less
-   and the absolute value of the mean of the group is less than 1.0.
+1. at least 12 generations have passed since the last reset, and one of
+2. the number of game spaces that have changed from dead to alive or alive to dead is equal to
+   zero, or
+3. The sum of population changes in groups of 2, 3, or 4 generations has a standard deviation of
+   1.0 or less and the absolute value of the mean of the group is less than 1.0.
 
 To better-explain 3, consider the following 12 generations' of population changes:
 ```
@@ -72,8 +76,8 @@ Size 3: -3.25, 18.08833
 Size 4: -4.333, 9.672412
 ```
 
-In this case none of the standard deviations nor means have a magnitude smaller than 1, so the system is not
-considered to be in stasis.
+In this case none of the standard deviations nor means have a magnitude smaller than 1, so the
+system is not considered to be in stasis.
 
 Conversely, given these population changes:
 ```
@@ -83,20 +87,23 @@ Size 2: [-6, 6, -6, 6, -6, 6] -> 0.0, 6.0
 Size 3: [-2, -4, -6, 12]      -> 0.0, 7.071068
 Size 4: [0, 0, 0]             -> 0.0, 0.0
 ```
-we would assume we have reached stasis, as the mean and standard deviation of the size-4 buckets are less than 1.0.
+we would assume we have reached stasis, as the mean and standard deviation of the size-4 buckets are
+less than 1.0.
 
 ## LFO Rate Variablility
 
-Because of the implementation of Conway's Game of Life, when the field is densely-populated, e.g. immediately after a
-reset with a high spawn rate, the outputs will change relatively slow.  As cells die off and the field becomes more
-sparse the rate will increase.  This is normal.
+Because of the implementation of Conway's Game of Life, when the field is densely-populated,
+e.g. immediately after a reset with a high spawn rate, the outputs will change relatively slow.  As
+cells die off and the field becomes more sparse the rate will increase.  This is normal.
 
 ## Patch Ideas
 
-You can patch an external LFO into DIN to periodically reset the simulation before it reaches a state of stasis.
+You can patch an external LFO into DIN to periodically reset the simulation before it reaches a
+state of stasis.
 
-You can create interesting feedback by patching `cv1`-`cv3` into `ain` and using the gate/trigger signals from
-`cv4`-`cv6` to control the simulation reset rate & reset density.
+You can create interesting feedback by patching `cv1`-`cv3` into `ain` and using the gate/trigger
+signals from `cv4`-`cv6` to control the simulation reset rate & reset density.
 
-If the variation in the LFO rate causes problems you can take the outputs from Conway and connect them to an
-externally-clocked Sample & Hold module. This will smooth out the changes in the update frequency of Conway.
+If the variation in the LFO rate causes problems you can take the outputs from Conway and connect
+them to an externally-clocked Sample & Hold module. This will smooth out the changes in the update
+frequency of Conway.

--- a/software/contrib/cvecorder.md
+++ b/software/contrib/cvecorder.md
@@ -1,65 +1,76 @@
-# EuroPi CVecorder - An open-source 6-bank, 6-channel CV recorder and playback module
+# CVecorder
 
-CVecorder ("Sveecorder")
+CVecorder ("Sveecorder") is a 6 bank, 6 channel CV recording and playback program that runs on the
+EuroPi from [Allen-Synthesis](https://github.com/Allen-Synthesis/EuroPi). It can be used to control
+the CV of any module in a really fine-grained way, rather than spending time creating CV patterns
+with sequencers, envelopes or LFOs, you simply record the exact CV pattern you want and have this
+played back into your modules.
 
-author: Nik Ansell (github.com/gamecat69)
+Also, because CVecorder has 6 banks you can record 6 different variations of 6 channels of CV, then
+smoothly change between them during a performance without skipping a beat!
 
-date: 2022-04-13
-
-labels: sequencer, CV, performance
-
-CVecorder is a 6 bank, 6 channel CV recording and playback program that runs on the EuroPi from [Allen-Synthesis](https://github.com/Allen-Synthesis/EuroPi). It can be used to control the CV of any module in a really fine-grained way, rather than spending time creating CV patterns with sequencers, envelopes or LFOs, you simply record the exact CV pattern you want and have this played back into your modules.
-
-Also, because CVecorder has 6 banks you can record 6 different variations of 6 channels of CV, then smoothly change between them during a performance without skipping a beat!
-
-Note, due to limitations in the Raspberry Pi pico (the hardware running behind the EuroPi), only positive CV can be recorded and played back.
+Note, due to limitations in the Raspberry Pi pico (the hardware running behind the EuroPi), only
+positive CV can be recorded and played back.
 
 Demo video: https://youtu.be/Crj0P7pr2YA
 
-# Controls and Display
+## Controls and Display
 
 ![Operating Diagram](./cvecorder-docs/cvecorder.png)
 
-# Getting Started
+## Getting Started
 
 The following sections provide instructions for recording and playing back CV using CVecorder.
 
-## Initial Connections
+### Initial Connections
 1. Connect a 50% duty cycle gate input to the Digital input
 2. Connect a CV source to the analogue input (0 to +5V works best)
 3. Connect each output (1 to 6) to modules you want to send CV to
 
-## Recording and Playing back CV
+### Recording and Playing back CV
 CVecorder records CV using the following format:
 - Each CV channel records a total of 64 CV values (samples).
-- Two CV samples are recorded for each received gate. One sample is captured on the rising edge, another on the falling edge.
+- Two CV samples are recorded for each received gate. One sample is captured on the rising edge,
+  another on the falling edge.
 - Each CV channel is looped with every 32nd gate into the Digital input.
-- Each CV sample is captured with a resolution of 0 - 9.99, providing a resolution of 1000 potential CV values to record.
-- Each CV channel relates directly to each output. CV channel 1 sends the recorded CV to output 1, CV channel 2 to output 2 and so on.
-- There are 6 banks of 6 CV channels, allowing you to record 6 variations of CV recordings in each bank and move smoothly between them during a performance.
+- Each CV sample is captured with a resolution of 0 - 9.99, providing a resolution of 1000 potential
+  CV values to record.
+- Each CV channel relates directly to each output. CV channel 1 sends the recorded CV to output 1,
+  CV channel 2 to output 2 and so on.
+- There are 6 banks of 6 CV channels, allowing you to record 6 variations of CV recordings in each
+  bank and move smoothly between them during a performance.
 
 To record and playback CV:
-1. Send a 50% duty cycle gate to the Digital input, this will automatically start the CVecorder. You will see this on the display on the bottom left-hand side.
+1. Send a 50% duty cycle gate to the Digital input, this will automatically start the CVecorder. You
+   will see this on the display on the bottom left-hand side.
 2. Select the required bank using knob 1
 3. Select the required channel using button 2
-4. Press button 1 to queue CV recording to the selected bank:channel. You will see indicator at the bottom of the screen change to '. .' , CV recording will start at the beginning of the CV channel. 'REC' will be displayed when recording has started.
+4. Press button 1 to queue CV recording to the selected bank:channel. You will see indicator at the
+   bottom of the screen change to '. .' , CV recording will start at the beginning of the CV
+   channel. 'REC' will be displayed when recording has started.
 5. At the end of the channel, the recorded CV is output from the corresponding output.
 6. Select the next required CV channel using button 2, then repeat step 4.
-7. Once you have everything the way you want it on bank 1, select the next bank using knob 1 and record your next set of 6 CV channels to the next bank.
-8. During your performance, you can move smoothly between each CV bank using knob 1. This allows you to switch between 6 variations of CV to all 6 outputs.
+7. Once you have everything the way you want it on bank 1, select the next bank using knob 1 and
+   record your next set of 6 CV channels to the next bank.
+8. During your performance, you can move smoothly between each CV bank using knob 1. This allows you
+   to switch between 6 variations of CV to all 6 outputs.
 
-# Saving CV between power cycles
-Every time you record a new CV channel, CV is automatically saved to local storage on the Raspberry Pi pico. This means that you can power off your module at any time (other than during the recording of a channel) and it will always be available when you power back up.
+## Saving CV between power cycles
+Every time you record a new CV channel, CV is automatically saved to local storage on the Raspberry
+Pi pico. This means that you can power off your module at any time (other than during the recording
+of a channel) and it will always be available when you power back up.
 
-To overwrite saved CV simply record over it. However, if you would prefer to clear an entire bank or all banks use button 2 - see 'Clearing banks' for more info.
+To overwrite saved CV simply record over it. However, if you would prefer to clear an entire bank or
+all banks use button 2 - see 'Clearing banks' for more info.
 
-## Clearing banks and channels
-If you want to update the CV recorded into a channel, simply record over it. To clear a bank, repeat this process for all channels in the bank.
-However, if you would rather clear a channel completely hit record and send no CV into the channel during the recording period.
+### Clearing banks and channels
+If you want to update the CV recorded into a channel, simply record over it. To clear a bank, repeat
+this process for all channels in the bank. However, if you would rather clear a channel completely
+hit record and send no CV into the channel during the recording period.
 
-# Patching ideas
+## Patching ideas
 
-## Painting quantized melodies
+### Painting quantized melodies
 
 This patch allows you to paint melodies using a CV source like a joystick.
 CV is recorded and played back by the CVecorder, which is quantized to scale and sent to a VCO.
@@ -69,10 +80,12 @@ CV is recorded and played back by the CVecorder, which is quantized to scale and
 
 If your quantizer has a trigger input:
 
-3. Mult / Divide the gate input and connect to the quantizer trigger input. This will sample CV from the CVecorder each time it receives a gate
+3. Mult / Divide the gate input and connect to the quantizer trigger input. This will sample CV from
+   the CVecorder each time it receives a gate
 4. Connect CVecorder output 1 to the quantizer input
 5. Connect the quantizer output to a VCO
-6. Play around with subtle movements on your CV controller and hear the melodies come out of your VCO!
+6. Play around with subtle movements on your CV controller and hear the melodies come out of your
+   VCO!
 
 If your quantizer has no trigger input:
 
@@ -81,20 +94,24 @@ If your quantizer has no trigger input:
 5. Connect the sample and hold output the quantizer input
 6. Connect the quantizer output to a VCO
 
-## Extreme FX control
+### Extreme FX control
 
-This patch provides super-granular control of FX modules, allowing you to control the value of each FX parameter up to two times with each clock cycle. Doing this can create both smooth and whacky FX changes.
+This patch provides super-granular control of FX modules, allowing you to control the value of each
+FX parameter up to two times with each clock cycle. Doing this can create both smooth and whacky FX
+changes.
 
 1. Connect a 50% duty cycle gate to the Digital input
 2. Connect a CV source to the analogue input (0 to +5V works best) for example a joystick
 3. Connect each of the outputs to parameters on your FX module
-4. Play around with different combinations of CV across the different channels to have fine-grained control of your FX CV parameters
+4. Play around with different combinations of CV across the different channels to have fine-grained
+   control of your FX CV parameters
 
-## Creating percussion variations
+### Creating percussion variations
 
 This patch allows you to add interesting variations to your percussion.
 
 1. Connect a 50% duty cycle gate to the Digital input
 2. Connect a CV source to the analogue input (0 to +5V works best) for example a joystick
-3. Connect each of the outputs to parameters on your percussion modules, for example connect to inputs that control pitch, accents, timbre or sample.
+3. Connect each of the outputs to parameters on your percussion modules, for example connect to
+   inputs that control pitch, accents, timbre or sample.
 4. Play around with different combinations - if it sounds good stick with it!

--- a/software/contrib/daily_random.md
+++ b/software/contrib/daily_random.md
@@ -20,7 +20,7 @@ Generates pseudo-random gate and CV patterns based on the current date and time.
 ## Required Hardware
 
 This script _can_ be used on a normal EuroPi, but will result in highly predictable
-patterns. For best result, connect a Realtime Clock (RTC) to EuroPi's secondary I2C
+patterns. For best results, connect a Realtime Clock (RTC) to EuroPi's secondary I2C
 header pins, located on the underside of the board.
 
 See [Realtime Clock Installation](/software/realtime_clock.md) for instructions on

--- a/software/contrib/dfam.md
+++ b/software/contrib/dfam.md
@@ -1,7 +1,8 @@
 # DFAM Controller
 
-This program is intended to be used with the Moog DFAM semi-modular. It allows for sequences less than
-8 steps long to be played and features a fast-reset button and reset input
+This program is intended to be used with the [Moog DFAM](https://www.moogmusic.com/synthesizers/dfam-drummer-another-mother/)
+semi-modular instrument. It allows for sequences less than 8 steps long to be played and features a
+fast-reset button and reset input.
 
 ## I/O Mapping
 
@@ -24,16 +25,16 @@ This program is intended to be used with the Moog DFAM semi-modular. It allows f
 
 Connect your clock source or square LFO to `din` and connect `cv1` to DFAM's `ADV/CLOCK` input.
 
-Optionally, connect a reset source to `ain` to automatically reset EuroPi and DFAM (e.g. a clock-stop signal
-from [`Pam's Workout`](/software/contrib/pams.md)).
+Optionally, connect a reset source to `ain` to automatically reset EuroPi and DFAM (e.g. a
+clock-stop signal from [`Pam's Workout`](/software/contrib/pams.md)).
 
 ## Preparing DFAM
 
 Patch EuroPi and DFAM as described above.
 
-Manually advance DFAM so the last sequence LED is
-illuminated. Then start DFAM by pressing the Start/Stop button. DFAM will now automatically
-advance every time a pulse is sent from `cv1` of EuroPi
+Manually advance DFAM so the last sequence LED is illuminated. Then start DFAM by pressing the
+Start/Stop button. DFAM will now automatically advance every time a pulse is sent from `cv1` of
+EuroPi.
 
 ## A Note on DFAM's Sequencer
 

--- a/software/contrib/dscn2.md
+++ b/software/contrib/dscn2.md
@@ -1,7 +1,7 @@
 # DCSN-2
 
-DSCN-2 is a loopable, random gate sequencer based on a binary tree. An incoming clock signal is routed to
-one of two child nodes, and from there to one of four grandchild nodes.
+DSCN-2 is a loopable, random gate sequencer based on a binary tree. An incoming clock signal is
+routed to one of two child nodes, and from there to one of four grandchild nodes.
 
 Inspired by the [Robaux DCSN3](https://robaux.io/products/dcsn3).
 
@@ -24,8 +24,8 @@ Inspired by the [Robaux DCSN3](https://robaux.io/products/dcsn3).
 
 ## Operation
 
-Every time a clock signal is received on `DIN` the one child & one grandchild output is turned on; all other
-outputs are turned off.  Depending on the randomness the pattern of gates will be looped, fully random, or
-somewhere in between
+Every time a clock signal is received on `DIN` the one child & one grandchild output is turned on;
+all other outputs are turned off.  Depending on the randomness the pattern of gates will be looped,
+fully random, or somewhere in between
 
 The pulse width of the outputs is determined by the pulse width of the input clock.

--- a/software/contrib/egressus_melodiam.md
+++ b/software/contrib/egressus_melodiam.md
@@ -1,91 +1,107 @@
-# Egressus Melodiam (Stepped Melody)
+# Egressus Melodiam
 
-author: Nik Ansell (github.com/gamecat69)
-date: 19-Feb-24
-labels: clocked lfo, sequencer, CV, randomness
-Demo Video: https://youtu.be/_qlnV_ewb_c
+Egressus Melodiam ("Stepped Melody") is a clockable and free-running LFO and random CV pattern
+generator. Eight different wave shapes either define the LFO shape or the slew shape between CV
+pattern steps. Use it to generate variable length melodies (using a quantizer), LFOs or weird and
+wonderful control voltages.
 
-Clock-able and free-running LFO and random CV pattern generator.
-Eight different wave shapes either define the LFO shape or the slew shape between CV pattern steps.
-Use it to generate variable length melodies (using a quantizer), LFOs or weird and wonderful control voltages.   
+## Demo Video
 
-# Inputs, Outputs and Controls
+https://youtu.be/_qlnV_ewb_c
+
+
+## Inputs, Outputs and Controls
 
 ![Operating Diagram](./egressus_melodiam-docs/egressus_melodiam.png)
 
-Analogue outputs send a voltage from 0V to the maximum configured output voltage (MAX_OUTPUT_VOLTAGE) as defined by europi_config.
-The default maximum output voltage is +10V.
+Analogue outputs send a voltage from 0V to the maximum configured output voltage
+(`MAX_OUTPUT_VOLTAGE`) as defined by europi_config. The default maximum output voltage is +10V.
 
-# Getting started
+## Getting started
 
-1. Patch a 50% duty cycle square wave or clock with pulses >= 16ms in duration into the digital input
+1. Patch a 50% duty cycle square wave or clock with pulses >= 16ms in duration into the digital
+   input
 2. Connect one or more outputs to an input on another module (e.g. CV modulation inputs)
 3. Select a pattern length using Knob 1
 4. Start your clock. Each output will now send a looping CV pattern to your module!
 
-So, what happened in the above example?
-When the module first powered on it automatically generated 6 x 32 step random CV patterns - one for each of the 6 outputs.
-Each time a clock is received, the step advances by one step and then loops when it get to the end of the pattern.
-The length of the pattern loop is controlled using knob 1, which supports a value from 1 to 32.
+So, what happened in the above example? When the module first powered on it automatically generated
+6 x 32 step random CV patterns - one for each of the 6 outputs. Each time a clock is received, the
+step advances by one step and then loops when it get to the end of the pattern. The length of the
+pattern loop is controlled using knob 1, which supports a value from 1 to 32.
 
-# Changing the slew/wave shape and clock division of an output
+## Changing the slew/wave shape and clock division of an output
 
 Refer to the above diagram for a visual representation of the example below.
 
-1. Press and release button 2 until the output number you would like to edit is shown on the top-right.
+1. Press and release button 2 until the output number you would like to edit is shown on the
+   top-right.
 2. Press button 1 to cycle through the available wave shapes
-3. Adjust knob 2 to select the output division. An output division of 1 causes the CV pattern / LFO for that
-output to run at the clock rate. An output division greater than one reduces the CV pattern / LFO to run at the selected division (e.g. selecting a division of 2 would run at half the clock rate)
+3. Adjust knob 2 to select the output division. An output division of 1 causes the CV pattern / LFO
+   for that output to run at the clock rate. An output division greater than one reduces the CV
+   pattern / LFO to run at the selected division (e.g. selecting a division of 2 would run at half
+   the clock rate)
 
-In LFO mode (pattern length of 1) the wave shape determines the shape of the cycling LFO. However, when in CV pattern mode (Pattern length > 1) the wave shape determines the slew between pattern steps.
+In LFO mode (pattern length of 1) the wave shape determines the shape of the cycling LFO. However,
+when in CV pattern mode (Pattern length > 1) the wave shape determines the slew between pattern
+steps.
 
-## Available Slew/wave shapes
+### Available Slew/wave shapes
 
-Eight shapes are available. Some are symmetrical where the rising shape is the same as the falling shape, others are asymmetrical.
+Eight shapes are available. Some are symmetrical where the rising shape is the same as the falling
+shape, others are asymmetrical.
 
-- [<img src="./egressus_melodiam-docs/square.png" width="15"/>](square.png) **Square/Step**: Moves up/down immediately and holds until the next step
-- [<img src="./egressus_melodiam-docs/tri.png" width="15"/>](tri.png) **Triangle/Linear**: A straight line between steps
-- [<img src="./egressus_melodiam-docs/sine.png" width="15"/>](sine.png) **Sine/Smooth**: A smooth line between steps using a sine/cosine wave
-- [<img src="./egressus_melodiam-docs/exp-up-exp-down.png" width="15"/>](exp-up-exp-down.png) **Exponential up and down**: An exponential curve between steps. This rises/falls slowly at the start and fast at the end
-- [<img src="./egressus_melodiam-docs/sharktooth.png" width="15"/>](sharktooth.png) **Sharktooth**: Logarithmic rise, exponential fall. A logarithmic curve rises/falls quickly at the start and slowly at the end.
-- [<img src="./egressus_melodiam-docs/sharktooth-rev.png" width="15"/>](sharktooth-rev.png) **Reverse Sharktooth**: Exponential rise, Logarithmic fall.
-- [<img src="./egressus_melodiam-docs/log-up-step-down.png" width="15"/>](log-up-step-down.png) **Logarithmic up, step down**: Upward transitions are logarithmic, downward transitions are stepped.
-- [<img src="./egressus_melodiam-docs/square-up-exp-down.png" width="15"/>](square-up-exp-down.png) **Step up, exponential down**: Upward transitions are stepped, downward transitions are exponential.
+- [<img src="./egressus_melodiam-docs/square.png" width="15"/>](square.png) **Square/Step**: Moves
+  up/down immediately and holds until the next step
+- [<img src="./egressus_melodiam-docs/tri.png" width="15"/>](tri.png) **Triangle/Linear**: A
+  straight line between steps
+- [<img src="./egressus_melodiam-docs/sine.png" width="15"/>](sine.png) **Sine/Smooth**: A smooth
+  line between steps using a sine wave
+- [<img src="./egressus_melodiam-docs/exp-up-exp-down.png" width="15"/>](exp-up-exp-down.png)
+  **Exponential up and down**: An exponential curve between steps. This rises/falls slowly at the
+  start and fast at the end
+- [<img src="./egressus_melodiam-docs/sharktooth.png" width="15"/>](sharktooth.png) **Sharktooth**:
+  Logarithmic rise, exponential fall. A logarithmic curve rises/falls quickly at the start and
+  slowly at the end.
+- [<img src="./egressus_melodiam-docs/sharktooth-rev.png" width="15"/>](sharktooth-rev.png)
+  **Reverse Sharktooth**: Exponential rise, Logarithmic fall.
+- [<img src="./egressus_melodiam-docs/log-up-step-down.png" width="15"/>](log-up-step-down.png)
+  **Logarithmic up, step down**: Upward transitions are logarithmic, downward transitions are
+  stepped.
+- [<img src="./egressus_melodiam-docs/square-up-exp-down.png" width="15"/>](square-up-exp-down.png)
+  **Step up, exponential down**: Upward transitions are stepped, downward transitions are
+  exponential.
 
-# Generating a new CV pattern for an output
+## Generating a new CV pattern for an output
 
-A new CV pattern is generated for the selected output by holding down button 1 for 2 seconds and releasing. An indicator is shown on the top left of the screen to show a new CV pattern has been generated. Note that if you are in LFO mode (pattern length of 1) this function will have no effect until the pattern length is increased. 
+A new CV pattern is generated for the selected output by holding down button 1 for 2 seconds and
+releasing. An indicator is shown on the top left of the screen to show a new CV pattern has been
+generated. Note that if you are in LFO mode (pattern length of 1) this function will have no effect
+until the pattern length is increased.
 
-# LFO Mode / CV Pattern mode
+## LFO Mode / CV Pattern mode
 
 Selecting a pattern length of 1 will output an LFO.
 Selecting a pattern length greater than one plays through the generated CV patterns.
 Slew is generated between CV pattern steps when a wave shape other then square is selected.
 
-# Clocked / Free-running mode
+## Clocked / Free-running mode
 
-Clocked mode is selected by default - indicated by showing the length of the CV pattern (in dots) in the middle of the screen.
-To enter free-running mode, hold button 2 for 2 seconds and release. The configured clock rate in milliseconds is shown
+Clocked mode is selected by default - indicated by showing the length of the CV pattern (in dots)
+in the middle of the screen. To enter free-running mode, hold button 2 for 2 seconds and release.
+The configured clock rate in milliseconds is shown
 in the middle of the screen to indicate you are in free-running mode.
 
-Note that when in free-running mode, the previously selected pattern length remains unchanged, it is therefore a good idea to select the required pattern length before changing to unclocked mode.
+Note that when in free-running mode, the previously selected pattern length remains unchanged, it
+is therefore a good idea to select the required pattern length before changing to unclocked mode.
 
-# Saving and loading
+## Saving and loading
 
-All settings and CV patterns are saved when changes are made and will not be lost when the module is powered off.
+All settings and CV patterns are saved when changes are made and will not be lost when the module
+is powered off.
 
-# Changing the maximum CV voltage
+## Changing the maximum CV voltage
 
 CV Patterns (including LFOs) output a range of 0-10V based on the default globally configured value.
-If you would like to change this value, two methods are available 1) Create a json file (see below), 2) Configure the global configuration value using the UI (coming soon in a later firmware release).
-
-## Reducing the maximum CV output using a json file
-
-1. Create a file on your pico named `config/config_EuroPiConfig.json`. Thonny is the easiest method for this.
-2. Add the following to the json file:
-
-```json
-{
-    "max_output_voltage": 5
-}
-```
+If you would like to change this value, see [configuration](../CONFIGURATION.md#io-voltage) for
+details on changing EuroPi's output voltages.

--- a/software/contrib/envelope_generator.md
+++ b/software/contrib/envelope_generator.md
@@ -1,14 +1,10 @@
 # Envelope Generator
 
-author: Rory Allen
+A simple one channel envelope generator with exponential attack and decay, sustain option, and
+looping capability.
 
-date: 2023-04-11
+## Inputs and Outputs
 
-labels: utility
-
-A simple one channel envelope generator with exponential attack and decay, sustain option, and looping capability
-
-Inputs and Outputs:
 - **digital in:** trigger an envelope
 - **analog in:** added to knob 2 to determine fall time
 - **button 1:** change sustain mode between AR (Attack Release) and ASR (Attack Sustain Release)

--- a/software/contrib/envelope_generator.md
+++ b/software/contrib/envelope_generator.md
@@ -18,9 +18,9 @@ looping capability.
 - **cv 5:** a 10ms end-of-rise trigger
 - **cv 6:** a 10ms end-of-fall trigger
 
-The 10ms end-of-rise trigger will fire every time the envelope transitions from the rising to either the
-falling or sustain states. This can occur as a result of the incoming gate signal dropping low while a slow rise
-is still being processed.
+The 10ms end-of-rise trigger will fire every time the envelope transitions from the rising to either
+the falling or sustain states. This can occur as a result of the incoming gate signal dropping low
+while a slow rise is still being processed.
 
-The 10ms end-of-fall trigger will only fire if the full duration of the fall portion is reached; if the envelope
-is re-triggered before the fall completes, this trigger will _not_ fire.
+The 10ms end-of-fall trigger will only fire if the full duration of the fall portion is reached; if
+the envelope is re-triggered before the fall completes, this trigger will _not_ fire.

--- a/software/contrib/euclid.md
+++ b/software/contrib/euclid.md
@@ -1,8 +1,7 @@
 # Euclid
 
-This script generates six different Euclidean rhythms, one
-on each output. The length, number of steps, and rotation
-of each pattern can be independently adjusted.
+This script generates six different Euclidean rhythms, one on each output. The length, number of
+steps, and rotation of each pattern can be independently adjusted.
 
 ## I/O Assignments
 

--- a/software/contrib/gate_phaser.md
+++ b/software/contrib/gate_phaser.md
@@ -1,52 +1,49 @@
 # Gate Phaser
 
-author: Nik Ansell (github.com/gamecat69)
+_What would [Steve Reich](https://en.wikipedia.org/wiki/Steve_Reich) do if he had a EuroPi?_
 
-date: May 2024
+Gate Phaser creates 6 gates that drift in and out of phase with each other over time.
 
-labels: sequencer, gates
+You can use this script to create Piano Phase type patches, dynamic rhythms which evolve over time
+and eventually resolve back in phase, or... well lots of other things that would benefit from
+having gates which are delayed from each other.
 
-A script which attempts to answer the question "What would Steve Reich do if he had a EuroPi?".
+## Demo Video
 
-Gates are sent from outputs 1-6 which are offset (or out of phase) with each other. This creates a group of gates that drift in and out of phase with each other over time.
+https://www.youtube.com/watch?v=fnpH8Q6sxIM
 
-You can use this script to create Piano Phase type patches, dynamic rhythms which evolve over time and eventually resolve back in phase, or ... well lots of other things that would benefit from having gates which are delayed from each other.
-
-Demo Video: https://www.youtube.com/watch?v=fnpH8Q6sxIM
-
-# Inputs, Outputs and Controls
+## Inputs, Outputs and Controls
 
 ![Operating Diagram](./gate_phaser-docs/gate_phaser.png)
 
-digital input: reset
-anaologue input: not used
+- `din`: reset
+- `ain`: not used
+- `k1`: adjust cycle time in milliseconds
+- `k2`: adjust gate delay time in milliseconds
+- `b1`: cycle through gate delay multiple options
+- `b2`: change the behaviour of knob2 (x5, x10, x20)
+- `cv1`-`cv6`: output gates
 
-knob_1: adjust cycle time in milliseconds
-knob_2: adjust gate delay time in milliseconds
-
-button_1: cycle through gate delay multiple options
-button_2: change the behaviour of knob2 (x5, x10, x20)
-
-outputs: gates
-
-# Getting started
+## Getting started
 
 1. Patch anything you want to trigger with a gate to any of the outputs, for example
-percussions elements, emvelopes, sequencer clocks or samples.
+   percussions elements, emvelopes, sequencer clocks or samples.
 2. Set the Cycle time in milliseconds using knob 1
 3. Set delay time in milliseconds using knob 2
 4. Set the desired gate delay interval using button 1
 5. Use button 2 to change the behaviour of knob 2 to set the desired gate delay time
 
-# So what is this script actually doing?
+## So what is this script actually doing?
 
-**Cycle time** is the time in milliseconds between gate outputs at output 1 when the gate delay multiple for output 1 is set to 0. When gate delay multiples are set to value greater than 0 the cycle time will be increased by the gate delay time multiplies by the gate delay multiple.
+**Cycle time** is the time in milliseconds between gate outputs at output 1 when the gate delay
+multiple for output 1 is set to 0. When gate delay multiples are set to value greater than 0 the
+cycle time will be increased by the gate delay time multiplies by the gate delay multiple.
 
 **Gate delay** is the time in milliseconds that gate outputs are delayed from the master cycle time.
 
 **Gate multiples** are multiples of the gate delay time per output.
 
-## For Example:
+### For Example:
 
 - Cycle Time: 1000ms
 - Gate Delay Time: 500ms
@@ -57,7 +54,7 @@ Each subsequent output is sent after "Cycle Time + (Delay Time * Gate Delay Mult
 
 Therefore after the initial gate output from each output:
 
-- Output 1 sends a gate every 1000ms 
+- Output 1 sends a gate every 1000ms
 - Output 2 sends a gate every 1500ms
 - Output 3 sends a gate every 2000ms
 - Output 4 sends a gate every 2500ms
@@ -74,4 +71,3 @@ Which results in the following:
 |   4    |         |         |         |    x    |         |         |         |         |    x    |
 |   5    |         |         |         |         |    x    |         |         |         |         |
 |   6    |         |         |         |         |         |    x    |         |         |         |
-

--- a/software/contrib/gates_and_triggers.md
+++ b/software/contrib/gates_and_triggers.md
@@ -1,8 +1,8 @@
 # Gates and Triggers (G&T)
 
 This program is inspired by the [After Later Audio G&T](https://afterlateraudio.com/products/gt-gates-and-triggers)
-module.  The program converts a gate or trigger signal on `din` into a gate signal with a variable length and
-rising/falling edge triggers.
+module.  The program converts a gate or trigger signal on `din` into a gate signal with a variable
+length and rising/falling edge triggers.
 
 ## I/O Mapping
 
@@ -30,8 +30,8 @@ The gate output on `cv1` has a range of 50ms to 1s, depending on the position of
 knob response is quadratic, giving finer precision at the higher (clockwise) end.
 
 When `ain` receives maximum voltage and `k2` is set to maximum gain, the duration of the gate on
-`cv1` is increased by 2 seconds, giving an absolute maximum gate duration of 3 seconds. The following
-formula gives the exact calculation of the gate duration:
+`cv1` is increased by 2 seconds, giving an absolute maximum gate duration of 3 seconds. The
+following formula gives the exact calculation of the gate duration:
 ```
 k1 in range [0, 100]
 k2 in range [0, 1]
@@ -50,22 +50,23 @@ Gate time is rounded to the nearest millisecond.
 
 ## Fine-tuning Gate Duration
 
-`k1` offers fairly coarse control over the gate length of `cv1`, especially at low values.  If you need to fine-tune
-a gate duration in the 50-150ms range you should set `k1` to its minimum value and use a combination of a constant
-voltage into `ain` and a relatively low gain set on `k2`.  By adjusting the value of your input voltage and turning `k2`
-you should be able to fine-tune the gate duration much more accurately.
+`k1` offers fairly coarse control over the gate length of `cv1`, especially at low values.  If you
+need to fine-tune a gate duration in the 50-150ms range you should set `k1` to its minimum value and
+use a combination of a constant voltage into `ain` and a relatively low gain set on `k2`.  By
+adjusting the value of your input voltage and turning `k2` you should be able to fine-tune the gate
+duration much more accurately.
 
-For example to accurately achieve 60ms gates, patch the output from an adjustable voltage source such as Intellijel's
-Quadratt (0-5V) or Molten Modular's Motion Meter (0-10V) into `ain`. Turn `k1` to its minimum setting and leave it
-there. Slowly increase `k2` and your voltage source while keeping an eye on EuroPi's display. When the display reads
-`Gate: 60ms` stop adjusting `k2` and the input voltage.  While fiddly, this method will provide much finer control
-for short gate durations.
+For example to accurately achieve 60ms gates, patch the output from an adjustable voltage source
+such as Intellijel's Quadratt (0-5V) or Molten Modular's Motion Meter (0-10V) into `ain`. Turn `k1`
+to its minimum setting and leave it there. Slowly increase `k2` and your voltage source while
+keeping an eye on EuroPi's display. When the display reads `Gate: 60ms` stop adjusting `k2` and the
+input voltage.  While fiddly, this method will provide much finer control for short gate durations.
 
 ## Timing Diagram
 
-The following diagram shows the input and output states of the module.  The height of the input to `din` or `b1` is
-irrelevant, as long as it is enough to trigger the rising-edge interrupt service handler on the module (approx. 0.8V
-minimum).
+The following diagram shows the input and output states of the module.  The height of the input to
+`din` or `b1` is irrelevant, as long as it is enough to trigger the rising-edge interrupt service
+handler on the module (approx. 0.8V minimum).
 
 ```
 DIN or B1
@@ -105,14 +106,16 @@ ____________________________| |________________________| |_
                              T                          T
 ```
 
-We assume that between the first and second pulses, the combined CV input via `k1`, `k2`, and `ain` has changed,
-resulting in different gate lengths (`L1` and `L2`, above).  The trigger durations marked with `T` are 10ms.
+We assume that between the first and second pulses, the combined CV input via `k1`, `k2`, and `ain`
+has changed, resulting in different gate lengths (`L1` and `L2`, above).  The trigger durations
+marked with `T` are 10ms.
 
 ## Delayed Triggers
 
-If you need a delayed trigger, `cv4` can be used; set the gate duration of `cv1` to the desired delay
-duration.  `cv4` will fire a 10ms trigger on the falling edge of `cv1`, which will correspond with the
-rising edge of `din` plus the delay.  Note that using `cv4` in this way will limit the usefulness of `cv1`
-and `cv3`, as the gate length will be used to control the delay.
+If you need a delayed trigger, `cv4` can be used; set the gate duration of `cv1` to the desired
+delay duration.  `cv4` will fire a 10ms trigger on the falling edge of `cv1`, which will correspond
+with the rising edge of `din` plus the delay.  Note that using `cv4` in this way will limit the
+usefulness of `cv1` and `cv3`, as the gate length will be used to control the delay.
 
-There is no way to add a delay between the signal received from `din` or `b1` and the rising edge of the gate on `cv1`.
+There is no way to add a delay between the signal received from `din` or `b1` and the rising edge
+of the gate on `cv1`.

--- a/software/contrib/hamlet.md
+++ b/software/contrib/hamlet.md
@@ -1,34 +1,26 @@
-# EuroPi Hamlet - Sequencing Drums and Two Voices
+# Hamlet
 
-author: Sean Bechhofer (github.com/seanbechhofer)
-
-date: 2022-04-16
-
-labels: sequencer, gates, triggers, drums, randomness
+_Sequencing Drums and Two Voices_
 
 **TB or not TB?**
 
-Hamlet is a drum and voice sequencer based on Nik Ansell's
-Consequencer, which is itself inspired by Grids from Mutable
-Instruments. It's also influenced by O_C's TB3PO. Hamlet adds two
-tracks of CV and gates to the Consequencer, sacrificing one drum track
-to do so.
+Hamlet is a drum and voice sequencer based on [Nik Ansell](https://github.com/gamecat69)'s
+[Consequencer](./consequencer.md), which is itself inspired by
+[Mutable Instruments' Grids](https://pichenettes.github.io/mutable-instruments-documentation/modules/grids/).
+It is also influenced by O_C's TB3PO. Hamlet adds two tracks of CV and gates to the Consequencer,
+sacrificing one drum track to do so.
 
-The app provides two gates for drum patterns and a pair of channels
-giving gate/CV to drive voices. Density of notes played on the CV
-tracks can be adjusted.
+The app provides two gates for drum patterns and a pair of channels giving gate/CV to drive voices.
+Density of notes played on the CV tracks can be adjusted.
 
 Use outputs 1/2 for drum gates. Pairs 3/4 and 5/6 provide gate/CV for
 melody lines. Send a clock to the digital input to start the sequence.
 
-Demo video: https://www.youtube.com/watch?v=bEbHBpgIl4A
+## Demo video
 
-Credits:
-- The Europi hardware and firmware was designed by Allen Synthesis:
-https://github.com/Allen-Synthesis/EuroPi
-- Hamlet is based on the Consequencer by Nik Ansell (github.com/gamecat69)
+https://www.youtube.com/watch?v=bEbHBpgIl4A
 
-# Controls
+## Controls
 
 ![hamlet_controls](https://user-images.githubusercontent.com/1035997/163685864-8640d144-a394-4f25-a094-b89feb6e0942.png)
 
@@ -51,20 +43,20 @@ https://github.com/Allen-Synthesis/EuroPi
 - output_5: track 2 randomly generated stepped CV
 - output_6: track 1 randomly generated stepped CV
 
-# Getting Started
+## Getting Started
 
 The following sections provide instructions for creating a simple 2
 drum pattern with a kick and hi-hat, then using random CV patterns to
 drive voices.
 
-## Basic Usage
+### Basic Usage
 1. Connect a clock input to the Digital input
 2. Connect a Bass Drum to output 1, Hi-hat to output 2
 3. Start your clock - the pattern will output gates on outputs 1/2.
 4. Select different patterns manually using knob 2 (right-hand
 knob). The first section of the selected gate pattern for track 1 is shown visually on the screen.
 
-## Voices
+### Voices
 1. Connect output 3 to gate on voice 1
 2. Connect output 6 to pitch on voice 1, optionally via quantiser/attenuator.
 3. Connect output 4 to gate on voice 2
@@ -75,7 +67,7 @@ knob). The first section of the selected gate pattern for track 1 is shown visua
    outputs 3 and 4. Fully CCW all notes are played, as the knob is
    turned CW, notes will drop out of the sequence.
 
-## Sparsity
+### Sparsity
 
 A key feature of the two voice tracks in Hamlet is *sparsity*
 control. With this set to 0, all events in the track are present. As
@@ -103,7 +95,7 @@ values. Note also that track 1 and track 2 have *different* gate
 patterns, thus different notes will drop out giving some nice
 interplay between the voices.
 
-## Pattern Length
+### Pattern Length
 
 CV patterns are N, 2xN or 4xN steps, where N is the length of the
 current drum pattern. This can be varied through a long
@@ -113,24 +105,25 @@ respectively. Patterns of length 2xN and 4xN will be made up of two or four
 set to `15` with pattern length `4x`, there will be four notes played
 across the 64 note sequence.
 
-## Selecting analogue input modes
+### Selecting analogue input modes
 
-Hamlet can perform 3 different actions when a control voltage input is received at the analogue input.
-The current running mode is shown on the bottom right of the screen (e.g. M1, M2, M3)
+Hamlet can perform 3 different actions when a control voltage input is received at the analogue
+input. The current running mode is shown on the bottom right of the screen (e.g. M1, M2, M3)
 Cycle through the modes by long-pressing and releasing button 2. The following modes are available:
 
 - Mode 1: Randomness
 - Mode 2: Control voltage selects the gate pattern
 - Mode 3: Control voltage selects the stepped CV pattern
 
-## Controlling a pattern using CV
+### Controlling a pattern using CV
 
 1. Select analogue mode 2.
 2. Send a control voltage into the analogue input
 
-A fixed voltage will select a single pattern and varying voltage (e.g. an envelope or LFO) will smoothly cycle through patterns.
+A fixed voltage will select a single pattern and varying voltage (e.g. an envelope or LFO) will
+smoothly cycle through patterns.
 
-## Adding / Removing / Updating Gate Patterns
+### Adding / Removing / Updating Gate Patterns
 
 1. Update patterns in the code
 2. Restart the Europi module, or restart the program if using a micropython IDE/CLI
@@ -146,6 +139,13 @@ The mapping of `BD`, `HH` is as follows:
     HH.append("1111111111111111")
 ```
 
-# Known bugs / Interesting features
+## Known bugs / Interesting features
 
 Probably.
+
+## Credits:
+
+- The Europi hardware and firmware was designed by Allen Synthesis:
+https://github.com/Allen-Synthesis/EuroPi
+
+- Hamlet is based on the Consequencer by Nik Ansell (github.com/gamecat69)

--- a/software/contrib/harmonic_lfos.md
+++ b/software/contrib/harmonic_lfos.md
@@ -1,32 +1,40 @@
 # Harmonically Related LFOs
 
-author: rory allen
-
-date: 12/01/22
-
-labels: LFO
-
 Six harmonically related sine/saw/square wave LFOs
 
-    digital in: Reset all LFOs
-    analogue in: Added to master rate
-    knob 1: Master rate
-    knob 2: Adjusts the master clock division of the currently selected LFO (or the maximum voltage for noise)
-    button 1, short press: Change mode of current LFO between sine/saw/square/off/random/noise
-    button 1, long press (> 0.5sec): Toggles between displaying all LFOs or just the currently selected one
-    button 2: Select the next LFO
-    cv1/cv2/cv3/cv4/cv5/cv6: LFO outputs
+- `din``: Reset all LFOs
+- `ain`: Added to master rate
+- `k1`: Master rate
+- `k2`: Adjusts the master clock division of the currently selected LFO (or the maximum voltage
+  for noise)
+- `b1`, short press: Change mode of current LFO between sine/saw/square/off/random/noise
+- `b1`, long press (> 0.5sec): Toggles between displaying all LFOs or just the currently selected
+  one
+- `b2`: Select the next LFO
+- `cv1`-`cv6`: LFO outputs
 
+## Editing/understanding the program
 
-#### Editing/understanding the program
-There is a list named ```divisions``` which controls the relationship of each LFO to the master clock, in terms of its division.
-You could change them to all be evenly divisible, for example ```[1, 2, 4, 8, 16, 32]```, or to be very 'unrelated', for example ```[1.24, 5.27, 9.46, 13.45, 17.23, 23.54]```.
-The last example would only come back into sync after 2,472,424,774,707 cycles, which is approximately 78400 years at one second per cycle.
-The default example uses all prime numbers (except 1 if you want to be technical), and will only sync up around 15,015 cycles.
-You can change any of these values during operation of the program by using knob 2, and button 2 to change which LFO you have selected. The maximum division is controlled by the MAX_HARMONIC variable at the top of the script.
+There is a list named ```divisions``` which controls the relationship of each LFO to the master
+clock, in terms of its division. You could change them to all be evenly divisible, for example
+`[1, 2, 4, 8, 16, 32]`, or to be very 'unrelated', for example
+`[1.24, 5.27, 9.46, 13.45, 17.23, 23.54]`. The last example would only come back into sync after
+2,472,424,774,707 cycles, which is approximately 78400 years at one second per cycle.
 
-Both the division and mode (wave shape) of each LFO are saved to a file, so will be retained after shut down. For this reason there isn't much point in changing the values of the LFO divisions in code, as they will be overwritten and saved as soon as you use knob 2 to alter them.
+The default example uses all prime numbers (except 1 if you want to be technical), and will only
+sync up around 15,015 cycles. You can change any of these values during operation of the program by
+using knob 2, and button 2 to change which LFO you have selected. The maximum division is controlled
+by the MAX_HARMONIC variable at the top of the script.
 
-The state of ```viewAllWaveforms``` is also saved to the same file. Therefore, you can set it and forget it to your preferred view, or toggle as desired. Either way, the previous state will be recalled on power up.
+Both the division and mode (wave shape) of each LFO are saved to a file, so will be retained after
+shut down. For this reason there isn't much point in changing the values of the LFO divisions in
+code, as they will be overwritten and saved as soon as you use knob 2 to alter them.
 
-There is also a variable named ```MAX_VOLTAGE```, which is likely only going to be 10 or 5 depending on which you prefer in your system, and what modules you are controlling. This is inherited by the MAX_OUTPUT_VOLTAGE set in europi.py, but you can override it if you use this script for something specific.
+The state of ```viewAllWaveforms``` is also saved to the same file. Therefore, you can set it and
+forget it to your preferred view, or toggle as desired. Either way, the previous state will be
+recalled on power up.
+
+There is also a variable named ```MAX_VOLTAGE```, which is likely only going to be 10 or 5
+depending on which you prefer in your system, and what modules you are controlling. This is
+inherited by the `MAX_OUTPUT_VOLTAGE` set in `europi.py`, but you can override it if you use this
+script for something specific.

--- a/software/contrib/itty_bitty.md
+++ b/software/contrib/itty_bitty.md
@@ -1,12 +1,13 @@
 # Itty Bitty
 
-A gate & CV sequencer that uses the binary representation of an 8-bit integer to determine the of/off pattern.
+A gate & CV sequencer that uses the binary representation of an 8-bit integer to determine the
+of/off pattern.
 
-The module has 2 channels, A and B.  Channel A is controlled by `K1` and outputs on `CV1-3`.  Channel B is controlled
-by `K2` and outputs on `CV4-6`.
+The module has 2 channels, A and B.  Channel A is controlled by `K1` and outputs on `CV1-3`.
+Channel B is controlled by `K2` and outputs on `CV4-6`.
 
-Inspired by an [Instagram post by Schreibmaschine](https://www.instagram.com/p/DDaZklkgzbr) describing an idea for a
-new module.
+Inspired by an [Instagram post by Schreibmaschine](https://www.instagram.com/p/DDaZklkgzbr)
+describing an idea for a new module.
 
 ## Ins & Outs
 
@@ -35,8 +36,8 @@ The numbers 0-255 can be represented in binary in 8 bits:
 - `254`: `11111110`
 - `255`: `11111111`
 
-Let `0 <= n <= 255` be the value the user selects with the knob. Every time we receive a clock signal we rotate
-the bits 1 place to the left, giving us `n'`:
+Let `0 <= n <= 255` be the value the user selects with the knob. Every time we receive a clock
+signal we rotate the bits 1 place to the left, giving us `n'`:
 ```
 ...
 00000001
@@ -53,14 +54,15 @@ the bits 1 place to the left, giving us `n'`:
 
 The "current bit` is the most-significant bit.
 
-The trigger output will emit a trigger signal if the current 1s bit is 1, and no trigger if the current bit is 0. The
-duration of the trigger is the same as the incoming clock signal (or the duration of the button press).
+The trigger output will emit a trigger signal if the current 1s bit is 1, and no trigger if the
+current bit is 0. The duration of the trigger is the same as the incoming clock signal (or the
+duration of the button press).
 
 The gate output will go high if the current bit is 1, and will go low if the current bit is 0.
 
-The CV output set to `MAX_OUTPUT_VOLTAGE * reverse(n') / 255`. The bits are reversed so as to prevent a situation
-where the CV is always high when the active bit is also high; this forcibly de-couples the gate & CV outputs,
-which can lead to more interesting interactions between them.
+The CV output set to `MAX_OUTPUT_VOLTAGE * reverse(n') / 255`. The bits are reversed so as to
+prevent a situation where the CV is always high when the active bit is also high; this forcibly
+de-couples the gate & CV outputs, which can lead to more interesting interactions between them.
 
 ### Example sequence
 
@@ -113,13 +115,13 @@ _________.         .         .         .         .         .         .
 
 This program has the following configuration options:
 
-- `USE_AIN_A`: if `true`, channel A's value is determined by `AIN` and `k1` will act as an attenuator for the
-  CV signal connected to `AIN`
-- `USE_AIN_B`: if `true`, channel B's value is determined by `AIN` and `k2` will act as an attenuator for the
-  CV signal connected to `AIN`
-- `USE_GRAY_ENCODING`: if `true`, instead of traditional binary encoding, the pattern is encoded using
-  [gray encoding](https://en.wikipedia.org/wiki/Gray_encoding). This means that consecutive sequences will
-  always differ by exactly 1 bit.
+- `USE_AIN_A`: if `true`, channel A's value is determined by `AIN` and `k1` will act as an
+  attenuator for the CV signal connected to `AIN`. Default: `false`
+- `USE_AIN_B`: if `true`, channel B's value is determined by `AIN` and `k2` will act as an
+  attenuator for the CV signal connected to `AIN`. Default: `false`
+- `USE_GRAY_ENCODING`: if `true`, instead of traditional binary encoding, the pattern is encoded
+  using [gray encoding](https://en.wikipedia.org/wiki/Gray_encoding). This means that consecutive
+  sequences will always differ by exactly 1 bit. Default: `false`
 
 | Decimal value | Traditional binary | Gray encoding |
 |---------------|--------------------|---------------|

--- a/software/contrib/kompari.md
+++ b/software/contrib/kompari.md
@@ -1,16 +1,27 @@
 # Kompari
 
-This program is a EuriPi re-imagining of Allen Synthesis' Kompari module.
+This program is a EuriPi re-imagining of [Allen Synthesis' Kompari](https://www.allensynthesis.co.uk/modules/kompari.html)
+module.
+
+An input signal is converted to a normalized `0-1` level and compared with the two knobs' levels,
+outputting gate and CV signals.
 
 ## Inputs & Outputs
 
-`AIN` is used for the input signal.  `K1` and `K2` define the lower & upper bounds for comparisons based on
-the knob position.
+Inputs:
+- `ain`: input signal to compare with knob posiotions
+- `din`: not used
+- `k1`: lower bound for comparisons with `ain`
+- `k2`: upper bound for comparisons with `ain`
+- `b1`: not used
+- `b2`: not used
 
 Outputs:
-- `CV1` +5V if `K1` < `AIN`, otherwise 0
-- `CV2` +5V if `AIN` < `K2`, otherwise 0
-- `CV3` +5V if `K1` < `AIN` < `K2`, otherwise 0
-- `CV4` `max(K1, AIN)`
-- `CV5` `min(AIN, K2)`
-- `CV6` `max(K1, min(AIN, K2))`
+- `cv1`: +5V if `K1` < `AIN`, otherwise 0V
+- `cv2`: +5V if `AIN` < `K2`, otherwise 0V
+- `cv3`: +5V if `K1` < `AIN` < `K2`, otherwise 0V
+- `cv4`: `max(K1, AIN) * MAX_OUTPUT_VOLTAGE`
+- `cv5`: `min(AIN, K2) * MAX_OUTPUT_VOLTAGE`
+- `cv6`: `max(K1, min(AIN, K2)) * MAX_OUTPUT_VOLTAGE`
+
+Output calculations treat `K1`, `K2`, and `AIN` as values in the range `[0.0, 1.0]`.

--- a/software/contrib/kompari.md
+++ b/software/contrib/kompari.md
@@ -1,6 +1,6 @@
 # Kompari
 
-This program is a EuriPi re-imagining of [Allen Synthesis' Kompari](https://www.allensynthesis.co.uk/modules/kompari.html)
+This program is a EuroPi re-imagining of [Allen Synthesis' Kompari](https://www.allensynthesis.co.uk/modules/kompari.html)
 module.
 
 An input signal is converted to a normalized `0-1` level and compared with the two knobs' levels,

--- a/software/contrib/lutra.md
+++ b/software/contrib/lutra.md
@@ -1,14 +1,29 @@
 # Lutra
 
-Lutra is a re-imagining of [Expert Sleepers' Otterley](https://expert-sleepers.co.uk/otterley.html) module.
+Lutra is a re-imagining of [Expert Sleepers' Otterley](https://expert-sleepers.co.uk/otterley.html)
+module.
 
-Each output channel is a free running LFO with a subtly different clock speed. The spread of clock speeds is controlled
-by `k2` (and optionally `ain` -- see configuration below)
+Each output channel is a free running LFO with a subtly different clock speed. The spread of clock
+speeds is controlled by `k2` (and optionally `ain` -- see configuration below)
+
+## Inputs & Outputs
+
+Inputs:
+- `din`: synchronization CV input (see [Re-Syncing](#re-syncing) below)
+- `ain`: configurable CV input (see [CV Input Configuration](#cv-input-configuration) below)
+- `k1`: primary speed control; rotating clockwise increases the speed of all LFOs
+- `k2`: primary spread control; rotating clockwise increases the spread between LFO speeds
+- `b1`: manual reset input (see [Re-Syncing](#re-syncing) below)
+- `b2`: wave shape selector (see [Wave Shapes](#wave-shapes) below)
+
+Outputs:
+- `cv1`-`cv6`: LFO outputs
 
 ## Wave Shapes
 
-The shape of the output wave can be changed by pressing `b2` while the module is running. This choice is saved to
-the module and will be re-loaded every time `Lutra` starts. Available wave shapes are:
+The shape of the output wave can be changed by pressing `b2` while the module is running. This
+choice is saved to the module and will be re-loaded every time `Lutra` starts. Available wave
+shapes are:
 - ![Sine Wave](./lutra-docs/wave_sine.png) Sine
 - ![Square Wave](./lutra-docs/wave_square.png) Square
 - ![Triangle Wave](./lutra-docs/wave_triangle.png) Triangle
@@ -17,48 +32,30 @@ the module and will be re-loaded every time `Lutra` starts. Available wave shape
 - ![Stepped Random Wave](./lutra-docs/wave_step_random.png) Stepped Random
 - ![Smooth Random Wave](./lutra-docs/wave_smooth_random.png) Smooth Random (Linear)
 
-When pressing `b2` to select the wave shape, the selected shape will briefly appear in the upper left corner of the
-screen.
+When pressing `b2` to select the wave shape, the selected shape will briefly appear in the upper
+left corner of the screen.
 
-The stepped random wave will hold a randomly-chosen voltage for the duration of the cycle period, choosing a new
-voltage every period.
+The stepped random wave will hold a randomly-chosen voltage for the duration of the cycle period,
+choosing a new voltage every period.
 
-The smooth random wave moves linearly from the current voltage toward a randomly-chosen goal over the cycle period,
-choosing a new random goal voltage every period.
-
-## CV Input Configuration
-
-By default CV signals applied to `ain` will adjust the spread of the output waves.  If preferred, this can be changed
-to control the overall speed of the waves instead by creating/editing `/config/Lutra.json` on the module.
-
-```json
-{
-    "AIN_MODE": "spread"
-}
-```
-
-- `AIN_MODE`: sets the mode for `ain`. Must be one of `spread` or `speed`.  If set to `spread` the spread of clock
-  speeds of the outputs is controlled by `ain`.  If set to `speed` the master clock speed is controlled by `ain`.
-
-`ain` is expected to receive signals from zero to `MAX_INPUT_VOLTAGE` (default 12V -- see
-[EuroPi configuration](/software/CONFIGURATION.md)).  Increasing the voltage will increase the speed or spread of
-the LFOs.  Decreasing the speed/spread is not allowed, as EuroPi cannot accept negative voltages.  Instead it is
-recommended to set `k1` and `k2` to set the minimum desired speed & spread with `ain` unpatched. Then send an
-attenuated signal into `ain` to increase the speed/spread as desired.
+The smooth random wave moves linearly from the current voltage toward a randomly-chosen goal over
+the cycle period, choosing a new random goal voltage every period.
 
 ## Knob Control
 
-Turning `k1` fully anticlockwise will set the clock speed to the slowest setting. Turning `k1` fully clockwise will set
-the clock speed to the fastest setting.
+Turning `k1` fully anticlockwise will set the clock speed to the slowest setting. Turning `k1` fully
+clockwise will set the clock speed to the fastest setting.
 
-Turning `k2` fully anticlockwise will set the spread of the waves to zero; every output will have the same clock speed,
-(though depending on previous settings and random noise) they may be phase-shifted from each other.
+Turning `k2` fully anticlockwise will set the spread of the waves to zero; every output will have
+the same clock speed, (though depending on previous settings and random noise) they may be
+phase-shifted from each other.
 
-Turning `k2` clockwise will gradually increase the speed of `cv2-6`, with each output becoming slightly faster than
-the previous one. i.e. `cv2` will be faster than `cv1`, `cv3` will be faster than `cv2`, etc...
+Turning `k2` clockwise will gradually increase the speed of `cv2-6`, with each output becoming
+slightly faster than the previous one. i.e. `cv2` will be faster than `cv1`, `cv3` will be faster
+than `cv2`, etc...
 
-At the maximum clockwise position, the speeds of `cv2-6` will be common harmonic intervals from `cv1`, as shown on the
-table below:
+At the maximum clockwise position, the speeds of `cv2-6` will be common harmonic intervals from
+`cv1`, as shown on the table below:
 
 | CV Output | Ratio w/ `cv1 | Max speed multiplier |
 |-----------|---------------|----------------------|
@@ -71,7 +68,31 @@ table below:
 
 ## Re-syncing
 
-When `b1` is pressed or `din` receives a high voltage all CV outputs are temporarily halted. Once `b1` is released
-_and_ the signal on `din` drops back to `0.0V` the output signals will begin again, starting in their initial,
-synchronized state. This allows a very short gate (trigger) signal to reset all of the waves to re-synchronize them,
-or a longer gate can be used to hold the outputs at zero for as long as desired.
+When `b1` is pressed or `din` receives a high voltage all CV outputs are temporarily halted. Once
+`b1` is released _and_ the signal on `din` drops back to `0.0V` the output signals will begin again,
+starting in their initial, synchronized state. This allows a very short gate (trigger) signal to
+reset all of the waves to re-synchronize them, or a longer gate can be used to hold the outputs at
+zero for as long as desired.
+
+## CV Input Configuration
+
+By default CV signals applied to `ain` will adjust the spread of the output waves.  If preferred,
+this can be changed to control the overall speed of the waves instead by creating/editing
+`/config/Lutra.json` on the module.
+
+```json
+{
+    "AIN_MODE": "spread"
+}
+```
+
+- `AIN_MODE`: sets the mode for `ain`. Must be one of `spread` or `speed`.  If set to `spread` the
+  spread of clock speeds of the outputs is controlled by `ain`.  If set to `speed` the master clock
+  speed is controlled by `ain`.
+
+`ain` is expected to receive signals from zero to `MAX_INPUT_VOLTAGE` (default 12V -- see
+[EuroPi configuration](/software/CONFIGURATION.md)).  Increasing the voltage will increase the speed
+or spread of the LFOs.  Decreasing the speed/spread is not allowed, as EuroPi cannot accept negative
+voltages.  Instead it is recommended to set `k1` and `k2` to set the minimum desired speed & spread
+with `ain` unpatched. Then send an attenuated signal into `ain` to increase the speed/spread as
+desired.

--- a/software/contrib/master_clock.md
+++ b/software/contrib/master_clock.md
@@ -1,57 +1,58 @@
-# EuroPi Master Clock and Clock Divider
+# Master Clock and Clock Divider
 
-'''
-Master Clock
-author: Nik Ansell (github.com/gamecat69)
-date: 2022-08-02
-labels: clock, divider
+A master clock and clock divider. Each output sends a +5V trigger/gate at different divisions of the
+master clock, or randomly if condigured with a division of zero. Pulse width (gate/trigger duration)
+is configurable up to a maximum of 50% of the pulse width of output 1.
 
-A master clock and clock divider. Each output sends a +5V trigger/gate at different divisions of the master clock, or randomly if condigured with a division of zero.
-Pulse width (gate/trigger duration) is configurable up to a maximum of 50% of the pulse width of output 1.
-
-All configuration (BPM, Pulse Width, output clock divisions) is automatically saved, then loaded when the module is restarted.
+All configuration (BPM, Pulse Width, output clock divisions) is automatically saved, then loaded
+when the module is restarted.
 
 For wonky/more interesting clock patterns try these:
-- Reset to step 1 using a gate into the digital input, or by using an odd value for the maximum division
+- Reset to step 1 using a gate into the digital input, or by using an odd value for the maximum
+  division
 - Vary BPM by sending CV into the analog input
-- Set the division to zero for an output, this will cause the output to randomly go from high (+5V) to low (0V)
+- Set the division to zero for an output, this will cause the output to randomly go from high
+  (+5V) to low (0V)
 
-Demo video: TBC
+## Inputs & Outputs
 
-knob_1: (in config mode) Select option to edit
-knob_2: (in config mode) Edit selected option
+- knob_1: (in config mode) Select option to edit
+- knob_2: (in config mode) Edit selected option
 
-knob_1: Screen 2: Adjust BPM. Screen 3: Select output to edit
-knob_2: Screen 2: Adjust Pulse width. Screen 3: Adjust division of selected output
+- knob_1: Screen 2: Adjust BPM. Screen 3: Select output to edit
+- knob_2: Screen 2: Adjust Pulse width. Screen 3: Adjust division of selected output
 
-button_1: Short Press (<500ms): Start/Stop (when using internal clock). Long Press (>500ms): Select clock source (Internal/External)
-button_2: Short Press (<500ms): Not used. Long Press (>500ms): Enter config mode
+- button_1: Short Press (<500ms): Start/Stop (when using internal clock). Long Press (>500ms):
+  Select clock source (Internal/External)
+- button_2: Short Press (<500ms): Not used. Long Press (>500ms): Enter config mode
 
 Defaults:
-output_1: clock / 1
-output_2: clock / 2
-output_3: clock / 4
-output_4: clock / 8
-output_5: clock / 16
-output_6: clock / 32
+- output_1: clock / 1
+- output_2: clock / 2
+- output_3: clock / 4
+- output_4: clock / 8
+- output_5: clock / 16
+- output_6: clock / 32
 
-Known Issues:
-- BPM occasionally drifts by 1ms - possibly because asyncio is is truely async
+## Getting started
 
-# Getting started
+Patch any module that uses gates/triggers to any output! By default the module will run at 100 BPM,
+using a 50% pulse width and send gates using the default divisions (1,2,4,8,16,32).
 
-Patch any module that uses gates/triggers to any output! By default the module will run at 100 BPM, using a 50% pulse width and send gates using the default divisions (1,2,4,8,16,32).
+## Configuring / Playing around
 
-# Configuring / Playing around
+Hold button 2 for 2 seconds to enter configuration mode, then use knob 1 (left) to adjust BPM and
+knob 2 (right) to adjust pulse width. To exit configuration mode, just press button 2 to move to the
+next screen.
 
-Hold button 2 for 2 seconds to enter configuration mode, then use knob 1 (left) to adjust BPM and knob 2 (right) to adjust pulse width. To exit configuration mode, just press button 2 to move to the next screen.
+Playback may be slightly erraratic when in config mode - this is due to more screen updates hogging
+the CPU
 
-Playback may be slightly erraratic when in config mode - this is due to more screen updates hogging the CPU
-
-## Screen
+### Screen
 
 This screen shows the BPM, Pulse width and configured clock division for each output.
-The Pulse width is displayed as `PW:MS`. `PW` is a percentage of the output 1 division and `MS` is the duration of each pulse in milliseconds
+The Pulse width is displayed as `PW:MS`. `PW` is a percentage of the output 1 division and `MS` is
+the duration of each pulse in milliseconds
 
 To edit the BPM (internal clock mode only), Pulse Width or the clock division for an output:
 - Use knob 1 to select the output you want to edit
@@ -59,16 +60,22 @@ To edit the BPM (internal clock mode only), Pulse Width or the clock division fo
 - Use knob 2 to select the division you want that that output.
 - Exit configuration mode by holding button 2 for 2 seconds.
 
-# Selecting a Clock Source
+## Selecting a Clock Source
 
 Master clock can generate its own clock, or use an external clock.
 Enter clock source configuration mode using a long press on button 1.
 Pressing either button 1 or button 2 will configure and save the clock source.
 
-If using an external clock, patch the clock source into the din jack - the clock source should ideally send a gate/trigger longer than 9ms to avoid issues.
+If using an external clock, patch the clock source into the din jack - the clock source should
+ideally send a gate/trigger longer than 9ms to avoid issues.
 
 Note that when using an external clock, the reset functionality using the din jack is disabled.
 
-# Randomizing pulses
+## Randomizing pulses
 
-Selecting a clock division of `/r` will cause pulses to be sent randomly from the configured output. Note that the 'r' option is at the end (far right) of the division options.
+Selecting a clock division of `/r` will cause pulses to be sent randomly from the configured output.
+Note that the 'r' option is at the end (far right) of the division options.
+
+## Known Issues:
+
+- BPM occasionally drifts by 1ms - possibly because asyncio is is truely async

--- a/software/contrib/menu.md
+++ b/software/contrib/menu.md
@@ -1,8 +1,10 @@
 # Menu
-A Menu which allows the user to select and execute one of the scripts available to this EuroPi. The menu will
-include the ``EuroPiScripts`` included in the ``EUROPI_SCRIPTS`` List. Button press handlers are added that allow
-the user to exit the script and return to the menu by holding both buttons down for a short period of time. If the
-module is restarted while a script is running it will boot right back into that same script.
+
+A Menu which allows the user to select and execute one of the scripts available to this EuroPi. The
+menu will include the ``EuroPiScripts`` included in the ``EUROPI_SCRIPTS`` List. Button press
+handlers are added that allow the user to exit the script and return to the menu by holding both
+buttons down for a short period of time. If the module is restarted while a script is running it
+will boot right back into that same script.
 
 In the menu:
 
@@ -33,30 +35,45 @@ if __name__ == "__main__":  #4
     HelloWorld().main()
 ```
 
-1. **Import ``EuroPiScript``:** Import the ``EuroPiScript`` base class so that we can implement it below.
-2. **Define a class that extends ``EuroPiScript``:** This defines your script as one that adheres to the menu's requirements.
-3. **A ``main()`` method:** The main code of the script should be encapsulated in an 'main()' method. The menu will initialize your class and then call this function to launch your script.
-4. **a ``__name__`` guard around the ``main()`` call site:** This allows your code to work correctly when it itself is the ``main.py``. To read more about name guarding, see the [Python Documentation](https://docs.python.org/3/library/__main__.html), or alternatively just copy and paste the example above, using your own script's name in place of 'HelloWorld'.
+1. **Import ``EuroPiScript``:** Import the ``EuroPiScript`` base class so that we can implement it
+   below.
+2. **Define a class that extends ``EuroPiScript``:** This defines your script as one that adheres to
+   the menu's requirements.
+3. **A ``main()`` method:** The main code of the script should be encapsulated in an 'main()' method.
+   The menu will initialize your class and then call this function to launch your script.
+4. **a ``__name__`` guard around the ``main()`` call site:** This allows your code to work correctly
+   when it itself is the ``main.py``. To read more about name guarding, see the
+   [Python Documentation](https://docs.python.org/3/library/__main__.html), or alternatively just
+   copy and paste the example above, using your own script's name in place of 'HelloWorld'.
 
 ## Menu Inclusion
 
-Once you have a script that conforms to the above requirements, you can add it to the list of scripts that are included
-in the menu. This list is in [menu.py](/software/contrib/menu.py) in the contrib folder. You will need to add two lines,
-one to import your class and one to add the class to the list. Use the existing scripts as examples.
+Once you have a script that conforms to the above requirements, you can add it to the list of
+scripts that are included in the menu. This list is in [menu.py](/software/contrib/menu.py) in the
+contrib folder. You will need to add two lines, one to import your class and one to add the class to
+the list. Use the existing scripts as examples.
 
 Note that the scripts are sorted before being displayed, so order in this file doesn't matter.
 
 ## Save/Load Script State
 
-You can add a bit of code to enable your script to save state upon change, and load previous state at startup.
+You can add a bit of code to enable your script to save state upon change, and load previous state
+at startup.
 
-When adding save state functionality to your script, there are a few important considerations to keep in mind:
+When adding save state functionality to your script, there are a few important considerations to
+keep in mind:
 
-1. Frequency of saves - scripts should only save state to disk when state changes, and should not save too frequently because OS write operations are expensive in terms of time. Saving too frequently will affect the performance of a script.
-1. Save state file size - The Pico only has about 1MB of free space available so save state storage format is important to keep as minimal as possible.
-1. No externally influenced input - The instance variables your script saves should not be externally influenced, meaning you should not save the current knob position, current analog input value or current digital input value.
+1. Frequency of saves - scripts should only save state to disk when state changes, and should not
+   save too frequently because OS write operations are expensive in terms of time. Saving too
+   frequently will affect the performance of a script.
+1. Save state file size - The Pico only has about 1MB of free space available so save state storage
+   format is important to keep as minimal as possible.
+1. No externally influenced input - The instance variables your script saves should not be
+   externally influenced, meaning you should not save the current knob position, current analog
+   input value or current digital input value.
 
-Here is an extension of the script above with some added trivial features that incorporate saving and loading script state.
+Here is an extension of the script above with some added trivial features that incorporate saving
+and loading script state.
 
 ```python
 from europi import oled
@@ -98,20 +115,29 @@ class HelloWorld(EuroPiScript):
         oled.centre_text("Hello world")
 ```
 
-1. **Initialize base classes** When implementing the `EuroPiScript` base class, its initialization method must be called to initialize its intance variables.
+1. **Initialize base classes** When implementing the `EuroPiScript` base class, its initialization
+   method must be called to initialize its intance variables.
 
-1. **Call the inherited `EuroPiScript` method `load_state_json()`.** The `EuroPiScript` base class has the method `load_state_json()` to check for a previously saved state in JSON format. When initializing your script, call `load_X_state()` where `X` is the persistence format of choice. If no state is found, an empty value will be returned.
+1. **Call the inherited `EuroPiScript` method `load_state_json()`.** The `EuroPiScript` base class
+   has the method `load_state_json()` to check for a previously saved state in JSON format. When
+   initializing your script, call `load_X_state()` where `X` is the persistence format of choice.
+   If no state is found, an empty value will be returned.
 
-1. **Apply saved state variables to this instance.** Set state variables with default fallback values if not found in the json save state.
+1. **Apply saved state variables to this instance.** Set state variables with default fallback
+   values if not found in the json save state.
 
 1. **Save state upon state change.** When a state variable changes, call the save state function.
 
-1. **Implement `save_state()` method.** Provide an implementation to serialize the state variables into a string, JSON, or bytes an call the appropriate save state method.
+1. **Implement `save_state()` method.** Provide an implementation to serialize the state variables
+   into a string, JSON, or bytes an call the appropriate save state method.
 
 
-1. **Throttle the frequency of saves.** Saving state too often could negatively impact the performance of your script, so it is advised to add some checks in your code to ensure it doesn't save too frequently.
+1. **Throttle the frequency of saves.** Saving state too often could negatively impact the
+   performance of your script, so it is advised to add some checks in your code to ensure it doesn't
+   save too frequently.
 
 ## Support testing
 
-For a simple, but complete example of a testable ``EuroPiScript`` see [hello_world.py](/software/contrib/hello_world.py)
-and its test [test_hello_world.py](/software/tests/contrib/test_hello_world.py).
+For a simple, but complete example of a testable ``EuroPiScript`` see
+[hello_world.py](/software/contrib/hello_world.py) and its test
+[test_hello_world.py](/software/tests/contrib/test_hello_world.py).

--- a/software/contrib/noddy_holder.md
+++ b/software/contrib/noddy_holder.md
@@ -1,9 +1,5 @@
 # Noddy Holder
 
-author: Sean Bechhofer (github.com/seanbechhofer)
-date: 2022-03-26
-labels: gates, sample&hold, track&hold
-
 *Cum On Feel the Noize!* Two channels of sample/track and hold based on
 a single trigger and CV source.
 
@@ -14,32 +10,23 @@ Ouput 3 is T&H based on gate and CV.
 
 Outputs 4, 5 and 6 are similar, but with the gate *inverted*.
 
-Credits:
-- The Europi hardware and firmware was designed by Allen Synthesis: https://github.com/Allen-Synthesis/EuroPi
+## Controls
 
-# Controls
+- digital_in: sample/track trigger input
+- analog_in: CV input to sample or track
 
-- digital_in: Gate
-- analog_in: CV
+- knob_1: not used
+- knob_2: not used
 
-- knob_1:
-- knob_2:
+- button_1: not used
+- button_2: not used
 
-- button_1:
-- button_2:
-
-- output_1: gate
+- output_1: copy of `din` gate signal
 - output_2: s&h based on gate
 - output_3: t&h based on gate
 - output_4: inverted gate
 - output_5: s&h based on inverted gate
 - output_6: t&h based on inverted gate
-
-## Basic Usage
-1. Switch on
-2. Connect outputs to modules
-3. Send gate and CV to inputs
-4. Send resulting gates and CV to modules
 
 ## Controls
 1. There are no controls. Noddy doesn't listen to The Man.
@@ -52,3 +39,7 @@ output until the gate goes ```HIGH``` again and we re-sample.
 *Track & Hold:* When gate is ```HIGH```, CV input is mirrored to the
 output. When gate goes ```LOW```, CV is sampled and the resulting value is
 output until the gate goes ```HIGH``` again.
+
+## Credits:
+
+- The Europi hardware and firmware was designed by Allen Synthesis: https://github.com/Allen-Synthesis/EuroPi

--- a/software/contrib/ocean_surge.md
+++ b/software/contrib/ocean_surge.md
@@ -2,8 +2,8 @@
 
 This program is a loose clone of the [ADDAC 508 "Swell Physics"](https://www.addacsystem.com/en/products/modules/addac500-series/addac508).
 The program uses a [trochoidal wave](https://en.wikipedia.org/wiki/Trochoidal_wave) to simulate
-the motion of 3 buoys floating on the ocean surface. The relative elevations of these buoys generates
-control voltage signals, while logical comparisons between them output gate signals.
+the motion of 3 buoys floating on the ocean surface. The relative elevations of these buoys
+generates control voltage signals, while logical comparisons between them output gate signals.
 
 ## Controls, Inputs, and Outputs
 

--- a/software/contrib/osc_control.md
+++ b/software/contrib/osc_control.md
@@ -51,7 +51,7 @@ Create `/config/OscControl.json` to set the namespace:
 If the namespace does not start with `/`, a `/` will automatically be added.  If the namespace
 is left empty, it will default to `/`.
 
-## Changint the topics
+## Changing the topics
 
 The input & output topics described above are defaults. To rename the topics (e.g. to facilitate
 easier interaction with other devices) the topics can be customized by specifying the topics for

--- a/software/contrib/pams.md
+++ b/software/contrib/pams.md
@@ -1,13 +1,13 @@
 # Pam's "EuroPi" Workout
 
-This program is an homage to ALM's Pamela's "NEW" Workout and Pamela's "PRO"
-Workout modules, designed for the EuroPi. It is intended to be used as a
-main clock generator, euclidean rhythm generator, clocked LFO, clocked
-random voltage source, etc... with optional quantization.
+This program is an homage to [ALM's Pamela's "NEW" Workout](https://busycircuits.com/alm017/)
+and [Pamela's "PRO" Workout](https://busycircuits.com/alm034/) modules, reimagined for the EuroPi.
+It is intended to be used as a main clock generator, euclidean rhythm generator, clocked LFO,
+clocked random voltage source, etc... with optional quantization.
 
-The module itself will generate the master clock signal with a configurable
-BPM (1-240 BPM supported). Each output has an independently controlled
-clock multiplier or divider, chosen from the following:
+The module itself will generate the master clock signal with a configurable BPM (1-240 BPM
+supported). Each output has an independently controlled clock multiplier or divider, chosen from
+the following:
 
 ```
 [x16, x12, x8, x6, x4, x3, x2, x1, /2, /3, /4, /6, /8, /12, /16]

--- a/software/contrib/pams.md
+++ b/software/contrib/pams.md
@@ -87,10 +87,11 @@ Visualization
 
 `**` This setting can be set up to work as a sample & hold for the signal coming into `ain`.
 
-Some settings (e.g. ADSR envelope parameters, quantization root) are hidden from the menu if they would be ignored
-by the current configuration for that channel.
+Some settings (e.g. ADSR envelope parameters, quantization root) are hidden from the menu if they
+would be ignored by the current configuration for that channel.
 
-The vizualization does not have any submenu items and simply displays the voltages of `CV1`-`6`, `AIN`, and `K1`.
+The vizualization does not have any submenu items and simply displays the voltages of `CV1`-`6`,
+`AIN`, and `K1`.
 
 ## Main Clock Options
 
@@ -103,28 +104,31 @@ The submenu for the main clock has the following options:
 - `DIN Mode` -- Control the action taken when a gate or trigger is sent to `DIN`:
   - `Gate`: the clock will start on a rising edge and stop on a falling edge
   - `Trigger`: the clock will toggle between the running & stopped states on a rising edge
-  - `Reset`: the clock will not change, but all waveforms & euclidean patterns will reset to the beginning
-- `Stop-Rst` -- Stop & Reset: if true, all waves & euclidean patterns will reset when the clock starts.
-  Otherwise they will continue from where they stopped
+  - `Reset`: the clock will not change, but all waveforms & euclidean patterns will reset to the
+    beginning
+- `Stop-Rst` -- Stop & Reset: if true, all waves & euclidean patterns will reset when the clock
+  starts. Otherwise they will continue from where they stopped
 
 ## CV Channel Options
 
 Each of the 6 CV output channels has the following options:
 
-- `Mod` -- the clock modifier: `/16` to `x16`.  `x1` will output one waveform every beat (dictated by the BPM).
-  Multipliers (`xN`) will output `N` waveforms every beat.  Divisions (`/N`) will output a waveform every `N`
-  beats.
+- `Mod` -- the clock modifier: `/16` to `x16`.  `x1` will output one waveform every beat (dictated
+  by the BPM). Multipliers (`xN`) will output `N` waveforms every beat.  Divisions (`/N`) will
+  output a waveform every `N` beats.
 
 3 additional special-purpose clock mods are available:
-- ![Reset](./pams-docs/wave_reset.png) Reset: a trigger that fires when the clock stops (can be used to trigger other
-  modules to reset, e.g. sequencers sequential switches, other euclidean generators). The fired trigger is 10ms in
-  duration at 10V times the channel's amplitude. e.g. at 50% the trigger will be 5V.
-- ![Start](./pams-docs/wave_start.png) Start: a trigger that fires when the clock starts (can be used to trigger other
-  modules, or reset on-start). The trigger is at least 10ms long, but is based on the clock speed and may be longer.
-  Trigger voltage is 10V times the channel's amplitude. e.g. at 50% the trigger will be 5V
-- ![Run](./pams-docs/wave_run.png) Run: a gate that is high when the clock is running and low when the clock is stopped.
-  As long as the clock is running the gate will remain high.  Gate voltage is 10V times channel's amplitude.
-  e.g. at 50% the gate is 5V.
+- ![Reset](./pams-docs/wave_reset.png) Reset: a trigger that fires when the clock stops (can be used
+  to trigger other modules to reset, e.g. sequencers sequential switches, other euclidean
+  generators). The fired trigger is 10ms in duration at 10V times the channel's amplitude. e.g. at
+  50% the trigger will be 5V.
+- ![Start](./pams-docs/wave_start.png) Start: a trigger that fires when the clock starts (can be
+  used to trigger other modules, or reset on-start). The trigger is at least 10ms long, but is based
+  on the clock speed and may be longer. Trigger voltage is 10V times the channel's amplitude. e.g.
+  at 50% the trigger will be 5V
+- ![Run](./pams-docs/wave_run.png) Run: a gate that is high when the clock is running and low when
+  the clock is stopped. As long as the clock is running the gate will remain high.  Gate voltage is
+  10V times channel's amplitude. e.g. at 50% the gate is 5V.
 
 See below for details on setting the channels' amplitude parameters
 
@@ -132,51 +136,61 @@ The submenu for each CV output has the following options:
 
 - `Wave` -- the wave shape to output. Square/Triangle/Sine/Random/AIN
   - ![Square Wave](./pams-docs/wave_square.png) Square: square/pulse wave with adjustable width
-  - ![Triangle Wave](./pams-docs/wave_triangle.png) Triangle: triangle wave with adjustable symmetry (saw to symmetrical
-    triangle to ramp)
+  - ![Triangle Wave](./pams-docs/wave_triangle.png) Triangle: triangle wave with adjustable symmetry
+    (saw to symmetrical triangle to ramp)
   - ![Sine Wave](./pams-docs/wave_sine.png) Sine: bog-standard sine wave
   - ![ADSR Envelope](./pams-docs/wave_adsr.png) ADSR: an Attack/Decay/Sustain/Release envelope
-  - ![Turing](./pams-docs/wave_turing.png) Turing: a shift-register like the Music Thing Modular Turing Machine. Can either
-    output pulses or stepped CV.
-  - ![Random Wave](./pams-docs/wave_random.png) Random: outputs a random voltage at the start of every euclidean pulse,
-    holding that voltage until the next pulse (if `EStep` is zero then every clock tick is assumed to be a euclidean
-    pulse)
-  - ![AIN](./pams-docs/wave_ain.png) AIN (S&H): acts as a sample & hold of `ain`, with a sample taken at the start of every
-    euclidean pulse (if `EStep` is zero then every clock tick is assumed to be a euclidean pulse)
-  - ![KNOB](./pams-docs/wave_knob.png) KNOB (S&H): acts as a sample & hold of `k1`, with a sample taken at the start of every
-    euclidean pulse (if `EStep` is zero then every clock tick is assumed to be a euclidean pulse)
+  - ![Turing](./pams-docs/wave_turing.png) Turing: a shift-register like the Music Thing Modular
+    Turing Machine. Can either output pulses or stepped CV.
+  - ![Random Wave](./pams-docs/wave_random.png) Random: outputs a random voltage at the start of
+    every euclidean pulse, holding that voltage until the next pulse (if `EStep` is zero then every
+    clock tick is assumed to be a euclidean pulse)
+  - ![AIN](./pams-docs/wave_ain.png) AIN (S&H): acts as a sample & hold of `ain`, with a sample
+    taken at the start of every euclidean pulse (if `EStep` is zero then every clock tick is assumed
+    to be a euclidean pulse)
+  - ![KNOB](./pams-docs/wave_knob.png) KNOB (S&H): acts as a sample & hold of `k1`, with a sample
+    taken at the start of every euclidean pulse (if `EStep` is zero then every clock tick is assumed
+    to be a euclidean pulse)
 
-- `Width` -- width of the resulting wave. See below for the effects of width adjustment on different wave shapes
+- `Width` -- width of the resulting wave. See below for the effects of width adjustment on different
+  wave shapes
 - `Phase` -- the phase offset of the wave. Starting a triangle at 50% would start it midway through
 - `Ampl.` -- the maximum amplitude of the output as a percentage of the 10V hardware maximum
 - `Attack` -- the percentage of the cycle time dedicated to the attack phase of an ADSR envelope
-- `Decay` -- the percentage of the cycle time minus attack time dedicated to the decay phase of an ADSR envelope
+- `Decay` -- the percentage of the cycle time minus attack time dedicated to the decay phase of an
+  ADSR envelope
 - `Sustain` -- the percentage level of the sustain phase of an ADSR envelope
-- `Release` -- the percentage of of the cyle time minus the attack & decay phases dedicated to the release phase of
-  an ADSR envelope
+- `Release` -- the percentage of of the cyle time minus the attack & decay phases dedicated to the
+  release phase of an ADSR envelope
 - `TLen` -- The length of the Turning machine shift register
 - `TLock` -- The lock value of the Turing machine shift register
 - `TMode` -- The mode of the Turing machine: either `Gate` or `CV`
 - `Skip%` -- the probability that a square pulse or euclidean trigger will be skipped
-- `EStep` -- the number of steps in the euclidean rhythm. If zero, the euclidean generator is disabled
+- `EStep` -- the number of steps in the euclidean rhythm. If zero, the euclidean generator is
+  disabled
 - `ETrig` -- the number of pulses in the euclidean rhythm
 - `ERot` -- rotation of the euclidean rhythm
-- `Swing%` -- percentage division between pairs of consecutive notes. 50% results in no swing. Less than 50% results in
-  a short-long-short-long-... pattern of notes. Greater than 50% results in a long-short-long-short-... pattern of notes
+- `Swing%` -- percentage division between pairs of consecutive notes. 50% results in no swing. Less
+  than 50% results in a short-long-short-long-... pattern of notes. Greater than 50% results in a
+  long-short-long-short-... pattern of notes
 - `Quant` -- quantization scale
 - `Q Root` -- quantizer root: transposes the quantized output up by the number of semitones above C.
-- `Mute` -- if a channel is muted its output will always be zero. A muted channel can still be edited.
-- `Save` -- save the channel's current settings to one of 6 banks. Banks are shared across all channels
+- `Mute` -- if a channel is muted its output will always be zero. A muted channel can still be
+  edited.
+- `Save` -- save the channel's current settings to one of 6 banks. Banks are shared across all
+  channels
 - `Load` -- load a channel's settings from one of 6 banks. Banks are shared across all channels
-- `Reset` -- if set to `OK` all channel settings are reset to their defaults. Setting to `Cancel` takes no action
+- `Reset` -- if set to `OK` all channel settings are reset to their defaults. Setting to `Cancel`
+  takes no action
 
-The values of the `Attack`, `Decay`, `Sustain`, and `Release` settings are ignored if the wave whape is not set to
-`ADSR`
+The values of the `Attack`, `Decay`, `Sustain`, and `Release` settings are ignored if the wave whape
+is not set to `ADSR`
 
 ### Changing Settings While Clock is Running
 
-Changing some settings while the clock is running may have undesirable side-effects, including clicks, out-of-time
-triggers, and the like.  Generally-speaking it is best to make changes while the clock is stopped.
+Changing some settings while the clock is running may have undesirable side-effects, including
+clicks, out-of-time triggers, and the like.  Generally-speaking it is best to make changes while
+the clock is stopped.
 
 Applies immediately, can be safely changed at any time:
 - Mute
@@ -192,17 +206,18 @@ Applies immediately, but may result in rapid output level changes, clicks, and s
 - Quantizer root
 - Clock Mod
 
-Can be changed safely at any time, but the effect is delayed until the current wave shape completes its cycle:
+Can be changed safely at any time, but the effect is delayed until the current wave shape completes
+its cycle:
 - Euclidean length, triggers, rotation
 
 ### ADSR Envelope
 
 The ADSR envelope is affected by the `Width`, `Amplitude` and `Phase` parameters:
 - `Phase` will shift the timing of the envelope
-- `Width` adjusts the total duration of the envelope. The envelope always starts at the beginning of the phase,
-  but may end early, outputting 0.0V after the end of the release
-- the `Amplitude` setting adjusts the overall height of the wave. The attack phase always reaches peak amplitude,
-  and the sutain phase is calculated relative to the `Amplitude` setting.
+- `Width` adjusts the total duration of the envelope. The envelope always starts at the beginning
+  of the phase, but may end early, outputting 0.0V after the end of the release
+- the `Amplitude` setting adjusts the overall height of the wave. The attack phase always reaches
+  peak amplitude, and the sutain phase is calculated relative to the `Amplitude` setting.
 
 The following diagram shows the breakdown of the ADSR envelope:
 
@@ -229,8 +244,8 @@ T' = T * Width%
 
 ### Phase Offsets
 
-The following ascii art shows the effect of phase on a squarewave.  Note that the wave is not clipped; the entire wave
-form is simply shifted to the right by the phase percentage.
+The following ascii art shows the effect of phase on a squarewave.  Note that the wave is not
+clipped; the entire wave form is simply shifted to the right by the phase percentage.
 
 ```
 x1, phase = 0
@@ -254,9 +269,9 @@ __|    |____|    |____|    |____|    |__
 
 ### Swing
 
-The following ascii art shows the effects of chaning the swing parameter on a simple square wave.  Note that the duty
-cycle of the wave is preserved within each step, and each 2-note cycle takes the same amount of time. Only the timing
-between the first and second notes of each pair is affected.
+The following ascii art shows the effects of chaning the swing parameter on a simple square wave.
+Note that the duty cycle of the wave is preserved within each step, and each 2-note cycle takes the
+same amount of time. Only the timing between the first and second notes of each pair is affected.
 
 ```
 Swing = 50%
@@ -278,17 +293,18 @@ Swing = 75%
 |      |______|  |__|      |______|  |__
 ```
 
-Setting the swing too high or too low, especially at higher clock speeds, can compress the shorter note so much that
-it ceases to exist. In that case the 0-length note is skipped entirely. This can lead to some interesting interactions
-with Euclidean patterns, as every second step is skipped whether it's on or off.
+Setting the swing too high or too low, especially at higher clock speeds, can compress the shorter
+note so much that it ceases to exist. In that case the 0-length note is skipped entirely. This can
+lead to some interesting interactions with Euclidean patterns, as every second step is skipped
+whether it's on or off.
 
 ### `AIN` and `Random` Waves
 
-`AIN` and `Random` wave modes are treated like a sample-hand-hold of the incoming signal, with the sample taken on the
-rising edge of a similarly-configured square wave.
+`AIN` and `Random` wave modes are treated like a sample-hand-hold of the incoming signal, with the
+sample taken on the rising edge of a similarly-configured square wave.
 
-For example, imagine `AIN` has a saw wave being sent into it.  For example, below we have a saw LFO being sent into
-`AIN` with CV1 configured to read it.
+For example, imagine `AIN` has a saw wave being sent into it.  For example, below we have a saw LFO
+being sent into `AIN` with CV1 configured to read it.
 ```
 AIN
       /|      /|      /|      /|      /|
@@ -315,20 +331,22 @@ _____|         |____|         |__________
 
 In `Gate` mode, it outputs simple of/off square waves.
 
-Like the [original Turing Machine](https://github.com/TomWhitwell/TuringMachine) module, the `TLock` parameter
-controls the likelihood that bits are randomly flipped when the register shifts.  When `TLock` is _positive_, the
-output pattern is equal to the `TLength` parameter. When `TLock` is _negative_ the output pattern is the initial
-`TLength` bits, followed by their compliment.  The further from zero in either direction, the less likely it is that
-bits will be flipped during the shift.
+Like the [original Turing Machine](https://github.com/TomWhitwell/TuringMachine) module, the `TLock`
+parameter controls the likelihood that bits are randomly flipped when the register shifts.  When
+`TLock` is _positive_, the output pattern is equal to the `TLength` parameter. When `TLock` is
+_negative_ the output pattern is the initial `TLength` bits, followed by their compliment.  The
+further from zero in either direction, the less likely it is that bits will be flipped during the
+shift.
 
-For example if `TLength` is 8 and the register contains `10101100`, and `TLock` is `+100` the gate output will be
-`[1, 0, 1, 0, 1, 1, 0, 0]`.  If `TLock` is `-100` instead the gate output will be
+For example if `TLength` is 8 and the register contains `10101100`, and `TLock` is `+100` the gate
+output will be `[1, 0, 1, 0, 1, 1, 0, 0]`.  If `TLock` is `-100` instead the gate output will be
 `[1, 0, 1, 0, 1, 1, 0, 0, 0, 1, 0, 1, 0, 0, 1, 1]`.
 
-In `CV` mode it outputs a pseudo-random control voltage,similar to the `Random` wave. The value of the wave is
-determined by looking at the lowest 8 bits in the register (the register always contains 16 bits, regardless of
-`TLength`), treating them as a binary integer, and dividing that value by 256.  The resulting value in the range
-`[0, 1)` is multiplied by the output amplitude to generate the output voltage.
+In `CV` mode it outputs a pseudo-random control voltage,similar to the `Random` wave. The value of
+the wave is determined by looking at the lowest 8 bits in the register (the register always contains
+16 bits, regardless of `TLength`), treating them as a binary integer, and dividing that value by
+256. The resulting value in the range `[0, 1)` is multiplied by the output amplitude to generate the
+output voltage.
 
 ### Effects of Width on Different Wave Shapes
 
@@ -351,9 +369,9 @@ The Start trigger fires once when the clock is started. The duration of the trig
 10ms, but may be longer depending on the BPM. This allows you to start other modules at the
 same time as Pam's Workout on the EuroPi.
 
-The duration of the `Start` trigger is based on the BPM of the master clock and the static PPQN of 48.
-The trigger turns on immediately and stays on for each PPQN pulse until it's stayed on for at least
-10ms. The table below shows approximate trigger times for some common BPM settings:
+The duration of the `Start` trigger is based on the BPM of the master clock and the static PPQN of
+48. The trigger turns on immediately and stays on for each PPQN pulse until it's stayed on for at
+least 10ms. The table below shows approximate trigger times for some common BPM settings:
 
 | BPM | Trigger length (ms, approx.) | PPQN pulses |
 |-----|------------------------------|-------------|
@@ -370,8 +388,8 @@ the variablility of the trigger width shouldn't cause any harmful effects in mos
 ### Quantization
 
 All quantizers are tuned to treat the root note of their respective scales as C by default, with the
-quantizer root transposing this by the number of semitones above C. For example if the root is C# the
-transposed output will be shifted up by 1 semitone.
+quantizer root transposing this by the number of semitones above C. For example if the root is C#
+the transposed output will be shifted up by 1 semitone.
 
 The following scales are available:
 

--- a/software/contrib/particle_physics.md
+++ b/software/contrib/particle_physics.md
@@ -1,7 +1,7 @@
 # Particle Physics
 
-This program implements a very basic particle physics model where an object falls under gravity and bounces. Every
-bounce reduces the velocity proportional to an elasticity constant.
+This program implements a very basic particle physics model where an object falls under gravity and
+bounces. Every bounce reduces the velocity proportional to an elasticity constant.
 
 ## I/O Mapping
 
@@ -18,24 +18,26 @@ bounce reduces the velocity proportional to an elasticity constant.
 
 ## CV Outputs
 
-`cv1` outputs a 5V trigger every time the particle touches the ground.  When at rest this trigger becomes a gate,
-indicating that the particle is always touching the ground.
+`cv1` outputs a 5V trigger every time the particle touches the ground.  When at rest this trigger
+becomes a gate, indicating that the particle is always touching the ground.
 
-`cv2` outputs a 5V trigger every time the particle reaches its peak altitude for the bounce and begins falling
-again. When at rest this becomes a gate, indicating that the particle is always at peak altitude.
+`cv2` outputs a 5V trigger every time the particle reaches its peak altitude for the bounce and
+begins falling again. When at rest this becomes a gate, indicating that the particle is always at
+peak altitude.
 
-`cv3` outputs a gate when the particle is at rest.  This can be patched into `din` to automatically reset the
-particle when it comes to rest.
+`cv3` outputs a gate when the particle is at rest.  This can be patched into `din` to automatically
+reset the particle when it comes to rest.
 
 `cv4` outputs a control signal in the range `[0, 10]V`, proportional to the particles height.
 
-`cv5` outputs a control signal in the range `[0, 10]V`, proportional to the particles absolute velocity.  (Because
-EuroPi can only output positive voltages this output will be high when the particle is moving quickly up or down.)
+`cv5` outputs a control signal in the range `[0, 10]V`, proportional to the particles absolute
+velocity.  (Because EuroPi can only output positive voltages this output will be high when the
+particle is moving quickly up or down.)
 
 ## Physics, Explained
 
-For clarity, positive values are up and negative values are down.  Units don't matter, but if it helps assume
-everything is SI units (meters, m/s, m/s^2).
+For clarity, positive values are up and negative values are down.  Units don't matter, but if it
+helps assume everything is SI units (meters, m/s, m/s^2).
 
 - let `(y, dy)` be a 1-D particle, representing its height `y` and velocity `dy`
 - let `h` be the particle's initial height above the ground
@@ -52,12 +54,13 @@ dy' = dy - g * dt
 y' = y + dy * dt
 ```
 
-If `y'` is less than or equal to zero we assume the particle has it the ground and further modify `dy'`:
+If `y'` is less than or equal to zero we assume the particle has it the ground and further modify
+`dy'`:
 
 ```
 dy' = |dy| * e
 ```
 
-To avoid floating point rounding causing the particle to bounce forever, we assume it has come to rest if its
-peak height for any bounce is `0.002`. When this occurs, `y` and `dy` are both set to zero and the simulation
-effectively stops.
+To avoid floating point rounding causing the particle to bounce forever, we assume it has come to
+rest if its peak height for any bounce is `0.002`. When this occurs, `y` and `dy` are both set to
+zero and the simulation effectively stops.

--- a/software/contrib/pet_rock.md
+++ b/software/contrib/pet_rock.md
@@ -19,13 +19,13 @@ This script generates pseudo-random gate sequences based on the phase of the moo
 - `cv5`: inverted gate output for sequence B
 - `cv6`: end of sequence trigger for sequence B
 
-Both sequence A and sequence B can be internally clocked by setting the speed using `K1` and `K2`. Turning
-these knobs fully anticlockwise will stop the internal clocks.
+Both sequence A and sequence B can be internally clocked by setting the speed using `K1` and `K2`.
+Turning these knobs fully anticlockwise will stop the internal clocks.
 
 ## Configuration
 
-Pet Rock can be configured to use different pseudo-random rhythm-generating algorithms. To choose, edit
-`config/PetRock.json` to set the `MOODS` key:
+Pet Rock can be configured to use different pseudo-random rhythm-generating algorithms. To choose,
+edit `config/PetRock.json` to set the `MOODS` key:
 ```json
 {
     "MOODS": "classic"
@@ -44,8 +44,8 @@ Depending on the `MOODS` configured, the following algorithms are used, cycling 
 
 **Alternate**
 
-These algorithms were implemented in the original Pet Rock firmware, but ultimately not used in the final
-release.
+These algorithms were implemented in the original Pet Rock firmware, but ultimately not used in the
+final release.
 - ![hearts](./pet_rock-docs/heart.png) Blocks
 - ![spades](./pet_rock-docs/spade.png) Culture
 - ![diamonds](./pet_rock-docs/diamond.png) Over
@@ -53,24 +53,24 @@ release.
 
 **All**
 
-When `"all"` moods are selected, the order is the 4 classic algorithms, followed by the 4 alternate algorithms,
-in the order listed above.
+When `"all"` moods are selected, the order is the 4 classic algorithms, followed by the 4 alternate
+algorithms, in the order listed above.
 
 
 ### Note on suits
 
-Yes, I'm aware that "shields" isn't a normal Tarot suit. Originally I used "clubs" (an alternative to the
-traditional "wands" suit in most tarot decks). But it seemed weird having 3/4 English card suits used for
-the alternate moods, and then have "shields" tossed-in to fill it out; "shields" is a suit more associated
-with Swiss playing cards.
+Yes, I'm aware that "shields" isn't a normal Tarot suit. Originally I used "clubs" (an alternative
+to the traditional "wands" suit in most tarot decks). But it seemed weird having 3/4 English card
+suits used for the alternate moods, and then have "shields" tossed-in to fill it out; "shields" is
+a suit more associated with Swiss playing cards.
 
-Since shields and swords are a natural pairing, I swapped things around to have, in my mind, more logical
-groupings. I'm sorry if this decision causes anyone distress.
+Since shields and swords are a natural pairing, I swapped things around to have, in my mind, more
+logical groupings. I'm sorry if this decision causes anyone distress.
 
-Additionally, I realize the "pentacle" symbol has some negative associations for some. No offense is meant;
-this is a traditional suit in tarot cards, and felt appropriate for a moon-phase-tracking program. I did
-consider swapping it for its "coins" alternative, but was concerned that a circular or elliptical coin
-motif might be too visually similar to the full & gibbous moon icons.
+Additionally, I realize the "pentacle" symbol has some negative associations for some. No offense
+is meant; this is a traditional suit in tarot cards, and felt appropriate for a moon-phase-tracking
+program. I did consider swapping it for its "coins" alternative, but was concerned that a circular
+or elliptical coin motif might be too visually similar to the full & gibbous moon icons.
 
 
 ## Required Hardware

--- a/software/contrib/piconacci.md
+++ b/software/contrib/piconacci.md
@@ -1,23 +1,15 @@
-# EuroPi Piconacci - Fibonacci based triggers
+# Piconacci - Fibonacci based triggers
 
-author: Sean Bechhofer (github.com/seanbechhofer)
+Piconacci is a simple trigger generator that produces a collection of triggers, one of each of the
+six outputs. Each output is associated with a clock division value. Those values are drawn from the
+Fibonacci series. So for example, clock divisions of 1, 2, 3, 5, 8, and 13.
 
-date: 2022-05-165
-
-labels: triggers, numbers
-
-Piconacci is a simple trigger generator that produces a collection of triggers, one of each of the six outputs. Each output is associated with a clock division value. Those values are drawn from the Fibonacci series. So for example, clock divisions of 1, 2, 3, 5, 8, and 13.
-
-Short button presses will move the trigger values through the sequence, e.g. to 2, 3, 5, 8, 13, and 21.
+Short button presses will move the trigger values through the sequence, e.g. to 2, 3, 5, 8, 13,
+and 21.
 
 Long button presses will rotate the values, e.g. to 3, 5, 8, 13, 21, and 2.
 
-Credits:
-- The Europi hardware and firmware was designed by Allen Synthesis:
-https://github.com/Allen-Synthesis/EuroPi
-- The name was suggested by @djmjr on the EuroPi Discord.
-
-# Controls
+## Controls
 
 - digital_in: Clock in
 - analog_in: Not used
@@ -36,12 +28,13 @@ https://github.com/Allen-Synthesis/EuroPi
 - output_5: trigger
 - output_6: trigger
 
-## Basic Usage
+### Basic Usage
+
 1. Connect a clock input to the Digital input
 2. Triggers will appear on the outputs.
 3. Use buttons to move values or rotate the triggers.
 
-# Details
+## Details
 
 Piconnaci emits triggers on each output with clock divisions based on
 values from the Fibonacci series. Those values are taken by selecting
@@ -55,12 +48,22 @@ numbers showing which division is used for each output.
 
 ![pico drawio](https://user-images.githubusercontent.com/1035997/168587520-de2286af-1ae4-45be-a0f4-0aeb8128c4a9.png)
 
-# Limitations
+## Limitations
 
-The code has a limit on the number of values used (50). In practice this is unlikely to be an issue and probably works for most sensible circumstances. The 50th value (disregarding 0, 1) is 20,365,011,074. At a BPM of 120, that'll be a trigger every 300 years which is pretty slow even for glacial ambient.
+The code has a limit on the number of values used (50). In practice this is unlikely to be an issue
+and probably works for most sensible circumstances. The 50th value (disregarding 0, 1) is
+20,365,011,074. At a BPM of 120, that'll be a trigger every 300 years which is pretty slow even for
+glacial ambient.
 
 Trigger length is coupled to the incoming clock.
 
-# Known bugs / Interesting features
+## Known bugs / Interesting features
 
 Probably.
+
+## Credits:
+
+- The Europi hardware and firmware was designed by Allen Synthesis:
+https://github.com/Allen-Synthesis/EuroPi
+
+- The name was suggested by @djmjr on the EuroPi Discord.

--- a/software/contrib/poly_square.md
+++ b/software/contrib/poly_square.md
@@ -1,44 +1,20 @@
 # Poly Square
 
-author: Tyler Schreiber (github.com/t-schreibs)
-date: 2022-05-10
-labels: oscillator, poly
+An audio-rate oscillator? On the EuroPi? You bet!
 
-An oscillator? On the EuroPi? You bet!
+This script makes use of a small PIO program to produce six square wave oscillators, each of which
+can be set to different frequencies. For a brief primer on the Pi Pico's PIO, visit
+https://blues.io/blog/raspberry-pi-pico-pio/. The core PIO program for this script had its origins
+in Ben Everard's great little article on HackSpace: https://hackspace.raspberrypi.com/articles/raspberry-pi-picos-pio-for-mere-mortals-part-3-sound.
+Is it all just assembly code magic? Yes, sort of, but it really isn't all that scary if you take the
+time to learn how the different PIO instructions work. There are only 9 of them!
 
-This script makes use of a small PIO program to produce six square wave oscillators, each of which can be set to different frequencies. For a brief primer on the Pi Pico's PIO, visit https://blues.io/blog/raspberry-pi-pico-pio/. The core PIO program for this script had its origins in Ben Everard's great little article on HackSpace: https://hackspace.raspberrypi.com/articles/raspberry-pi-picos-pio-for-mere-mortals-part-3-sound. Is it all just assembly code magic? Yes, sort of, but it really isn't all that scary if you take the time to learn how the different PIO instructions work. There are only 9 of them!
+The Poly Square is six independent oscillators which output on CVs 1-6. The base pitch is set by the
+analog input, which is interpreted as a V/oct input with 0V = C. Knob 1 allows for detuning of the 6
+voices, and as the knob is turned clockwise, the spread between them increases. Button 2 toggles the
+maximum detune between a half step and a major 9th. Knob 2 sets the polyphony mode.
 
-The Poly Square is six independent oscillators which output on CVs 1-6. The base pitch is set by the analog input, which is interpreted as a V/oct input with 0V = C. Knob 1 allows for detuning of the 6 voices, and as the knob is turned clockwise, the spread between them increases. Button 2 toggles the maximum detune between a half step and a major 9th. Knob 2 sets the polyphony mode.
-
-## The polyphony modes
-The following is a table of all available polyphony modes, as well as the offset of each CV output from the root note (shown in half steps):
-| Mode | CV1 | CV2 | CV3 | CV4 | CV5 | CV6 |
-|---|:-:|:-:|:-:|:-:|:-:|:-:|
-| Unison | 0 | 0 | 0 | 0 | 0 | 0 |
-| 5th | 0 | 0 | 7 | 0 | 0 | 7 |
-| Octave | 0 | 0 | 12 | 0 | 0 | 12 |
-| Power chord | 0 | 7 | 12 | 0 | 7 | 12 |
-| Stacked 5ths | 0 | 7 | 14 | 0 | 7 | 14 |
-| Minor triad | 0 | 7 | 15 | 0 | 7 | 15 |
-| Major triad | 0 | 7 | 16 | 0 | 7 | 16 |
-| Diminished | 0 | 6 | 15 | 0 | 6 | 15 |
-| Augmented | 0 | 8 | 16 | 0 | 8 | 16 |
-| Major 6th | 0 | 4 | 9 | 0 | 4 | 9 |
-| Major 7th | 0 | 4 | 11 | 0 | 4 | 11 |
-| Minor 7th | 0 | 3 | 10 | 0 | 3 | 10 |
-| Major penta. | 0 | 2 | 4 | 7 | 9 | 12 |
-| Minor penta. | 0 | 2 | 3 | 7 | 9 | 12 |
-| Whole tone | 0 | 2 | 4 | 6 | 8 | 10 |
-
-## Tuning mode
-When button 1 is depressed, tuning mode is activated, and it remains active until the button is released. While in tuning mode, the base pitch for a 0V signal may be adjusted. In tuning mode, knob 1 is repurposed to adjust coarse tuning (up to 8 octaves) while knob 2 handles fine tuning (up to an octave). Tuning settings are saved to storage when button 1 is released.
-
-Credits:
-- The Europi hardware and firmware was designed by Allen Synthesis: https://github.com/Allen-Synthesis/EuroPi
-- The basis of the PIO code is from an example written by Ben Everard in a HackSpace article: https://hackspace.raspberrypi.com/articles/raspberry-pi-picos-pio-for-mere-mortals-part-3-sound
-- Thanks to djmjr (github.com/djmjr) for testing that 6 oscillators can be run simultaneously, and for the idea to refrain from adjusting tuning settings until the knobs have been moved
-
-# Controls
+## Controls
 - digital_in: unused
 - analog_in: V/oct
 - knob_1: detune
@@ -54,11 +30,50 @@ Credits:
 - output_5: oscillator 5
 - output_6: oscillator 6
 
+## The polyphony modes
+
+The following is a table of all available polyphony modes, as well as the offset of each CV output
+from the root note (shown in half steps):
+
+| Mode         | CV1 | CV2 | CV3 | CV4 | CV5 | CV6 |
+|--------------|:---:|:---:|:---:|:---:|:---:|:---:|
+| Unison       | 0   | 0   | 0   | 0   | 0   | 0   |
+| 5th          | 0   | 0   | 7   | 0   | 0   | 7   |
+| Octave       | 0   | 0   | 12  | 0   | 0   | 12  |
+| Power chord  | 0   | 7   | 12  | 0   | 7   | 12  |
+| Stacked 5ths | 0   | 7   | 14  | 0   | 7   | 14  |
+| Minor triad  | 0   | 7   | 15  | 0   | 7   | 15  |
+| Major triad  | 0   | 7   | 16  | 0   | 7   | 16  |
+| Diminished   | 0   | 6   | 15  | 0   | 6   | 15  |
+| Augmented    | 0   | 8   | 16  | 0   | 8   | 16  |
+| Major 6th    | 0   | 4   | 9   | 0   | 4   | 9   |
+| Major 7th    | 0   | 4   | 11  | 0   | 4   | 11  |
+| Minor 7th    | 0   | 3   | 10  | 0   | 3   | 10  |
+| Major penta. | 0   | 2   | 4   | 7   | 9   | 12  |
+| Minor penta. | 0   | 2   | 3   | 7   | 9   | 12  |
+| Whole tone   | 0   | 2   | 4   | 6   | 8   | 10  |
+
+## Tuning mode
+
+When button 1 is depressed, tuning mode is activated, and it remains active until the button is
+released. While in tuning mode, the base pitch for a 0V signal may be adjusted. In tuning mode, knob
+1 is repurposed to adjust coarse tuning (up to 8 octaves) while knob 2 handles fine tuning (up to an
+octave). Tuning settings are saved to storage when button 1 is released.
+
+Credits:
+- The Europi hardware and firmware was designed by Allen Synthesis: https://github.com/Allen-Synthesis/EuroPi
+- The basis of the PIO code is from an example written by Ben Everard in a HackSpace article:
+  https://hackspace.raspberrypi.com/articles/raspberry-pi-picos-pio-for-mere-mortals-part-3-sound
+- Thanks to djmjr (github.com/djmjr) for testing that 6 oscillators can be run simultaneously, and
+  for the idea to refrain from adjusting tuning settings until the knobs have been moved
+
 ## Basic Usage
+
 1. Switch on
 2. Connect outputs to mixer, filters, what have you
 3. Send V/oct signal to analog input
 4. Enjoy square waves
 
 ## Details
+
 Polyphony modes are easy to add! Just add them to the PolySquare.modes list.

--- a/software/contrib/probapoly.md
+++ b/software/contrib/probapoly.md
@@ -1,97 +1,100 @@
-# EuroPi Probapoly - A polyrhythmic gate generator with probabilty
+# Probapoly - A polyrhythmic gate generator with probabilty
 
-Probapoly
+Probapoly creates interesting polyrhythmic gate patterns while also allowing probabilities to be set
+on gates. Given values for and upper and lower rhythmic ratios, Probapoly will create a looping
+pattern as short as possible with no repetition of the pattern within the loop.
 
-author: Nik Ansell (github.com/gamecat69)
+Outputs 1,2 and 3 output gates based on the upper rhythmic ratio. Outputs 4,5 and 6 output gates
+based on the lower rhythmic ratio.
 
-date: 2022-07-24
+Outputs 1 and 4 always have a probability of 100%. Outputs 2 and 5 have a default probability of
+50%. Outputs 3 and 6 have a default probability of 25%.
 
-labels: sequencer, performance, gates, polyrhythm, probability
+- digital_in: Clock input
+- analog_in: Different mode, adjusted by setting self.ainMode as follows:
+    - Mode 1: Analogue input toggles double time feature
+    - Mode 2: Analogue input voltage adjusts the upper poly value
+    - [default] Mode 3: Analogue input voltage adjusts the probabilities of outputs 2,3,5,6 sending
+      gates
 
-Probapoly creates interesting polyrhythmic gate patterns while also allowing probabilities to be set on gates.
-Given values for and upper and lower rhythmic ratios, Probapoly will create a looping pattern as short as possible with no repetition of the pattern within the loop.
+- button_1:
+    - Short press (<500ms): Reduce pattern length (using manual pattern length is ON).
+    - Long Press (>500ms): Toggle doubletime feature
+- button_2:
+    - Short press (<500ms): Reduce pattern length (using manual pattern length is ON).
+    - Long Press (>500ms): Toggle Manual pattern length feature
 
-Outputs 1,2 and 3 output gates based on the upper rhythmic ratio. Outputs 4,5 and 6 output gates based on the lower rhythmic ratio.
+- knob_1: Select upper polyrhythm value
+- knob_2: Select lower polyrhythm value
 
-Outputs 1 and 4 always have a probability of 100%. Outputs 2 and 5 have a default probability of 50%. Outputs 3 and 6 have a default probability of 25%.
+- output_1: Gate upper polyrhythm
+- output_2: Gate upper polyrhythm (50% probability)
+- output_3: Gate upper polyrhythm (25% probability)
+- output_4: Gate lower polyrhythm
+- output_5: Gate lower polyrhythm (50% probability)
+- output_6: Gate lower polyrhythm (50% probability)
 
-digital_in: Clock input
-analog_in: Different mode, adjusted by setting self.ainMode as follows:
-- Mode 1: Analogue input toggles double time feature
-- Mode 2: Analogue input voltage adjusts the upper poly value
-- [default] Mode 3: Analogue input voltage adjusts the probabilities of outputs 2,3,5,6 sending gates
+## Demo video
 
-button_1:
-    Short press (<500ms): Reduce pattern length (using manual pattern length is ON).
-    Long Press (>500ms): Toggle doubletime feature
-button_2:
-    Short press (<500ms): Reduce pattern length (using manual pattern length is ON).
-    Long Press (>500ms): Toggle Manual pattern length feature
+https://www.youtube.com/watch?v=Rflmr2yJYG0
 
-knob_1: Select upper polyrhythm value
-knob_2: Select lower polyrhythm value
-
-output_1: Gate upper polyrhythm
-output_2: Gate upper polyrhythm (50% probability)
-output_3: Gate upper polyrhythm (25% probability)
-output_4: Gate lower polyrhythm
-output_5: Gate lower polyrhythm (50% probability)
-output_6: Gate lower polyrhythm (50% probability)
-
-Demo video: https://www.youtube.com/watch?v=Rflmr2yJYG0
-
-# Display
+## Display
 
 Top Row: Upper ratio value, output 2 probability, output 3 probability
 Bottom Row: Lower ratio value, output 5 probability, output 6 probability
 
 Top right: current step / pattern length
 
-# Getting Started
+## Getting Started
 
 The following sections provide instructions for using Probapoly to create some interesting rhythms.
 
-## Initial Connections
+### Initial Connections
+
 1. Connect a 50% duty cycle gate / clock to the Digital input
 2. (Optional) Connect a CV source to the analogue input (0 to +5V works best)
 3. Connect each output (1 to 6) to modules you want to send gates to
 
-## Creating Polyrhythms
+### Creating Polyrhythms
 
-1. Use knob 1 to set the upper ratio and knob 2 to set the lower ratio. Changing these values will cause Probapoly to update the gate patterns in real-time.
+1. Use knob 1 to set the upper ratio and knob 2 to set the lower ratio. Changing these values will
+   cause Probapoly to update the gate patterns in real-time.
 
-The value of the upper and lower values determine the frequency of a gate output based on the incoming clock. A value of 1 will output a gate every 1 clock trigger, a value of 3 will output a gate every 3 clock triggers.
+The value of the upper and lower values determine the frequency of a gate output based on the
+incoming clock. A value of 1 will output a gate every 1 clock trigger, a value of 3 will output a
+gate every 3 clock triggers.
 
 Outputs 1,2 and 3 use the same rhythm, but with probabilities of 100, 50 and 25% respectively.
 Outputs 4,5 and 6 use the same rhythm, but with probabilities of 100, 50 and 25% respectively.
 
 See below for some examples.
 
-### 1:$ Four to the floor
+#### 1:$ Four to the floor
 upper: 1
 lower: 4
 automatically calculated pattern length: 4
 
-### 2:3 Hemiola
+#### 2:3 Hemiola
 upper: 2
 lower: 3
 automatically calculated pattern length: 6
 
-### 4:3 Four over Three (Pass the god damn butter)
+#### 4:3 Four over Three (Pass the god damn butter)
 upper: 4
 lower: 3
 automatically calculated pattern length: 12
 
-### 16:15
+#### 16:15
 upper: 16
 lower: 15
 automatically calculated pattern length: 240
 
-# Example patches
+## Example patches
 
-## Polyrhythmic percussion with probabilistic decay and FX movement
+### Polyrhythmic percussion with probabilistic decay and FX movement
 
-This patch will create a polyrhythm with two percussive elements. On 50% of the gates, the kick and tom decay will be changed. On 25% of the gates an FX module will have it's parameters tweaked.
+This patch will create a polyrhythm with two percussive elements. On 50% of the gates, the kick and
+tom decay will be changed. On 25% of the gates an FX module will have it's parameters tweaked.
 
 - Connect output 1 to some percussion element (e.g. a kick)
 - Connect output 2 to an envelope, connect the envelope to the kick decay
@@ -104,7 +107,7 @@ This patch will create a polyrhythm with two percussive elements. On 50% of the 
 - Set the upper value to 4
 - Set the lower value to 3
 
-## Polyrhythmic melodies
+### Polyrhythmic melodies
 
 This patch uses the polyrythmic gates to advance sequencer clocks
 
@@ -113,4 +116,5 @@ This patch uses the polyrythmic gates to advance sequencer clocks
 
 - Create a short (e.g. 4) pattern on both sequencers
 
-- Adjust the upper and lower values manually or during a performance to created interesting and fluid polyrhythmic melodies
+- Adjust the upper and lower values manually or during a performance to created interesting and
+  fluid polyrhythmic melodies

--- a/software/contrib/radio_scanner.md
+++ b/software/contrib/radio_scanner.md
@@ -2,25 +2,34 @@
 
 ## Concept
 
-I once bought a shortwave radio after seeing one belonging to my friend, and found that the experience of scanning through to try and find interesting sounds in two planes, and wanted to apply this concept to Eurorack.
-This program allows you to control up to 6 parameters, but all based on the key two CV outputs controlled by knobs 1 and 2.
+I once bought a shortwave radio after seeing one belonging to my friend, and found that the
+experience of scanning through to try and find interesting sounds in two planes, and wanted to
+apply this concept to Eurorack.
+
+This program allows you to control up to 6 parameters, but all based on the key two CV outputs
+controlled by knobs 1 and 2.
 
 
-Inspiration (Shortwave radio)             |  EuroPi Program
-:-------------------------:|:-------------------------:
-![](https://i.imgur.com/ZJUMUeT.png)  |  ![](https://i.imgur.com/ubOxajY.png)
-
+| Inspiration (Shortwave radio)         | EuroPi Program                       |
+|:-------------------------------------:|:------------------------------------:|
+| ![](https://i.imgur.com/ZJUMUeT.png)  | ![](https://i.imgur.com/ubOxajY.png) |
 
 ## Usage
+
 Knob 1 controls CV1, Knob 2 controls CV2.
+
 CV3 is the difference between CV1 and CV2.
+
 The bottom row of CV outputs (CV4, CV5, CV6) are the inverse of whichever output is above it.
 
-Pressing button 1 will allow you to rotate the outputs, inspired by the [4MS Rotating Clock Divider](https://4mscompany.com/rcd.php).
-The digital input also triggers a rotation.
+Pressing button 1 will allow you to rotate the outputs, inspired by the
+[4MS Rotating Clock Divider](https://4mscompany.com/rcd.php). The digital input also triggers a
+rotation.
+
 Pressing button 2 will change the mapping of the analogue input, with 3 options:
 - Off
 - Knob 1
 - Knob 2
 
-When the analogue input is mapped to either of the two knobs, it will apply the incoming CV as an offset to the knob value, so you still have manual control.
+When the analogue input is mapped to either of the two knobs, it will apply the incoming CV as an
+offset to the knob value, so you still have manual control.

--- a/software/contrib/sigma.md
+++ b/software/contrib/sigma.md
@@ -6,19 +6,19 @@ for details on the original module and a deeper dive into the mathematics used i
 
 ## Gaussian Distributions
 
-The Gaussian or Normal distribution is a bell-shaped curve often used in statistics. Unlike rolling a d20 in
-Dungeons and Dragons, where there is an equal chance of the roll being 1, 2, 3, ..., 19, or 20, a normal distribution
-is more likely to produce numbers in the middle of its range and less likely to produce numbers at the extremes. The
-way in which this probability changes is determined by the standard deviation of the curve, written using the
-Greek letter Sigma in statistics.
+The Gaussian or Normal distribution is a bell-shaped curve often used in statistics. Unlike rolling
+a d20 in Dungeons and Dragons, where there is an equal chance of the roll being 1, 2, 3, ..., 19,
+or 20, a normal distribution is more likely to produce numbers in the middle of its range and less
+likely to produce numbers at the extremes. The way in which this probability changes is determined
+by the standard deviation of the curve, written using the Greek letter Sigma in statistics.
 
 ## Inputs & Outputs
 
 Inputs:
-- `din`: an external clock signal to trigger sampling. The pulse width of this signal controls the output
-  pulse width
-- `ain`: assignable CV control (can be disabled, or assigned to control `mean`, `standard deviation`, `jitter` or
-  `bin mode`)
+- `din`: an external clock signal to trigger sampling. The pulse width of this signal controls the
+  output pulse width
+- `ain`: assignable CV control (can be disabled, or assigned to control `mean`,
+  `standard deviation`, `jitter` or `bin mode`)
 - `b1`: shift button; hold to change `k1` and `k2` modes
 - `b2`: cycles through `ain` routing
 - `k1`: mean control / shift: jitter control
@@ -26,25 +26,27 @@ Inputs:
 
 `k1` or `k2` will act as an attenuator for the assigned control (mean/spread/jitter/binning).
 
-Outputs are divided into 3 pairs: `cv1 & cv 4`, `cv2 & cv 5`, and `cv3 & cv 6`.  `cv1-3` output gate signals
-with a duration equivalent to the duty cycle of the incoming clock on `din`.  `cv4-6` output random control
-voltages according to the spread & mean controls and the binning mode.
+Outputs are divided into 3 pairs: `cv1 & cv 4`, `cv2 & cv 5`, and `cv3 & cv 6`.  `cv1-3` output gate
+signals with a duration equivalent to the duty cycle of the incoming clock on `din`.  `cv4-6` output
+random control voltages according to the spread & mean controls and the binning mode.
 
 ## Distrubution Control
 
 The following description assumes the binning mode is set to `continuous`.
 
-Changing `k1` will move the average output voltage of the outputs.  Keeping the knob near-vertical will keep the
-averate output close to 5V.
+Changing `k1` will move the average output voltage of the outputs.  Keeping the knob near-vertical
+will keep the averate output close to 5V.
 
-Increasing `k2` will increase the standard deviation of the outputs.  At the lowest setting the outputs will be
-effectively locked to the mean set by `k1`.  As `k2` increases the spread of output voltages increases.
+Increasing `k2` will increase the standard deviation of the outputs.  At the lowest setting the
+outputs will be effectively locked to the mean set by `k1`.  As `k2` increases the spread of output
+voltages increases.
 
 ## Jitter Control
 
-By default all six output channels update simultaneously. By applying positive voltage to `ain` the outputs can be
-desynchronized, updating at random intervals. `cv1 & 4` will always trigger in-time with the clock on `din`,
-but the other pairs will trigger at normally-distributed intervals after `cv1`.
+By default all six output channels update simultaneously. By applying positive voltage to `ain` the
+outputs can be desynchronized, updating at random intervals. `cv1 & 4` will always trigger in-time
+with the clock on `din`, but the other pairs will trigger at normally-distributed intervals after
+`cv1`.
 
 ## Binning and Quantize modes
 
@@ -61,7 +63,8 @@ In Bin mode the output voltage will oscillate between values chosen from the lev
 |    7   | 0V, 1.7V, 3.4V, 5V, 6.6V, 8.3V, 10V                 | 1.7V      |
 |    9   | 0V, 1.25V, 2.5V, 3.75V, 5V, 6.25V, 7.5V, 8.75V, 10V | 1.25V     |
 
-In Quantize mode, the output voltage will be quantized to 1V/Octave scales with the following resolution:
+In Quantize mode, the output voltage will be quantized to 1V/Octave scales with the following
+resolution:
 
 | Quantize Mode | Delta (V) |
 |---------------|-----------|

--- a/software/contrib/slopes.md
+++ b/software/contrib/slopes.md
@@ -1,23 +1,28 @@
 # Slopes
 
-Slopes is a CV processor that analyzes an incoming signal and generates outputs based on the shape of that input.
+Slopes is a CV processor that analyzes an incoming signal and generates outputs based on the shape
+of that input.
 
 ## Inputs & Outputs
 
-- `ain`: The analogue signal to process. Due to technical limitations this signal should ideally be an LFO, smooth
-  random voltage, or envelope. Audio-rate signals can be patched in, but will likely not be analyzed correctly due
-  to processing latency.
-- `k1`: Noise filter. Increasing `k1` will make the signal processing less sensitive, but will also reduce random
-  noise.
-- `k2`: CV output attenuator. At maximum, `cv4`-`6` will output `0-10V`. At 50% `cv4`-`6` will output `0-5V`. At 0%
-  `cv4`-`6` will produce no output
+- `ain`: The analogue signal to process. Due to technical limitations this signal should ideally be
+  an LFO, smooth random voltage, or envelope. Audio-rate signals can be patched in, but will likely
+  not be analyzed correctly due to processing latency.
+- `k1`: Noise filter. Increasing `k1` will make the signal processing less sensitive, but will also
+  reduce random noise.
+- `k2`: CV output attenuator. At maximum, `cv4`-`6` will output `0-10V`. At 50% `cv4`-`6` will
+  output `0-5V`. At 0% `cv4`-`6` will produce no output
 
 - `cv1`: A gate signal that is high when `ain` is rising and low when `ain` is falling
 - `cv2`: A gate signal that is high when `ain` is falling and low when `ain` is rising
-- `cv3`: A gate signal that is high when `ain` is flat (i.e. holding the same voltage across samples)
-- `cv4`: A CV signal representing the positive slope of `ain`; the faster `ain` is rising, the stronger the CV signal
-- `cv5`: A CV signal representing the negative slope of `ain`; the faster `ain` is falling, the stronger the CV signal
-- `cv6`: A CV signal representing the overall maginude of the slope, ignoring the direction (i.e. the sum of `cv4` and `cv5`)
+- `cv3`: A gate signal that is high when `ain` is flat (i.e. holding the same voltage across
+  samples)
+- `cv4`: A CV signal representing the positive slope of `ain`; the faster `ain` is rising, the
+  stronger the CV signal
+- `cv5`: A CV signal representing the negative slope of `ain`; the faster `ain` is falling, the
+  stronger the CV signal
+- `cv6`: A CV signal representing the overall maginude of the slope, ignoring the direction
+  (i.e. the sum of `cv4` and `cv5`)
 
 Unused:
 - `din`

--- a/software/contrib/strange_attractor.md
+++ b/software/contrib/strange_attractor.md
@@ -1,8 +1,4 @@
-# EuroPi Strange Attractor.
-
-author: Sean Bechhofer (github.com/seanbechhofer)
-date: 2022-03-15
-labels: gates, triggers, randomness
+# Strange Attractor.
 
 Strange Attractor is a source of chaotic modulation using systems
 of differential equations such as the Lorenz System:
@@ -17,10 +13,7 @@ attractor.
 Outputs 4, 5 and 6 are gates based on the values of *x*, *y* and *z* and
 relationships between them.
 
-Credits:
-- The Europi hardware and firmware was designed by Allen Synthesis: https://github.com/Allen-Synthesis/EuroPi
-
-# Controls
+## Controls
 
 - digital_in: Pause motion when `HIGH`
 - analog_in:
@@ -38,25 +31,23 @@ Credits:
 - output_5: triggers/gates
 - output_6: triggers/gates
 
-# Getting Started
+1. Knob 1 controls the speed. The sensitivity changes at noon, allowing for very slow or very fast
+   modulation.
+2. Knob 2 adjusts the threshold used for triggers.
+3. Short presses on buttons 1/2 reduce/increase the max output voltage of the CV outputs, from 1V
+   to 5V.
+4. Long press on button 1 changes the equation system
+5. Long press on button 2 changes the display between detail and graphical
+6. If the digital input is `HIGH`, change is paused.
 
 Outputs 1-3 provide chaotic shifting voltages.
 Outputs 4-6 provide gates/triggers.
 
 ## Basic Usage
+
 1. Switch on
 2. Connect outputs to modules
 3. Enjoy randomness
-
-## Controls
-1. Knob 1 controls the speed. The sensitivity changes at noon,
-allowing for very slow or very fast modulation.
-2. Knob 2 adjusts the threshold used for triggers.
-3. Short presses on buttons 1/2 reduce/increase the max output voltage of the CV outputs,
-from 1V to 5V.
-4. Long press on button 1 changes the equation system
-5. Long press on button 2 changes the display between detail and graphical
-6. If the digital input is `HIGH`, change is paused.
 
 ## Details
 
@@ -93,3 +84,7 @@ A long press on button 2 toggles between a numerical and graphical
 display
 
 If the digital input is set to `HIGH`, the system will pause.
+
+## Credits
+
+- The Europi hardware and firmware was designed by Allen Synthesis: https://github.com/Allen-Synthesis/EuroPi

--- a/software/contrib/traffic.md
+++ b/software/contrib/traffic.md
@@ -3,41 +3,47 @@
 This script is inspired by [Jasmine & Olive Tree's Traffic](https://jasmineandolivetrees.com/products/traffic).
 Instead of 3 trigger inputs, this version only has 2.
 
-Traffic has 3 output channels (`cv1`-`cv3`), which output CVs signals. The value of the output signal depends on:
+Traffic has 3 output channels (`cv1`-`cv3`), which output CVs signals. The value of the output
+signal depends on:
 1. which input the trigger was received most recently and
 2. the gains for that trigger on each channel.
 
-For example, suppose the gains for channel A are set to `[0.25, 0.6]`. Whenever a trigger on `din` (trigger input 1) is
-received, channel A (`cv1`) will output `MAX_VOLTAGE * 0.25 = 2.5V`. Whenever a trigger on `ain` (trigger input 2) in
-received, channel A will output `MAX_VOLTAGE * 0.6 = 6V`.
+For example, suppose the gains for channel A are set to `[0.25, 0.6]`. Whenever a trigger on `din`
+(trigger input 1) is received, channel A (`cv1`) will output `MAX_VOLTAGE * 0.25 = 2.5V`. Whenever a
+trigger on `ain` (trigger input 2) in received, channel A will output `MAX_VOLTAGE * 0.6 = 6V`.
 
-The same occurs for channels B and C on `cv2` and `cv3`, each with their own pair of gains for the two inputs.
+The same occurs for channels B and C on `cv2` and `cv3`, each with their own pair of gains for the
+two inputs.
 
-Changing the gains will immediately update the output value, if the gain for that input is active. i.e. if `din` last
-detected a trigger, changing the gains for `din` on channel A/B/C will affect the voltage on `cv1/2/3` immediately.
+Changing the gains will immediately update the output value, if the gain for that input is active.
+i.e. if `din` last detected a trigger, changing the gains for `din` on channel A/B/C will affect the
+voltage on `cv1/2/3` immediately.
 
 `cv6` outputs a 10ms, 5V gate every time a trigger is received on _either_ input.
 
-`cv4` and `cv5` have no equivalent on the original Traffic module, but are used here as difference channels:
+`cv4` and `cv5` have no equivalent on the original Traffic module, but are used here as difference
+channels:
 - `cv4` is the absolute difference between `cv1` and `cv2`
 - `cv4` is the absolute difference between `cv1` and `cv3`
 
 For a video tutorial on how the original Traffic module works, please see
-https://youtu.be/Pn7_NCCKcJc?si=OJ78FRa9PvjD8oSd. The functionality of this script is very much the same, but limited
-to two input triggers.
+https://youtu.be/Pn7_NCCKcJc?si=OJ78FRa9PvjD8oSd. The functionality of this script is very much the
+same, but limited to two input triggers.
 
 
 ## Setting the gains
 
-Turning `k1` and `k2` will set the gains for channel A. Pressing and holding `b1` while rotating the knobs will set the
-gains for channel B. Pressing and holding `b2` while rotating the knobs will set the gains for channel C.
+Turning `k1` and `k2` will set the gains for channel A. Pressing and holding `b1` while rotating the
+knobs will set the gains for channel B. Pressing and holding `b2` while rotating the knobs will set
+the gains for channel C.
 
-The gains for channels B and C are saved to the module's onboard memory, and will persist across power-cycles.  The
-gains for channel A are always read from the current knob positions on startup.
+The gains for channels B and C are saved to the module's onboard memory, and will persist across
+power-cycles.  The gains for channel A are always read from the current knob positions on startup.
 
-Note that this each channel makes used of "locked knobs."  This means that when changing the active channel by pressing
-or releasing `b1` or `b2` it may be necessary to sweep the knob to its prior position before the gain can be changed.
-This helps prevent accidentally changing the gains by pressing the buttons.
+Note that this each channel makes used of "locked knobs."  This means that when changing the active
+channel by pressing or releasing `b1` or `b2` it may be necessary to sweep the knob to its prior
+position before the gain can be changed. This helps prevent accidentally changing the gains by
+pressing the buttons.
 
 
 ## I/O Mapping

--- a/software/contrib/turing_machine.md
+++ b/software/contrib/turing_machine.md
@@ -1,23 +1,17 @@
 # Turing Machine
 
-author: Matthew Jaskula
-
-date: 2022-03-30
-
-labels: sequencer, random, triggers
-
 A script meant to recreate the [Music Thing Modular Turning Machine Random Sequencer](https://www.musicthing.co.uk/Turing-Machine/)
-as faithfully as possible on the EuroPi hardware. Plenty of information is available at that link, but the most
-important bit is this:
+as faithfully as possible on the EuroPi hardware. Plenty of information is available at that link,
+but the most important bit is this:
 
-  In the Turing Machine, looping is controlled by the big knob.
-    * At noon, the sequences are random.
-    * At 5 o'clock, it locks into a repeating sequence.
-    * At 7 o'clock, it double locks into a repeating sequence twice as long as the 'length' setting.
-    * At 3 o'clock or 9 o'clock, it slips; looping but occasionally changing notes.
+>  In the Turing Machine, looping is controlled by the big knob.
+>    * At noon, the sequences are random.
+>    * At 5 o'clock, it locks into a repeating sequence.
+>    * At 7 o'clock, it double locks into a repeating sequence twice as long as the 'length' setting.
+>    * At 3 o'clock or 9 o'clock, it slips; looping but occasionally changing notes.
 
-The left knob (k1) acts as the TM's big knob. The right knob (k2) serves dual duty as the scale and length knob. The
-mode of the knob is changed with the right button (b2).
+The left knob (`k1`) acts as the TM's big knob. The right knob (`k2`) serves dual duty as the scale
+and length knob. The mode of the knob is changed with the right button (`b2`).
 
 - **din:** clock
 - **ain:** cv control over the big knob, added to the knobs value

--- a/software/contrib/volts.md
+++ b/software/contrib/volts.md
@@ -9,8 +9,9 @@ This script is non-interactive and simply generates 6 fixed voltages:
 - `cv5`: 5.0V
 - `cv6`: 10.0V
 
-These can be used to apply fixed offsets for e.g. transposing a sequencer up a number of octaves, shifting a bipolar
-LFO so it is positive, sending a contant voltage to a VCA to amplify a signal, or calibrating other modules.
+These can be used to apply fixed offsets for e.g. transposing a sequencer up a number of octaves,
+shifting a bipolar LFO so it is positive, sending a contant voltage to a VCA to amplify a signal,
+or calibrating other modules.
 
 ## Changing the voltages
 


### PR DESCRIPTION
Go through all of the `contrib` documentation files and fix typos and formatting errors.

I've tried to make sure every readme at minimum has an introductory summary section and a `controls` or `inputs & outputs` section immediately after to explain basic operation as a quick reference. All detailed explanations, examples, credits, etc... come after that.

I've also removed the author & tag information from the readmes; those are included in the main contrib readme, and for the sake of consistency it was easier to remove this duplication from the minority of files that had it than to create this information for the ones where it was omitted.