### PR TITLE
fix: OSC: add missing `self` in `set_cvs()` for `/europi/cvs`

### DIFF
--- a/software/contrib/osc_control.py
+++ b/software/contrib/osc_control.py
@@ -110,7 +110,7 @@ class OscControl(EuroPiScript):
             cv_out.voltage(data.values[0] * europi_config.MAX_OUTPUT_VOLTAGE)
         self.ui_dirty = True
 
-    def set_cvs(data):
+    def set_cvs(self, data):
         """
         Set the level for all CVs
 


### PR DESCRIPTION
Due to missing `self` in `set_cvs()` the OSC address `/europi/cvs` fails.
I made the fix in my EuroPi and now it works!