### PR TITLE
Add support for Gray Encoding to `BinaryCounter`

### DIFF
--- a/software/contrib/binary_counter.md
+++ b/software/contrib/binary_counter.md
@@ -22,3 +22,31 @@ counter.
 | `cv4`         | 8s-bit output                                                     |
 | `cv5`         | 16s-bit output                                                    |
 | `cv6`         | Most significant bit output                                       |
+
+## Configuration
+
+This program has the following configuration options:
+
+- `USE_GRAY_ENCODING`: if `true`, instead of traditional binary encoding, the pattern is encoded
+  using [gray encoding](https://en.wikipedia.org/wiki/Gray_encoding). This means that consecutive
+  gate patterns will always differ by exactly 1 bit.
+
+| Decimal value | Traditional binary | Gray encoding |
+|---------------|--------------------|---------------|
+| 0             | `000000`           | `0000000`     |
+| 1             | `000001`           | `0000001`     |
+| 2             | `000010`           | `0000011`     |
+| 3             | `000011`           | `0000010`     |
+| 4             | `000100`           | `0000110`     |
+| 5             | `000101`           | `0000111`     |
+| 6             | `000110`           | `0000101`     |
+| 7             | `000111`           | `0000100`     |
+| ...           | ...                | ...           |
+
+To enable Gray encoding, create/edit `/config/BinaryCounter.json` to contain the following:
+```json
+{
+    "USE_GRAY_ENCODING": true
+}
+
+```

--- a/software/contrib/binary_counter.py
+++ b/software/contrib/binary_counter.py
@@ -14,6 +14,10 @@
 from europi import *
 from europi_script import EuroPiScript
 
+from experimental.math_extras import gray_encode
+
+import configuration
+
 
 class BinaryCounter(EuroPiScript):
     MAX_N = (1 << NUM_CVS) - 1
@@ -37,6 +41,16 @@ class BinaryCounter(EuroPiScript):
 
         b2.handler(self.reset)
 
+    @classmethod
+    def config_points(cls):
+        return [
+            # If true, use gray encoding instead of standard binary
+            configuration.boolean(
+                "USE_GRAY_ENCODING",
+                False
+            ),
+        ]
+
     def on_gate_rise(self):
         self.gate_recvd = True
 
@@ -47,11 +61,17 @@ class BinaryCounter(EuroPiScript):
         self.n = 0
 
     def set_outputs(self):
+        if self.config.USE_GRAY_ENCODING:
+            n = gray_encode(self.n)
+        else:
+            n = self.n
+
         for i in range(NUM_CVS):
-            if (self.n >> i) & 0x01:
+            if (n >> i) & 0x01:
                 cvs[i].on()
             else:
                 cvs[i].off()
+
 
     def main(self):
         while True:

--- a/software/contrib/itty_bitty.py
+++ b/software/contrib/itty_bitty.py
@@ -18,6 +18,8 @@ Two 8-step trigger, gate & CV sequencers based on the binary representation of a
 from europi import *
 from europi_script import EuroPiScript
 
+from experimental.math_extras import gray_encode
+
 import configuration
 import time
 
@@ -88,8 +90,7 @@ class BittySequence:
         self.sequence_n = n
 
         if self.use_gray_encoding:
-            # convert the number from traditional binary to its gray encoding equivalent
-            n = (n & 0xff) ^ ((n & 0xff) >> 1)
+            n = gray_encode(n)
         else:
             n = n & 0xff
 

--- a/software/firmware/experimental/math_extras.py
+++ b/software/firmware/experimental/math_extras.py
@@ -203,3 +203,25 @@ def solve_linear_system(m):
         results[i] = results[i] / m[i][i]
 
     return results
+
+
+def gray_encode(n: int) -> int:
+    """
+    Convert a binary integer to its Gray Encoding equivalent.
+
+    :param n:  The value to convert
+    """
+    return (n & 0xff) ^ ((n & 0xff) >> 1)
+
+
+def gray_decode(n: int) -> int:
+    """
+    Convert a binary integer from Gray Encoding to its traditional equivalent.
+
+    :param n:  The value to convert
+    """
+    mask = n
+    while (mask):
+        mask = mask >> 1
+        n = n ^ mask
+    return n


### PR DESCRIPTION
Allow `BinaryCounter` to use gray encoding if desired. Add gray encode/decode functions to `math_extras`, and modify `IttyBitty` to use these new functions too.