### PR TITLE
Add `discrete`, `continuous` modes to Binary Counter

### DIFF
--- a/software/contrib/binary_counter.md
+++ b/software/contrib/binary_counter.md
@@ -12,7 +12,7 @@ counter.
 |---------------|-------------------------------------------------------------------|
 | `din`         | Input gate signal                                                 |
 | `ain`         | CV input to control `k`                                           |
-| `b1`          | Manual gate signal                                                |
+| `b1`          | Change between discrete or continuous modes                       |
 | `b2`          | Reset `n` to zero                                                 |
 | `k1`          | Control for `k`                                                   |
 | `k2`          | Attenuator for `ain`                                              |
@@ -22,6 +22,28 @@ counter.
 | `cv4`         | 8s-bit output                                                     |
 | `cv5`         | 16s-bit output                                                    |
 | `cv6`         | Most significant bit output                                       |
+
+In `discrete` mode (default) all outputs go low when `din` goes low.
+
+In `continuous` mode the outputs stay on across consecutive values.
+
+```
+k = 1
+
+din
+   __    __    __    __    __    __    __    __    __
+__|  |__|  |__|  |__|  |__|  |__|  |__|  |__|  |__|  |__
+  .     .     .     .     .     .     .     .     .
+cv2 (discrete).     .     .     .     .     .     .
+  .     .__   .__   .__   .__   .__   .__   .     .
+________|  |__|  |__|  |__|  |__|  |__|  |______________
+  .     .     .     .     .     .     .     .     .
+cv2 (continuous)    .     .     .     .     .     .
+  .     .___________________________________.     .
+________|     .     .     .     .     .     |___________
+n .     .     .     .     .     .     .     .     .
+0 1     2     3     4     5     6     7     8     9
+```
 
 ## Configuration
 

--- a/software/contrib/binary_counter.py
+++ b/software/contrib/binary_counter.py
@@ -18,6 +18,7 @@ from experimental.math_extras import gray_encode
 
 import configuration
 
+
 class BinaryCounter(EuroPiScript):
     MAX_N = (1 << NUM_CVS) - 1
 


### PR DESCRIPTION
Change `b1` action to cycle between `discrete` and `continuous` modes. Discrete mode is the same as the old version, where all gates go low when the input goes low. In `continuous` mode, outputs will stay high if `n[t]` and `n[t+1]` would both have that bit high.

Down-side of this change is that you need a clock signal, you can't manually advance the sequence. I'm ok with this, but if there's anyone who really uses the manual advance feature I can change the mode to a configuration setting instead of a state setting. It makes it less convenient to change modes, but it would restore the old functionality.

Limit minimum `k` to 1 instead of 0. Having `k=0` prevents the outputs from changing at all, which isn't interesting. The same effect can be achieved by just unplugging the clock signal.