### PR TITLE
Add executable suffix to OffsetVoltages

### DIFF
--- a/software/contrib/volts.py
+++ b/software/contrib/volts.py
@@ -92,3 +92,7 @@ class OffsetVoltages(EuroPiScript):
 
         while True:
             pass
+
+
+if __name__ == "__main__":
+    OffsetVoltages().main()


### PR DESCRIPTION
Adds
```
if __name__ == "__main__":
    OffsetVoltages().main()
```
suffix to `volts.py`.